### PR TITLE
fix: 1.4.1 — lazy gemfile_path discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.4.1] - 2026-05-22
+
+### Fixed
+
+- `still_active --gems=X` (or any invocation that doesn't need a Gemfile) crashed with `Bundler::GemfileNotFound` when run from a directory without a Gemfile in the tree. `Config#initialize` eagerly called `Bundler.default_gemfile`. Now `gemfile_path` resolves lazily on first read and falls back to `./Gemfile` when none is reachable.
+
 ## [1.4.0] - 2026-05-22
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    still_active (1.4.0)
+    still_active (1.4.1)
       async
       bundler (>= 2.0)
       faraday-retry
@@ -237,7 +237,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   sawyer (0.9.3) sha256=0d0f19298408047037638639fe62f4794483fb04320269169bd41af2bdcf5e41
   simpleidn (0.2.3) sha256=08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29
-  still_active (1.4.0)
+  still_active (1.4.1)
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   traces (0.18.2) sha256=80f1649cb4daace1d7174b81f3b3b7427af0b93047759ba349960cb8f315e214
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f

--- a/lib/still_active/config.rb
+++ b/lib/still_active/config.rb
@@ -6,13 +6,12 @@ require "open3"
 
 module StillActive
   class Config
-    attr_writer :github_oauth_token, :gitlab_token
+    attr_writer :github_oauth_token, :gitlab_token, :gemfile_path
     attr_accessor :baseline_path,
       :critical_warning_emoji,
       :fail_if_critical,
       :fail_if_warning,
       :futurist_emoji,
-      :gemfile_path,
       :gems,
       :fail_if_outdated,
       :fail_if_vulnerable,
@@ -31,7 +30,7 @@ module StillActive
       @fail_if_outdated = nil
       @fail_if_vulnerable = nil
       @fail_if_warning = false
-      @gemfile_path = Bundler.default_gemfile.to_s
+      @gemfile_path = nil
       @gems = []
       @ignored_gems = []
       @github_oauth_token = nil
@@ -64,6 +63,16 @@ module StillActive
 
     def gitlab_token
       @gitlab_token ||= presence(ENV["GITLAB_TOKEN"]) || glab_cli_token
+    end
+
+    # Lazy so that running with --gems=... (no Gemfile needed) doesn't crash
+    # when invoked from a directory without a Gemfile in the tree.
+    def gemfile_path
+      @gemfile_path ||= begin
+        Bundler.default_gemfile.to_s
+      rescue Bundler::GemfileNotFound
+        File.join(Dir.pwd, "Gemfile")
+      end
     end
 
     private

--- a/lib/still_active/version.rb
+++ b/lib/still_active/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module StillActive
-  VERSION = "1.4.0"
+  VERSION = "1.4.1"
 end

--- a/spec/still_active/config_spec.rb
+++ b/spec/still_active/config_spec.rb
@@ -143,4 +143,36 @@ RSpec.describe(StillActive::Config) do
       expect(Open3).not_to(have_received(:capture3))
     end
   end
+
+  describe("gemfile_path discovery") do
+    it("returns Bundler.default_gemfile when a Gemfile is reachable") do
+      allow(Bundler).to(receive(:default_gemfile).and_return(Pathname.new("/proj/Gemfile")))
+      expect(described_class.new.gemfile_path).to(eq("/proj/Gemfile"))
+    end
+
+    it("falls back to ./Gemfile when no Gemfile is reachable (GemfileNotFound)") do
+      allow(Bundler).to(receive(:default_gemfile).and_raise(Bundler::GemfileNotFound))
+      expect(described_class.new.gemfile_path).to(eq(File.join(Dir.pwd, "Gemfile")))
+    end
+
+    it("does not invoke Bundler.default_gemfile at Config.new") do
+      allow(Bundler).to(receive(:default_gemfile))
+      described_class.new
+      expect(Bundler).not_to(have_received(:default_gemfile))
+    end
+
+    it("honours an explicit path set via the writer") do
+      config = described_class.new
+      config.gemfile_path = "/elsewhere/Gemfile"
+      expect(config.gemfile_path).to(eq("/elsewhere/Gemfile"))
+    end
+
+    it("does not call Bundler.default_gemfile when an explicit path is set first") do
+      allow(Bundler).to(receive(:default_gemfile))
+      config = described_class.new
+      config.gemfile_path = "/elsewhere/Gemfile"
+      config.gemfile_path
+      expect(Bundler).not_to(have_received(:default_gemfile))
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes a regression where running still_active from a directory without a Gemfile in the tree crashed with \`Bundler::GemfileNotFound\` at option-parse time, even when the invocation didn't need a Gemfile (\`--gems=X\` or \`--gemfile=path/elsewhere\`).

Caught by still_active-action's self-test on a fresh checkout (no Gemfile at action repo root) — confirms the bug bites real users in non-Ruby working directories.

## Fix

\`Config#gemfile_path\` is now lazy: \`Bundler.default_gemfile\` is called only on first read, and \`Bundler::GemfileNotFound\` falls back to \`./Gemfile\` (which \`--gemfile=PATH\` overrides). Five new specs lock the behavior.

## Test plan

- [x] 336 specs pass, rubocop clean
- [x] Still works in normal Ruby projects (default gemfile resolves as before)
- [x] Now works in non-Ruby cwd with \`--gems=X\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)