### PR TITLE
chore: dogfood SeanLF/still_active-action@v0

### DIFF
--- a/.github/workflows/still_active.yml
+++ b/.github/workflows/still_active.yml
@@ -22,12 +22,11 @@ jobs:
         with:
           ruby-version: '3.4'
           bundler-cache: true
-      - name: Audit dependencies (SARIF)
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: bundle exec still_active --sarif
-      - name: Upload SARIF to Code Scanning
+      - uses: SeanLF/still_active-action@v0
+        with:
+          github-token: ${{ github.token }}
+          sarif: still_active.sarif.json
+      - uses: github/codeql-action/upload-sarif@v3
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: still_active.sarif.json


### PR DESCRIPTION
Replaces the inline \`bundle exec still_active --sarif\` step with the freshly-published [\`SeanLF/still_active-action@v0\`](https://github.com/SeanLF/still_active-action) composite action. Same output (SARIF uploaded to Code Scanning), but now this repo dogfoods the action wrapper.

If the action breaks for any reason, this PR's CI catches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)