### PR TITLE
fix: 1.4.2 — clear error when Gemfile.lock missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.4.2] - 2026-05-22
+
+### Fixed
+
+- Replaced an opaque `NoMethodError` on `nil.specs` with `StillActive::MissingLockfileError` and a clear "run `bundle lock` first" message when a Gemfile exists but no `Gemfile.lock` is reachable. Caught during the still_active-action self-test wiring.
+
 ## [1.4.1] - 2026-05-22
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    still_active (1.4.1)
+    still_active (1.4.2)
       async
       bundler (>= 2.0)
       faraday-retry
@@ -237,7 +237,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   sawyer (0.9.3) sha256=0d0f19298408047037638639fe62f4794483fb04320269169bd41af2bdcf5e41
   simpleidn (0.2.3) sha256=08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29
-  still_active (1.4.1)
+  still_active (1.4.2)
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   traces (0.18.2) sha256=80f1649cb4daace1d7174b81f3b3b7427af0b93047759ba349960cb8f315e214
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f

--- a/bin/still_active
+++ b/bin/still_active
@@ -3,7 +3,7 @@
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), "../lib"))
 
-require "still_active/cli"
 require "still_active"
+require "still_active/cli"
 
 StillActive::CLI.new.run(ARGV)

--- a/lib/helpers/bundler_helper.rb
+++ b/lib/helpers/bundler_helper.rb
@@ -5,11 +5,16 @@ module StillActive
     extend self
 
     def gemfile_dependencies(gemfile_path: StillActive.config.gemfile_path)
-      ::Bundler::SharedHelpers.set_env("BUNDLE_GEMFILE", File.expand_path(gemfile_path))
+      absolute_gemfile = File.expand_path(gemfile_path)
+      ::Bundler::SharedHelpers.set_env("BUNDLE_GEMFILE", absolute_gemfile)
       gemfile_gems = ::Bundler.definition.dependencies.map(&:name)
-      Bundler
-        .definition
-        .locked_gems
+      locked_gems = ::Bundler.definition.locked_gems
+      if locked_gems.nil?
+        raise MissingLockfileError,
+          "no lockfile next to #{absolute_gemfile} — run `bundle lock` (or `bundle install`) first"
+      end
+
+      locked_gems
         .specs
         .select { |spec| gemfile_gems.include?(spec.name) }
         .uniq(&:name)

--- a/lib/still_active.rb
+++ b/lib/still_active.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "still_active/version"
+require_relative "still_active/errors"
 require_relative "still_active/config"
 require_relative "still_active/cli"
 
@@ -9,8 +10,6 @@ require_relative "still_active/cli"
 require "faraday/retry"
 
 module StillActive
-  class Error < StandardError; end
-
   class << self
     def config
       @config ||= Config.new

--- a/lib/still_active/cli.rb
+++ b/lib/still_active/cli.rb
@@ -18,7 +18,12 @@ module StillActive
     def run(args)
       options = Options.new.parse!(args)
       unless options[:provided_gems]
-        StillActive.config.gems = BundlerHelper.gemfile_dependencies
+        begin
+          StillActive.config.gems = BundlerHelper.gemfile_dependencies
+        rescue MissingLockfileError => e
+          $stderr.puts("error: #{e.message}")
+          exit(2)
+        end
       end
 
       result = if $stderr.tty?

--- a/lib/still_active/errors.rb
+++ b/lib/still_active/errors.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module StillActive
+  class Error < StandardError; end
+  class MissingLockfileError < Error; end
+end

--- a/lib/still_active/version.rb
+++ b/lib/still_active/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module StillActive
-  VERSION = "1.4.1"
+  VERSION = "1.4.2"
 end

--- a/spec/still_active/bundler_helper_spec.rb
+++ b/spec/still_active/bundler_helper_spec.rb
@@ -11,6 +11,25 @@ RSpec.describe(StillActive::BundlerHelper) do
       Bundler.reset_settings_and_root! if Bundler.respond_to?(:reset_settings_and_root!)
     end
 
+    context("when Bundler.definition.locked_gems is nil (no Gemfile.lock)") do
+      let(:fake_definition) do
+        instance_double(Bundler::Definition, dependencies: [], locked_gems: nil)
+      end
+
+      before do
+        allow(Bundler).to(receive(:definition).and_return(fake_definition))
+        allow(Bundler::SharedHelpers).to(receive(:set_env))
+      end
+
+      it("raises MissingLockfileError with the absolute path and a helpful message") do
+        expect { described_class.gemfile_dependencies(gemfile_path: "Gemfile") }
+          .to(raise_error(StillActive::MissingLockfileError) do |e|
+            expect(e.message).to(match(/run `bundle lock`/))
+            expect(e.message).to(include(File.expand_path("Gemfile")))
+          end)
+      end
+    end
+
     it("returns the versioned gems specified in the gemfile") do
       gem_names = gemfile_dependencies.map { |dep| dep[:name] }
       expect(gem_names).to(include("rake", "rspec"))


### PR DESCRIPTION
## Summary

Replaces an opaque `NoMethodError: undefined method 'specs' for nil` with `StillActive::MissingLockfileError` and a clear "run `bundle lock` first" message when a Gemfile exists but no `Gemfile.lock` is reachable. Caught during the still_active-action self-test wiring.

## Use case check

Verified there's no legitimate scenario for auditing a Gemfile without its lockfile:

- `--gems=X` bypasses BundlerHelper entirely (no lockfile needed)
- `--gemfile=PATH` with no lockfile = we'd have to invent resolved versions; refusing with a clear message is the right contract

## Review-driven cleanups

- `lib/still_active/errors.rb` — dedicated file for the error tree (`Error`, `MissingLockfileError`); conventional Ruby gem pattern, no inline class declarations in helpers
- `cli.rb` rescues `MissingLockfileError` → stderr message → `exit(2)` (matches existing `--sarif`/`--baseline` exit contract)
- Error message includes the absolute Gemfile path so users can copy-paste

## Test plan

- [x] 337 specs pass, rubocop clean
- [x] Pre-push hook (rake) green
- [x] Reviewed by code-reviewer subagent (twice — addressed all 3 prior findings, second pass found nothing new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
