### PR TITLE
ci: PR-diff workflow + Node 24 actions + Ruby 4.0 defaults

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
     schedule:
       interval: weekly
     groups:
+      # GitHub Actions major bumps are usually just Node runtime updates
+      # (v4 -> v6 = Node 20 -> Node 24); group them so they land together
+      # rather than as one-PR-per-action.
       actions:
         patterns: ["*"]
-        update-types: [minor, patch]
+        update-types: [major, minor, patch]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,9 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: ruby
+          ruby-version: '4.0'
           bundler-cache: true
       - uses: rubygems/release-gem@v1

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.ruby == 'head' }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/rubocop-analysis.yml
+++ b/.github/workflows/rubocop-analysis.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.4'
+        ruby-version: '4.0'
         bundler-cache: true
 
     - name: Rubocop run

--- a/.github/workflows/still_active.yml
+++ b/.github/workflows/still_active.yml
@@ -17,16 +17,16 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.4'
+          ruby-version: '4.0'
           bundler-cache: true
       - uses: SeanLF/still_active-action@v0
         with:
           github-token: ${{ github.token }}
           sarif: still_active.sarif.json
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: still_active.sarif.json

--- a/.github/workflows/still_active_diff.yml
+++ b/.github/workflows/still_active_diff.yml
@@ -1,0 +1,71 @@
+name: Dependency PR diff
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base (main) as baseline
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          path: baseline
+
+      - name: Checkout PR HEAD
+        uses: actions/checkout@v6
+        with:
+          path: current
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '4.0'
+
+      - name: Bundle install baseline
+        working-directory: baseline
+        run: bundle install --jobs 4 --retry 3
+
+      - name: Bundle install current
+        working-directory: current
+        run: bundle install --jobs 4 --retry 3
+
+      - name: Capture baseline JSON from main
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        working-directory: baseline
+        run: bundle exec still_active --json > "$RUNNER_TEMP/baseline.json"
+
+      - name: Run diff against baseline
+        id: diff
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        working-directory: current
+        run: |
+          set +e
+          bundle exec still_active --baseline="$RUNNER_TEMP/baseline.json" > "$RUNNER_TEMP/diff.md"
+          code=$?
+          echo "exit-code=$code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Append to job summary
+        run: cat "$RUNNER_TEMP/diff.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on PR
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        working-directory: current
+        run: gh pr comment "$PR_NUMBER" --body-file "$RUNNER_TEMP/diff.md" --edit-last --create-if-none
+
+      - name: Fail if regressions detected
+        if: steps.diff.outputs.exit-code != '0'
+        run: |
+          echo "::error::still_active --baseline reported regressions; see job summary"
+          exit 1


### PR DESCRIPTION
## Summary

Three orthogonal CI/CD improvements bundled together:

### 1. PR-mode diff workflow

`.github/workflows/still_active_diff.yml` — on every PR:
1. Checks out base (main) and PR HEAD into separate dirs
2. Runs `bundle exec still_active --json` on main to get a baseline
3. Runs `bundle exec still_active --baseline=…` on PR HEAD
4. Posts the markdown delta as a PR comment (`gh pr comment --edit-last --create-if-none` — updates the same comment on subsequent pushes)
5. Appends to the job step summary
6. Fails the job if regressions detected

Closes [`still_active-action#2`](https://github.com/SeanLF/still_active-action/issues/2).

### 2. Node 24 readiness

- `actions/checkout@v4 → @v6` across all workflows (Node 24-ready; drops the deprecation warning we've been seeing on every push)
- `codeql-action/upload-sarif@v3 → @v4` in `still_active.yml` (one straggler; rest were already on v4)

### 3. Ruby 4.0 default + Dependabot policy

- Hardcoded Ruby 3.4 → 4.0 in single-version workflows; rspec matrix unchanged (still tests 3.3/3.4/4.0/head)
- `publish.yml`: `ruby-version: ruby` → `'4.0'` (explicit beats runner-image default)
- Dependabot `github-actions` group allows major bumps now — Node runtime updates have historically been the only "breaking" change in this group and we'd rather group them

## Test plan

- [x] Two code-review subagent passes; addressed exit-code-capture and version-drift findings
- [x] Pre-push hook (rake) green
- [x] Verified Ruby 4.0 actually exists (released 2025-12-25, EOL 2029-03)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
