### PR TITLE
Implement artifactory support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- JFrog Artifactory gem registry support: fetches versions from `.jfrog.io` RubyGems-compatible registries via the versions API with an AQL search fallback. Auth via `--artifactory-token`, `STILL_ACTIVE_ARTIFACTORY_TOKEN`, or Bundler credentials for the source URL.
+- JFrog Artifactory gem registry support: fetches versions from `.jfrog.io` RubyGems-compatible registries via the versions API with an AQL search fallback. Auth reuses Bundler's per-source credentials when present, otherwise a global token via `--artifactory-token` or `STILL_ACTIVE_ARTIFACTORY_TOKEN` (requires a matching `--artifactory-host` / `STILL_ACTIVE_ARTIFACTORY_HOST`).
 
 ## [1.6.0] - 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- JFrog Artifactory gem registry support: fetches versions from `.jfrog.io` RubyGems-compatible registries via the versions API with an AQL search fallback. Auth via `--artifactory-token`, `STILL_ACTIVE_ARTIFACTORY_TOKEN`, or Bundler credentials for the source URL.
+
 ## [1.6.0] - 2026-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ GitLab cascade mirrors GitHub: `--gitlab-token` → `GITLAB_TOKEN` → `glab aut
 
 Artifactory cascade: `--artifactory-token` → `STILL_ACTIVE_ARTIFACTORY_TOKEN` → Bundler credentials for the gem source URL (or host). Use `user:password` in Bundler settings for Basic auth, or a bare token for Bearer auth. Required for private JFrog gem registries (`.jfrog.io`).
 
+When providing the artifactory token via flag or env, you must also set `--artifactory-host` or `STILL_ACTIVE_ARTIFACTORY_HOST` to the expected registry hostname (e.g. `my-org.jfrog.io`). still_active only sends the a token to a matching host, so a lockfile cannot redirect it elsewhere to prevent leaking the token to an unverified host. Providing a token/host in this manner will work only for a single-host. To support multiple Artifactory hosts, use Bundler's credentials per source URL or hostname (`bundle config set credentials.my-org.jfrog.io user:pass`).
+
 ### CLI options
 
 ```text
@@ -111,6 +113,7 @@ Usage: still_active [options]
         --github-oauth-token=TOKEN   GitHub OAuth token to make API calls
         --gitlab-token=TOKEN         GitLab personal access token for API calls
         --artifactory-token=TOKEN    Artifactory token for private gem registry API calls
+        --artifactory-host=HOST      Artifactory host allowed to receive the global token (e.g. my-org.jfrog.io)
         --simultaneous-requests=QTY  Number of simultaneous requests made
         --safe-range-end=YEARS       maximum years since last activity considered safe (no warning)
         --warning-range-end=YEARS    maximum years since last activity that triggers a warning (beyond this is critical)

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ Without a token, GitHub API calls are unauthenticated and rate-limited to 60 req
 
 GitLab cascade mirrors GitHub: `--gitlab-token` → `GITLAB_TOKEN` → `glab auth status --show-token`. Optional for public repos, required for private ones.
 
-Artifactory cascade: `--artifactory-token` → `STILL_ACTIVE_ARTIFACTORY_TOKEN` → Bundler credentials for the gem source URL (or host). Use `user:password` in Bundler settings for Basic auth, or a bare token for Bearer auth. Required for private JFrog gem registries (`.jfrog.io`).
+Artifactory auth prefers Bundler's per-source credentials (`Bundler.settings` for the source URL or hostname) so private registries work the same way `bundle install` does and multiple hosts need no extra configuration. If none are set, still_active falls back to a global token via `--artifactory-token` or `STILL_ACTIVE_ARTIFACTORY_TOKEN`; that path requires `--artifactory-host` / `STILL_ACTIVE_ARTIFACTORY_HOST` to prevent sending the token to an unexpected host from the lockfile. Use `user:password` in Bundler settings for Basic auth, or a bare token for Bearer auth. Required for private JFrog gem registries (`.jfrog.io`).
 
-When providing the artifactory token via flag or env, you must also set `--artifactory-host` or `STILL_ACTIVE_ARTIFACTORY_HOST` to the expected registry hostname (e.g. `my-org.jfrog.io`). still_active only sends the a token to a matching host, so a lockfile cannot redirect it elsewhere to prevent leaking the token to an unverified host. Providing a token/host in this manner will work only for a single-host. To support multiple Artifactory hosts, use Bundler's credentials per source URL or hostname (`bundle config set credentials.my-org.jfrog.io user:pass`).
+When providing the artifactory token via flag or env, you must also set `--artifactory-host` or `STILL_ACTIVE_ARTIFACTORY_HOST` to the expected registry hostname (e.g. `my-org.jfrog.io`). still_active only sends the token to a matching host, so a lockfile cannot redirect it elsewhere to prevent leaking the token to an unverified host. Providing a token/host in this manner will work only for a single-host. To support multiple Artifactory hosts, use Bundler's credentials per source URL or hostname (`bundle config set credentials.my-org.jfrog.io user:pass`).
 
 ### CLI options
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Without a token, GitHub API calls are unauthenticated and rate-limited to 60 req
 
 GitLab cascade mirrors GitHub: `--gitlab-token` → `GITLAB_TOKEN` → `glab auth status --show-token`. Optional for public repos, required for private ones.
 
+Artifactory cascade: `--artifactory-token` → `STILL_ACTIVE_ARTIFACTORY_TOKEN` → Bundler credentials for the gem source URL (or host). Use `user:password` in Bundler settings for Basic auth, or a bare token for Bearer auth. Required for private JFrog gem registries (`.jfrog.io`).
+
 ### CLI options
 
 ```text
@@ -108,6 +110,7 @@ Usage: still_active [options]
         --baseline=PATH              Compare current state to baseline JSON; emit markdown deltas
         --github-oauth-token=TOKEN   GitHub OAuth token to make API calls
         --gitlab-token=TOKEN         GitLab personal access token for API calls
+        --artifactory-token=TOKEN    Artifactory token for private gem registry API calls
         --simultaneous-requests=QTY  Number of simultaneous requests made
         --safe-range-end=YEARS       maximum years since last activity considered safe (no warning)
         --warning-range-end=YEARS    maximum years since last activity that triggers a warning (beyond this is critical)
@@ -358,7 +361,7 @@ These are **leads, not recommendations**: same-category does not mean drop-in re
 
 ### Data sources
 
-- **Versions, release dates, and licenses** from [RubyGems.org](https://rubygems.org) or [GitHub Packages](https://docs.github.com/en/packages)
+- **Versions, release dates, and licenses** from [RubyGems.org](https://rubygems.org), [GitHub Packages](https://docs.github.com/en/packages), or [JFrog Artifactory](https://jfrog.com/artifactory/) gem registries
 - **Last commit date and archived status** from the [GitHub](https://docs.github.com/en/rest) or [GitLab](https://docs.gitlab.com/ee/api/) API
 - **OpenSSF Scorecard**, **vulnerability counts**, and **CVSS severity** from Google's [deps.dev](https://deps.dev) API
 - **Additional advisories** from [ruby-advisory-db](https://github.com/rubysec/ruby-advisory-db), merged in when `bundler-audit` is installed alongside (run `bundle audit update` to keep its checkout current)

--- a/lib/helpers/http_helper.rb
+++ b/lib/helpers/http_helper.rb
@@ -55,5 +55,51 @@ module StillActive
       $stderr.puts("warning: #{uri.host}#{uri.path} returned invalid JSON: #{e.message}")
       nil
     end
+
+    def post_json(base_uri, path, body:, headers: {})
+      uri = base_uri.dup
+      uri.path = path
+
+      MAX_REDIRECTS.times do
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+        http.open_timeout = 10
+        http.read_timeout = 10
+
+        request = Net::HTTP::Post.new(uri)
+        headers.each { |key, value| request[key] = value }
+        request.body = body
+
+        response = http.request(request)
+
+        if response.is_a?(Net::HTTPRedirection)
+          redirect_uri = uri + response["Location"]
+          unless TRUSTED_HOSTS.include?(redirect_uri.host)
+            $stderr.puts("warning: #{uri.host}#{uri.path} redirected to untrusted host #{redirect_uri.host}, skipping")
+            return
+          end
+          $stderr.puts("warning: #{uri.host}#{uri.path} redirected to #{redirect_uri.host}#{redirect_uri.path} (stale metadata?)")
+          headers = {} if redirect_uri.host != uri.host
+          uri = redirect_uri
+          next
+        end
+
+        unless response.is_a?(Net::HTTPSuccess)
+          $stderr.puts("warning: #{uri.host}#{uri.path} returned HTTP #{response.code}") unless response.is_a?(Net::HTTPNotFound)
+          return
+        end
+
+        return JSON.parse(response.body)
+      end
+
+      $stderr.puts("warning: #{uri.host}#{uri.path} too many redirects")
+      nil
+    rescue Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNREFUSED, Errno::ECONNRESET => e
+      $stderr.puts("warning: #{uri.host}#{uri.path} failed: #{e.class} (#{e.message})")
+      nil
+    rescue JSON::ParserError => e
+      $stderr.puts("warning: #{uri.host}#{uri.path} returned invalid JSON: #{e.message}")
+      nil
+    end
   end
 end

--- a/lib/still_active/artifactory_client.rb
+++ b/lib/still_active/artifactory_client.rb
@@ -74,7 +74,11 @@ module StillActive
 
         base = URI(artifactory_base)
         path = "#{base.path}#{AQL_PATH}"
-        body = %(items.find({"name":{"$match":"#{gem_name}-*.gem"},"repo":"#{repo_key}"}).include("name","created"))
+        query = {
+          "name" => { "$match" => "#{gem_name}-*.gem" },
+          "repo" => repo_key,
+        }
+        body = %(items.find(#{JSON.generate(query)}).include("name","created"))
         headers = auth_headers(source_uri).merge("Content-Type" => "text/plain")
         response = HttpHelper.post_json(base, path, body: body, headers: headers)
         return [] if response.nil?

--- a/lib/still_active/artifactory_client.rb
+++ b/lib/still_active/artifactory_client.rb
@@ -25,26 +25,19 @@ module StillActive
       []
     end
 
-    # Artifactory's Rubygems-compatible API
-    module RubygemsClient
-      extend self
-
-      def versions(gem_name:, source_uri:)
-        base = URI(source_uri.chomp("/"))
-        path = "#{base.path}/api/v1/versions/#{encode(gem_name)}.json"
-        HttpHelper.get_json(base, path, headers: auth_headers(source_uri)) || []
-      end
-
+    module Authentication
       private
-
-      def encode(value)
-        CGI.escape(value)
-      end
 
       def credentials(source_uri)
         host = URI(source_uri).host
-        creds = Bundler.settings[source_uri] || Bundler.settings[host]
-        creds && !creds.empty? ? creds : StillActive.config.artifactory_token
+        bundler = Bundler.settings[source_uri] || Bundler.settings[host]
+        return bundler if bundler && !bundler.empty?
+
+        global = StillActive.config.artifactory_token
+        configured_host = StillActive.config.artifactory_host
+        return unless global && configured_host && host&.casecmp?(configured_host)
+
+        global
       end
 
       def auth_headers(source_uri)
@@ -60,10 +53,29 @@ module StillActive
       end
     end
 
+    # Artifactory's Rubygems-compatible API
+    module RubygemsClient
+      extend self
+      include Authentication
+
+      def versions(gem_name:, source_uri:)
+        base = URI(source_uri.chomp("/"))
+        path = "#{base.path}/api/v1/versions/#{encode(gem_name)}.json"
+        HttpHelper.get_json(base, path, headers: auth_headers(source_uri)) || []
+      end
+
+      private
+
+      def encode(value)
+        CGI.escape(value)
+      end
+    end
+
     # AQL stands for Artifactory Query Language
     # https://docs.jfrog.com/artifactory/docs/artifactory-query-language
     module AqlClient
       extend self
+      include Authentication
 
       SOURCE_URL_PATTERN = %r{\A(https?://[^/]+\.jfrog\.io/[^/]+)/api/gems/([^/]+)/?\z}
       AQL_PATH = "/api/search/aql"
@@ -137,24 +149,6 @@ module StillActive
           return candidate if Gem::Version.correct?(candidate)
         end
         nil
-      end
-
-      def credentials(source_uri)
-        host = URI(source_uri).host
-        creds = Bundler.settings[source_uri] || Bundler.settings[host]
-        creds && !creds.empty? ? creds : StillActive.config.artifactory_token
-      end
-
-      def auth_headers(source_uri)
-        creds = credentials(source_uri)
-        return {} unless creds
-
-        if creds.include?(":")
-          user, pass = creds.split(":", 2).map { |part| CGI.unescape(part) }
-          { "Authorization" => "Basic #{["#{user}:#{pass}"].pack("m0")}" }
-        else
-          { "Authorization" => "Bearer #{creds}" }
-        end
       end
     end
   end

--- a/lib/still_active/artifactory_client.rb
+++ b/lib/still_active/artifactory_client.rb
@@ -78,7 +78,7 @@ module StillActive
           "name" => { "$match" => "#{gem_name}-*.gem" },
           "repo" => repo_key,
         }
-        body = %(items.find(#{JSON.generate(query)}).include("name","created"))
+        body = %(items.find(#{JSON.generate(query)}).include("repo", "path", "name", "created"))
         headers = auth_headers(source_uri).merge("Content-Type" => "text/plain")
         response = HttpHelper.post_json(base, path, body: body, headers: headers)
         return [] if response.nil?

--- a/lib/still_active/artifactory_client.rb
+++ b/lib/still_active/artifactory_client.rb
@@ -10,11 +10,6 @@ module StillActive
   module ArtifactoryClient
     extend self
 
-    # NOT GitHub Packages' /api/v1/gems/.../versions.json
-    VERSIONS_API_PATH = "/api/v1/versions/%<gem>s.json"
-    SOURCE_URL_PATTERN = %r{\A(https?://[^/]+\.jfrog\.io/[^/]+)/api/gems/([^/]+)/?\z}
-    AQL_PATH = "/api/search/aql"
-
     def artifactory_uri?(uri)
       uri.is_a?(String) && URI(uri).host&.end_with?(".jfrog.io")
     rescue URI::InvalidURIError
@@ -22,102 +17,140 @@ module StillActive
     end
 
     def versions(gem_name:, source_uri:)
-      vs = versions_api(gem_name: gem_name, source_uri: source_uri)
+      vs = RubygemsClient.versions(gem_name: gem_name, source_uri: source_uri)
       return vs unless vs.empty?
 
-      versions_aql(gem_name: gem_name, source_uri: source_uri)
+      AqlClient.versions(gem_name: gem_name, source_uri: source_uri)
     rescue Errno::ECONNRESET, Errno::ECONNREFUSED, Net::OpenTimeout, Net::ReadTimeout, SocketError
       []
     end
 
-    private
+    # Artifactory's Rubygems-compatible API
+    module RubygemsClient
+      extend self
 
-    def versions_api(gem_name:, source_uri:)
-      base = URI(source_uri.chomp("/"))
-      path = "#{base.path}#{format(VERSIONS_API_PATH, gem: gem_name)}"
-      HttpHelper.get_json(base, path, headers: auth_headers(source_uri)) || []
-    end
-
-    def versions_aql(gem_name:, source_uri:)
-      artifactory_base, repo_key = parse_source_url(source_uri)
-      return [] if artifactory_base.nil?
-
-      base = URI(artifactory_base)
-      path = "#{base.path}#{AQL_PATH}"
-      body = %(items.find({"name":{"$match":"#{gem_name}-*.gem"},"repo":"#{repo_key}"}).include("name","created"))
-      headers = auth_headers(source_uri).merge("Content-Type" => "text/plain")
-      response = HttpHelper.post_json(base, path, body: body, headers: headers)
-      return [] if response.nil?
-
-      results = response["results"] || []
-      build_version_hashes(results: results, gem_name: gem_name)
-    end
-
-    def parse_source_url(source_uri)
-      match = source_uri.match(SOURCE_URL_PATTERN)
-      unless match
-        $stderr.puts("warning: unrecognized Artifactory source URL for AQL fallback: #{source_uri}")
-        return [nil, nil]
+      def versions(gem_name:, source_uri:)
+        base = URI(source_uri.chomp("/"))
+        path = "#{base.path}/api/v1/versions/#{encode(gem_name)}.json"
+        HttpHelper.get_json(base, path, headers: auth_headers(source_uri)) || []
       end
 
-      [match[1], match[2]]
-    end
+      private
 
-    def build_version_hashes(results:, gem_name:)
-      results
-        .filter_map do |item|
-          version = extract_version(item["name"], gem_name)
-          next if version.nil?
+      def encode(value)
+        URI.encode_www_form_component(value)
+      end
 
-          {
-            "number" => version,
-            "created_at" => item["created"],
-            "prerelease" => Gem::Version.new(version).prerelease?,
-          }
+      def credentials(source_uri)
+        host = URI(source_uri).host
+        creds = Bundler.settings[source_uri] || Bundler.settings[host]
+        creds && !creds.empty? ? creds : StillActive.config.artifactory_token
+      end
+
+      def auth_headers(source_uri)
+        creds = credentials(source_uri)
+        return {} unless creds
+
+        if creds.include?(":")
+          user, pass = creds.split(":", 2).map { |part| CGI.unescape(part) }
+          { "Authorization" => "Basic #{["#{user}:#{pass}"].pack("m0")}" }
+        else
+          { "Authorization" => "Bearer #{creds}" }
         end
-        .uniq { |h| h["number"] }
-        .sort_by { |h| Gem::Version.new(h["number"]) }
-        .reverse
-    end
-
-    def extract_version(filename, gem_name)
-      prefix = "#{gem_name}-"
-      return unless filename&.end_with?(".gem") && filename.start_with?(prefix)
-
-      version_part = filename[prefix.length..-5]
-      return if version_part.nil? || version_part.empty?
-
-      parse_version_from_filename_tail(version_part)
-    end
-
-    # Given the portion of a `.gem` filename after `name-`, returns the
-    # leading semver (e.g. `7.0.0` from `7.0.0-x86_64-linux`). Ignores
-    # unrelated artifacts that share a prefix (e.g. `datadog-ruby_core_source`
-    # when the gem name is `datadog`).
-    def parse_version_from_filename_tail(version_part)
-      segments = version_part.split("-")
-      segments.length.times do |i|
-        candidate = segments[0, i + 1].join("-")
-        return candidate if Gem::Version.correct?(candidate)
       end
-      nil
     end
 
-    def credentials(source_uri)
-      host = URI(source_uri).host
-      creds = Bundler.settings[source_uri] || Bundler.settings[host]
-      creds && !creds.empty? ? creds : StillActive.config.artifactory_token
-    end
+    # AQL stands for Artifactory Query Language
+    # https://docs.jfrog.com/artifactory/docs/artifactory-query-language
+    module AqlClient
+      extend self
 
-    def auth_headers(source_uri)
-      creds = credentials(source_uri)
-      return {} unless creds
+      SOURCE_URL_PATTERN = %r{\A(https?://[^/]+\.jfrog\.io/[^/]+)/api/gems/([^/]+)/?\z}
+      AQL_PATH = "/api/search/aql"
 
-      if creds.include?(":")
-        user, pass = creds.split(":", 2).map { |part| CGI.unescape(part) }
-        { "Authorization" => "Basic #{["#{user}:#{pass}"].pack("m0")}" }
-      else
-        { "Authorization" => "Bearer #{creds}" }
+      def versions(gem_name:, source_uri:)
+        artifactory_base, repo_key = parse_source_url(source_uri)
+        return [] if artifactory_base.nil?
+
+        base = URI(artifactory_base)
+        path = "#{base.path}#{AQL_PATH}"
+        body = %(items.find({"name":{"$match":"#{gem_name}-*.gem"},"repo":"#{repo_key}"}).include("name","created"))
+        headers = auth_headers(source_uri).merge("Content-Type" => "text/plain")
+        response = HttpHelper.post_json(base, path, body: body, headers: headers)
+        return [] if response.nil?
+
+        results = response["results"] || []
+        build_version_hashes(results: results, gem_name: gem_name)
+      end
+
+      private
+
+      def parse_source_url(source_uri)
+        match = source_uri.match(SOURCE_URL_PATTERN)
+        unless match
+          $stderr.puts("warning: unrecognized Artifactory source URL for AQL fallback: #{source_uri}")
+          return [nil, nil]
+        end
+
+        [match[1], match[2]]
+      end
+
+      def build_version_hashes(results:, gem_name:)
+        results
+          .filter_map do |item|
+            version = extract_version(item["name"], gem_name)
+            next if version.nil?
+
+            {
+              "number" => version,
+              "created_at" => item["created"],
+              "prerelease" => Gem::Version.new(version).prerelease?,
+            }
+          end
+          .uniq { |h| h["number"] }
+          .sort_by { |h| Gem::Version.new(h["number"]) }
+          .reverse
+      end
+
+      def extract_version(filename, gem_name)
+        prefix = "#{gem_name}-"
+        return unless filename&.end_with?(".gem") && filename.start_with?(prefix)
+
+        version_part = filename[prefix.length..-5]
+        return if version_part.nil? || version_part.empty?
+
+        parse_version_from_filename_tail(version_part)
+      end
+
+      # Given the portion of a `.gem` filename after `name-`, returns the
+      # leading semver (e.g. `7.0.0` from `7.0.0-x86_64-linux`). Ignores
+      # unrelated artifacts that share a prefix (e.g. `datadog-ruby_core_source`
+      # when the gem name is `datadog`).
+      def parse_version_from_filename_tail(version_part)
+        segments = version_part.split("-")
+        segments.length.times do |i|
+          candidate = segments[0, i + 1].join("-")
+          return candidate if Gem::Version.correct?(candidate)
+        end
+        nil
+      end
+
+      def credentials(source_uri)
+        host = URI(source_uri).host
+        creds = Bundler.settings[source_uri] || Bundler.settings[host]
+        creds && !creds.empty? ? creds : StillActive.config.artifactory_token
+      end
+
+      def auth_headers(source_uri)
+        creds = credentials(source_uri)
+        return {} unless creds
+
+        if creds.include?(":")
+          user, pass = creds.split(":", 2).map { |part| CGI.unescape(part) }
+          { "Authorization" => "Basic #{["#{user}:#{pass}"].pack("m0")}" }
+        else
+          { "Authorization" => "Bearer #{creds}" }
+        end
       end
     end
   end

--- a/lib/still_active/artifactory_client.rb
+++ b/lib/still_active/artifactory_client.rb
@@ -17,51 +17,62 @@ module StillActive
     end
 
     def versions(gem_name:, source_uri:)
-      vs = RubygemsClient.versions(gem_name: gem_name, source_uri: source_uri)
+      headers = auth_headers(gem_name: gem_name, source_uri: source_uri)
+      vs = RubygemsClient.versions(gem_name: gem_name, source_uri: source_uri, headers: headers)
       return vs unless vs.empty?
 
-      AqlClient.versions(gem_name: gem_name, source_uri: source_uri)
+      AqlClient.versions(gem_name: gem_name, source_uri: source_uri, headers: headers)
     rescue Errno::ECONNRESET, Errno::ECONNREFUSED, Net::OpenTimeout, Net::ReadTimeout, SocketError
       []
     end
 
-    module Authentication
-      private
+    private
 
-      def credentials(source_uri)
-        host = URI(source_uri).host
-        bundler = Bundler.settings[source_uri] || Bundler.settings[host]
-        return bundler if bundler && !bundler.empty?
+    def credentials(gem_name:, source_uri:)
+      host = URI(source_uri).host
+      bundler = Bundler.settings[source_uri] || Bundler.settings[host]
+      return bundler if bundler && !bundler.empty?
 
-        global = StillActive.config.artifactory_token
-        configured_host = StillActive.config.artifactory_host
-        return unless global && configured_host && host&.casecmp?(configured_host)
+      global = StillActive.config.artifactory_token
+      return unless global
 
-        global
+      configured_host = StillActive.config.artifactory_host
+      unless configured_host && host&.casecmp?(configured_host)
+        warn_unauthorized_host(gem_name: gem_name, host: host)
+        return
       end
 
-      def auth_headers(source_uri)
-        creds = credentials(source_uri)
-        return {} unless creds
+      global
+    end
 
-        if creds.include?(":")
-          user, pass = creds.split(":", 2).map { |part| CGI.unescape(part) }
-          { "Authorization" => "Basic #{["#{user}:#{pass}"].pack("m0")}" }
-        else
-          { "Authorization" => "Bearer #{creds}" }
-        end
+    def warn_unauthorized_host(gem_name:, host:)
+      $stderr.puts(
+        "warning: an Artifactory token is set but #{host} (source for #{gem_name}) is not an authorized host, " \
+          "so the token will not be sent. " \
+          "To allow it, set --artifactory-host=#{host} or STILL_ACTIVE_ARTIFACTORY_HOST=#{host}",
+      )
+    end
+
+    def auth_headers(gem_name:, source_uri:)
+      creds = credentials(gem_name: gem_name, source_uri: source_uri)
+      return {} unless creds
+
+      if creds.include?(":")
+        user, pass = creds.split(":", 2).map { |part| CGI.unescape(part) }
+        { "Authorization" => "Basic #{["#{user}:#{pass}"].pack("m0")}" }
+      else
+        { "Authorization" => "Bearer #{creds}" }
       end
     end
 
     # Artifactory's Rubygems-compatible API
     module RubygemsClient
       extend self
-      include Authentication
 
-      def versions(gem_name:, source_uri:)
+      def versions(gem_name:, source_uri:, headers: {})
         base = URI(source_uri.chomp("/"))
         path = "#{base.path}/api/v1/versions/#{encode(gem_name)}.json"
-        HttpHelper.get_json(base, path, headers: auth_headers(source_uri)) || []
+        HttpHelper.get_json(base, path, headers: headers) || []
       end
 
       private
@@ -75,12 +86,11 @@ module StillActive
     # https://docs.jfrog.com/artifactory/docs/artifactory-query-language
     module AqlClient
       extend self
-      include Authentication
 
       SOURCE_URL_PATTERN = %r{\A(https?://[^/]+\.jfrog\.io/[^/]+)/api/gems/([^/]+)/?\z}
       AQL_PATH = "/api/search/aql"
 
-      def versions(gem_name:, source_uri:)
+      def versions(gem_name:, source_uri:, headers: {})
         artifactory_base, repo_key = parse_source_url(source_uri)
         return [] if artifactory_base.nil?
 
@@ -91,8 +101,7 @@ module StillActive
           "repo" => repo_key,
         }
         body = %(items.find(#{JSON.generate(query)}).include("repo", "path", "name", "created"))
-        headers = auth_headers(source_uri).merge("Content-Type" => "text/plain")
-        response = HttpHelper.post_json(base, path, body: body, headers: headers)
+        response = HttpHelper.post_json(base, path, body: body, headers: headers.merge("Content-Type" => "text/plain"))
         return [] if response.nil?
 
         results = response["results"] || []

--- a/lib/still_active/artifactory_client.rb
+++ b/lib/still_active/artifactory_client.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "bundler"
+require "cgi"
+require "json"
+require "uri"
+require_relative "../helpers/http_helper"
+
+module StillActive
+  module ArtifactoryClient
+    extend self
+
+    # NOT GitHub Packages' /api/v1/gems/.../versions.json
+    VERSIONS_API_PATH = "/api/v1/versions/%<gem>s.json"
+    SOURCE_URL_PATTERN = %r{\A(https?://[^/]+\.jfrog\.io/[^/]+)/api/gems/([^/]+)/?\z}
+    AQL_PATH = "/api/search/aql"
+
+    def artifactory_uri?(uri)
+      uri.is_a?(String) && URI(uri).host&.end_with?(".jfrog.io")
+    rescue URI::InvalidURIError
+      false
+    end
+
+    def versions(gem_name:, source_uri:)
+      vs = versions_api(gem_name: gem_name, source_uri: source_uri)
+      return vs unless vs.empty?
+
+      versions_aql(gem_name: gem_name, source_uri: source_uri)
+    rescue Errno::ECONNRESET, Errno::ECONNREFUSED, Net::OpenTimeout, Net::ReadTimeout, SocketError
+      []
+    end
+
+    private
+
+    def versions_api(gem_name:, source_uri:)
+      base = URI(source_uri.chomp("/"))
+      path = "#{base.path}#{format(VERSIONS_API_PATH, gem: gem_name)}"
+      HttpHelper.get_json(base, path, headers: auth_headers(source_uri)) || []
+    end
+
+    def versions_aql(gem_name:, source_uri:)
+      artifactory_base, repo_key = parse_source_url(source_uri)
+      return [] if artifactory_base.nil?
+
+      base = URI(artifactory_base)
+      path = "#{base.path}#{AQL_PATH}"
+      body = %(items.find({"name":{"$match":"#{gem_name}-*.gem"},"repo":"#{repo_key}"}).include("name","created"))
+      headers = auth_headers(source_uri).merge("Content-Type" => "text/plain")
+      response = HttpHelper.post_json(base, path, body: body, headers: headers)
+      return [] if response.nil?
+
+      results = response["results"] || []
+      build_version_hashes(results: results, gem_name: gem_name)
+    end
+
+    def parse_source_url(source_uri)
+      match = source_uri.match(SOURCE_URL_PATTERN)
+      unless match
+        $stderr.puts("warning: unrecognized Artifactory source URL for AQL fallback: #{source_uri}")
+        return [nil, nil]
+      end
+
+      [match[1], match[2]]
+    end
+
+    def build_version_hashes(results:, gem_name:)
+      results
+        .filter_map do |item|
+          version = extract_version(item["name"], gem_name)
+          next if version.nil?
+
+          {
+            "number" => version,
+            "created_at" => item["created"],
+            "prerelease" => Gem::Version.new(version).prerelease?,
+          }
+        end
+        .uniq { |h| h["number"] }
+        .sort_by { |h| Gem::Version.new(h["number"]) }
+        .reverse
+    end
+
+    def extract_version(filename, gem_name)
+      prefix = "#{gem_name}-"
+      return unless filename&.end_with?(".gem") && filename.start_with?(prefix)
+
+      version_part = filename[prefix.length..-5]
+      return if version_part.nil? || version_part.empty?
+
+      parse_version_from_filename_tail(version_part)
+    end
+
+    # Given the portion of a `.gem` filename after `name-`, returns the
+    # leading semver (e.g. `7.0.0` from `7.0.0-x86_64-linux`). Ignores
+    # unrelated artifacts that share a prefix (e.g. `datadog-ruby_core_source`
+    # when the gem name is `datadog`).
+    def parse_version_from_filename_tail(version_part)
+      segments = version_part.split("-")
+      segments.length.times do |i|
+        candidate = segments[0, i + 1].join("-")
+        return candidate if Gem::Version.correct?(candidate)
+      end
+      nil
+    end
+
+    def credentials(source_uri)
+      host = URI(source_uri).host
+      creds = Bundler.settings[source_uri] || Bundler.settings[host]
+      creds && !creds.empty? ? creds : StillActive.config.artifactory_token
+    end
+
+    def auth_headers(source_uri)
+      creds = credentials(source_uri)
+      return {} unless creds
+
+      if creds.include?(":")
+        user, pass = creds.split(":", 2).map { |part| CGI.unescape(part) }
+        { "Authorization" => "Basic #{["#{user}:#{pass}"].pack("m0")}" }
+      else
+        { "Authorization" => "Bearer #{creds}" }
+      end
+    end
+  end
+end

--- a/lib/still_active/artifactory_client.rb
+++ b/lib/still_active/artifactory_client.rb
@@ -38,7 +38,7 @@ module StillActive
       private
 
       def encode(value)
-        URI.encode_www_form_component(value)
+        CGI.escape(value)
       end
 
       def credentials(source_uri)

--- a/lib/still_active/config.rb
+++ b/lib/still_active/config.rb
@@ -6,7 +6,7 @@ require "open3"
 
 module StillActive
   class Config
-    attr_writer :github_oauth_token, :gitlab_token, :artifactory_token, :gemfile_path
+    attr_writer :github_oauth_token, :gitlab_token, :artifactory_token, :artifactory_host, :gemfile_path
     attr_accessor :alternatives,
       :baseline_path,
       :critical_warning_emoji,
@@ -40,6 +40,7 @@ module StillActive
       @github_oauth_token = nil
       @gitlab_token = nil
       @artifactory_token = nil
+      @artifactory_host = nil
 
       @parallelism = 10
 
@@ -74,6 +75,10 @@ module StillActive
 
     def artifactory_token
       @artifactory_token ||= presence(ENV["STILL_ACTIVE_ARTIFACTORY_TOKEN"])
+    end
+
+    def artifactory_host
+      @artifactory_host ||= presence(ENV["STILL_ACTIVE_ARTIFACTORY_HOST"])
     end
 
     # Lazy so that running with --gems=... (no Gemfile needed) doesn't crash

--- a/lib/still_active/config.rb
+++ b/lib/still_active/config.rb
@@ -6,7 +6,7 @@ require "open3"
 
 module StillActive
   class Config
-    attr_writer :github_oauth_token, :gitlab_token, :gemfile_path
+    attr_writer :github_oauth_token, :gitlab_token, :artifactory_token, :gemfile_path
     attr_accessor :alternatives,
       :baseline_path,
       :critical_warning_emoji,
@@ -39,6 +39,7 @@ module StillActive
       @ignored_gems = []
       @github_oauth_token = nil
       @gitlab_token = nil
+      @artifactory_token = nil
 
       @parallelism = 10
 
@@ -69,6 +70,10 @@ module StillActive
 
     def gitlab_token
       @gitlab_token ||= presence(ENV["GITLAB_TOKEN"]) || glab_cli_token
+    end
+
+    def artifactory_token
+      @artifactory_token ||= presence(ENV["STILL_ACTIVE_ARTIFACTORY_TOKEN"])
     end
 
     # Lazy so that running with --gems=... (no Gemfile needed) doesn't crash

--- a/lib/still_active/options.rb
+++ b/lib/still_active/options.rb
@@ -94,6 +94,9 @@ module StillActive
       opts.on("--artifactory-token=TOKEN", String, "Artifactory token for private gem registry API calls") do |value|
         StillActive.config { |config| config.artifactory_token = value }
       end
+      opts.on("--artifactory-host=HOST", String, "Artifactory host that may receive the global token (e.g. my-org.jfrog.io)") do |value|
+        StillActive.config { |config| config.artifactory_host = value }
+      end
     end
 
     def add_parallelism_options(opts)

--- a/lib/still_active/options.rb
+++ b/lib/still_active/options.rb
@@ -91,6 +91,9 @@ module StillActive
       opts.on("--gitlab-token=TOKEN", String, "GitLab personal access token for API calls") do |value|
         StillActive.config { |config| config.gitlab_token = value }
       end
+      opts.on("--artifactory-token=TOKEN", String, "Artifactory token for private gem registry API calls") do |value|
+        StillActive.config { |config| config.artifactory_token = value }
+      end
     end
 
     def add_parallelism_options(opts)

--- a/lib/still_active/workflow.rb
+++ b/lib/still_active/workflow.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "artifactory_client"
 require_relative "deps_dev_client"
 require_relative "gitlab_client"
 require_relative "repository"
@@ -185,11 +186,16 @@ module StillActive
     def versions(gem_name:, source_uri: nil)
       if github_packages_uri?(source_uri)
         fetch_github_packages_versions(gem_name: gem_name, source_uri: source_uri)
+      elsif ArtifactoryClient.artifactory_uri?(source_uri)
+        ArtifactoryClient.versions(gem_name: gem_name, source_uri: source_uri)
       else
         Gems.versions(gem_name)
       end
     rescue Gems::NotFound
       []
+    # TODO: This rescue likely only needs to wrap Gems.versions — GitHub Packages and
+    # Artifactory use HttpHelper (which swallows network errors) and ArtifactoryClient
+    # also rescues them. Only the rubygems.org path can realistically hit this today.
     rescue Errno::ECONNRESET, Errno::ECONNREFUSED, Net::OpenTimeout, Net::ReadTimeout, SocketError => e
       $stderr.puts("warning: rubygems.org versions lookup failed for #{gem_name}: #{e.class} (#{e.message})")
       []

--- a/lib/still_active/workflow.rb
+++ b/lib/still_active/workflow.rb
@@ -193,9 +193,6 @@ module StillActive
       end
     rescue Gems::NotFound
       []
-    # TODO: This rescue likely only needs to wrap Gems.versions — GitHub Packages and
-    # Artifactory use HttpHelper (which swallows network errors) and ArtifactoryClient
-    # also rescues them. Only the rubygems.org path can realistically hit this today.
     rescue Errno::ECONNRESET, Errno::ECONNREFUSED, Net::OpenTimeout, Net::ReadTimeout, SocketError => e
       $stderr.puts("warning: rubygems.org versions lookup failed for #{gem_name}: #{e.class} (#{e.message})")
       []

--- a/spec/still_active/artifactory_client_spec.rb
+++ b/spec/still_active/artifactory_client_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe(StillActive::ArtifactoryClient) do
 
   let(:source_uri) { "https://my-org.jfrog.io/artifactory/api/gems/my-repo/" }
   let(:gem_name) { "private_gem" }
+  let(:versions_api_url) { "https://my-org.jfrog.io/artifactory/api/gems/my-repo/api/v1/versions/#{gem_name}.json" }
+  let(:aql_url) { "https://my-org.jfrog.io/artifactory/api/search/aql" }
 
   describe(".artifactory_uri?") do
     it("returns true for a jfrog.io host") do
@@ -51,18 +53,91 @@ RSpec.describe(StillActive::ArtifactoryClient) do
       expect(result).to(eq([]))
     end
 
-    it("does not send the global token on AQL fallback when artifactory_host is not configured") do
-      StillActive.config.artifactory_token = "secret-global-token"
-      attacker_uri = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/"
-      attacker_versions_api = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/api/v1/versions/#{gem_name}.json"
-      attacker_aql_url = "https://attacker.jfrog.io/artifactory/api/search/aql"
-      stub_request(:get, attacker_versions_api).to_return(status: 404)
-      stub_request(:post, attacker_aql_url).to_return(status: 404)
+    describe("authentication") do
+      it("does not send the global token to a host the lockfile names but the user never opted into") do
+        StillActive.config.artifactory_token = "secret-global-token"
+        attacker_uri = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/"
+        attacker_api = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/api/v1/versions/#{gem_name}.json"
+        attacker_aql = "https://attacker.jfrog.io/artifactory/api/search/aql"
+        stub_request(:get, attacker_api).to_return(status: 404)
+        stub_request(:post, attacker_aql).to_return(status: 404)
 
-      described_class.versions(gem_name: gem_name, source_uri: attacker_uri)
+        described_class.versions(gem_name: gem_name, source_uri: attacker_uri)
 
-      expect(WebMock).to(have_requested(:get, attacker_versions_api).with { |req| !req.headers.key?("Authorization") })
-      expect(WebMock).to(have_requested(:post, attacker_aql_url).with { |req| !req.headers.key?("Authorization") })
+        expect(WebMock).to(have_requested(:get, attacker_api).with { |req| !req.headers.key?("Authorization") })
+        expect(WebMock).to(have_requested(:post, attacker_aql).with { |req| !req.headers.key?("Authorization") })
+      end
+
+      it("does not send the global token when artifactory_host does not match the request host") do
+        StillActive.config.artifactory_token = "secret-global-token"
+        StillActive.config.artifactory_host  = "my-org.jfrog.io"
+        attacker_uri = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/"
+        attacker_api = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/api/v1/versions/#{gem_name}.json"
+        attacker_aql = "https://attacker.jfrog.io/artifactory/api/search/aql"
+        stub_request(:get, attacker_api).to_return(status: 404)
+        stub_request(:post, attacker_aql).to_return(status: 404)
+
+        described_class.versions(gem_name: gem_name, source_uri: attacker_uri)
+
+        expect(WebMock).to(have_requested(:get, attacker_api).with { |req| !req.headers.key?("Authorization") })
+        expect(WebMock).to(have_requested(:post, attacker_aql).with { |req| !req.headers.key?("Authorization") })
+      end
+
+      it("does send the global token to the host the user named") do
+        StillActive.config.artifactory_token = "secret-global-token"
+        StillActive.config.artifactory_host  = "my-org.jfrog.io"
+        body = [{ "number" => "1.0.0", "prerelease" => false, "created_at" => "2025-06-01T00:00:00Z" }]
+        stub_request(:get, versions_api_url)
+          .to_return(status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" })
+
+        described_class.versions(gem_name: gem_name, source_uri: source_uri)
+
+        expect(WebMock).to(have_requested(:get, versions_api_url)
+          .with(headers: { "Authorization" => "Bearer secret-global-token" }))
+      end
+
+      it("warns that the token will not be sent to an unauthorized host") do
+        StillActive.config.artifactory_token = "secret-global-token"
+        StillActive.config.artifactory_host  = "my-org.jfrog.io"
+        attacker_uri = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/"
+        attacker_api = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/api/v1/versions/#{gem_name}.json"
+        attacker_aql = "https://attacker.jfrog.io/artifactory/api/search/aql"
+        stub_request(:get, attacker_api).to_return(status: 404)
+        stub_request(:post, attacker_aql).to_return(status: 404)
+
+        expect do
+          described_class.versions(gem_name: gem_name, source_uri: attacker_uri)
+        end.to(output(
+          /an Artifactory token is set but attacker\.jfrog\.io \(source for #{gem_name}\) is not an authorized host.*--artifactory-host=attacker\.jfrog\.io/m,
+        ).to_stderr)
+      end
+
+      it("URL-decodes Bundler credentials before Basic auth") do
+        allow(Bundler.settings).to(receive(:[]).with(source_uri).and_return("user%40example.com:pa%3Ass"))
+        allow(Bundler.settings).to(receive(:[]).with("my-org.jfrog.io").and_return(nil))
+        api_body = [{ "number" => "1.0.0", "prerelease" => false, "created_at" => "2025-06-01T00:00:00Z" }]
+        stub_request(:get, versions_api_url)
+          .with(headers: { "Authorization" => "Basic #{["user@example.com:pa:ss"].pack("m0")}" })
+          .to_return(status: 200, body: api_body.to_json, headers: { "Content-Type" => "application/json" })
+
+        described_class.versions(gem_name: gem_name, source_uri: source_uri)
+
+        expect(WebMock).to(have_requested(:get, versions_api_url))
+      end
+
+      it("sends Basic auth on AQL fallback when Bundler credentials are set") do
+        allow(Bundler.settings).to(receive(:[]).with(source_uri).and_return("alice:secret"))
+        allow(Bundler.settings).to(receive(:[]).with("my-org.jfrog.io").and_return(nil))
+        stub_request(:get, versions_api_url).to_return(status: 404)
+        aql_body = { "results" => [{ "name" => "private_gem-1.0.0.gem", "created" => "2025-06-01T00:00:00Z" }] }
+        stub_request(:post, aql_url)
+          .with(headers: { "Authorization" => /^Basic / })
+          .to_return(status: 200, body: aql_body.to_json, headers: { "Content-Type" => "application/json" })
+
+        described_class.versions(gem_name: gem_name, source_uri: source_uri)
+
+        expect(WebMock).to(have_requested(:post, aql_url))
+      end
     end
   end
 end
@@ -93,56 +168,19 @@ RSpec.describe(StillActive::ArtifactoryClient::RubygemsClient) do
       expect(result).to(eq([]))
     end
 
-    describe("authentication") do
-      it("does not send the global token to a host the lockfile names but the user never opted into") do
-        StillActive.config.artifactory_token = "secret-global-token"
-        attacker_uri = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/"
-        attacker_api = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/api/v1/versions/#{gem_name}.json"
-        stub_request(:get, attacker_api).to_return(status: 404)
-        stub_request(:post, "https://attacker.jfrog.io/artifactory/api/search/aql").to_return(status: 404)
+    it("applies provided headers to the request") do
+      body = [{ "number" => "1.0.0", "prerelease" => false, "created_at" => "2025-06-01T00:00:00Z" }]
+      stub_request(:get, versions_api_url)
+        .with(headers: { "Authorization" => "Bearer test-token" })
+        .to_return(status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" })
 
-        described_class.versions(gem_name: gem_name, source_uri: attacker_uri)
+      described_class.versions(
+        gem_name: gem_name,
+        source_uri: source_uri,
+        headers: { "Authorization" => "Bearer test-token" },
+      )
 
-        expect(WebMock).to(have_requested(:get, attacker_api).with { |req| !req.headers.key?("Authorization") })
-      end
-
-      it("does not send the global token when artifactory_host does not match the request host") do
-        StillActive.config.artifactory_token = "secret-global-token"
-        StillActive.config.artifactory_host  = "my-org.jfrog.io"
-        attacker_uri = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/"
-        attacker_api = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/api/v1/versions/#{gem_name}.json"
-        stub_request(:get, attacker_api).to_return(status: 404)
-
-        described_class.versions(gem_name: gem_name, source_uri: attacker_uri)
-
-        expect(WebMock).to(have_requested(:get, attacker_api).with { |req| !req.headers.key?("Authorization") })
-      end
-
-      it("does send the global token to the host the user named") do
-        StillActive.config.artifactory_token = "secret-global-token"
-        StillActive.config.artifactory_host  = "my-org.jfrog.io"
-        uri  = "https://my-org.jfrog.io/artifactory/api/gems/my-repo/"
-        api  = "https://my-org.jfrog.io/artifactory/api/gems/my-repo/api/v1/versions/#{gem_name}.json"
-        body = [{ "number" => "1.0.0", "prerelease" => false, "created_at" => "2025-06-01T00:00:00Z" }]
-        stub_request(:get, api).to_return(status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" })
-
-        described_class.versions(gem_name: gem_name, source_uri: uri)
-
-        expect(WebMock).to(have_requested(:get, api).with(headers: { "Authorization" => "Bearer secret-global-token" }))
-      end
-
-      it("URL-decodes Bundler credentials before Basic auth") do
-        allow(Bundler.settings).to(receive(:[]).with(source_uri).and_return("user%40example.com:pa%3Ass"))
-        allow(Bundler.settings).to(receive(:[]).with("my-org.jfrog.io").and_return(nil))
-        api_body = [{ "number" => "1.0.0", "prerelease" => false, "created_at" => "2025-06-01T00:00:00Z" }]
-        stub_request(:get, versions_api_url)
-          .with(headers: { "Authorization" => "Basic #{["user@example.com:pa:ss"].pack("m0")}" })
-          .to_return(status: 200, body: api_body.to_json, headers: { "Content-Type" => "application/json" })
-
-        described_class.versions(gem_name: gem_name, source_uri: source_uri)
-
-        expect(WebMock).to(have_requested(:get, versions_api_url))
-      end
+      expect(WebMock).to(have_requested(:get, versions_api_url))
     end
   end
 end
@@ -228,54 +266,18 @@ RSpec.describe(StillActive::ArtifactoryClient::AqlClient) do
       expect(WebMock).not_to(have_requested(:post, aql_url))
     end
 
-    describe("authentication") do
-      let(:gem_name) { "private_gem" }
+    it("applies provided headers and sets Content-Type to text/plain") do
+      stub_request(:post, aql_url)
+        .with(headers: { "Authorization" => "Bearer test-token", "Content-Type" => "text/plain" })
+        .to_return(status: 200, body: { "results" => [] }.to_json, headers: { "Content-Type" => "application/json" })
 
-      it("does not send the global token to a host the lockfile names but the user never opted into") do
-        StillActive.config.artifactory_token = "secret-global-token"
-        attacker_uri = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/"
-        attacker_aql = "https://attacker.jfrog.io/artifactory/api/search/aql"
-        stub_request(:post, attacker_aql).to_return(status: 404)
+      described_class.versions(
+        gem_name: "private_gem",
+        source_uri: source_uri,
+        headers: { "Authorization" => "Bearer test-token" },
+      )
 
-        described_class.versions(gem_name: gem_name, source_uri: attacker_uri)
-
-        expect(WebMock).to(have_requested(:post, attacker_aql).with { |req| !req.headers.key?("Authorization") })
-      end
-
-      it("does not send the global token when artifactory_host does not match the request host") do
-        StillActive.config.artifactory_token = "secret-global-token"
-        StillActive.config.artifactory_host  = "my-org.jfrog.io"
-        attacker_uri = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/"
-        attacker_aql = "https://attacker.jfrog.io/artifactory/api/search/aql"
-        stub_request(:post, attacker_aql).to_return(status: 404)
-
-        described_class.versions(gem_name: gem_name, source_uri: attacker_uri)
-
-        expect(WebMock).to(have_requested(:post, attacker_aql).with { |req| !req.headers.key?("Authorization") })
-      end
-
-      it("does send the global token to the host the user named") do
-        StillActive.config.artifactory_token = "secret-global-token"
-        StillActive.config.artifactory_host  = "my-org.jfrog.io"
-        stub_request(:post, aql_url)
-          .to_return(status: 200, body: { "results" => [] }.to_json, headers: { "Content-Type" => "application/json" })
-
-        described_class.versions(gem_name: gem_name, source_uri: source_uri)
-
-        expect(WebMock).to(have_requested(:post, aql_url).with(headers: { "Authorization" => "Bearer secret-global-token" }))
-      end
-
-      it("URL-decodes Bundler credentials before Basic auth") do
-        allow(Bundler.settings).to(receive(:[]).with(source_uri).and_return("user%40example.com:pa%3Ass"))
-        allow(Bundler.settings).to(receive(:[]).with("my-org.jfrog.io").and_return(nil))
-        stub_request(:post, aql_url)
-          .with(headers: { "Authorization" => "Basic #{["user@example.com:pa:ss"].pack("m0")}" })
-          .to_return(status: 200, body: { "results" => [] }.to_json, headers: { "Content-Type" => "application/json" })
-
-        described_class.versions(gem_name: gem_name, source_uri: source_uri)
-
-        expect(WebMock).to(have_requested(:post, aql_url))
-      end
+      expect(WebMock).to(have_requested(:post, aql_url))
     end
   end
 end

--- a/spec/still_active/artifactory_client_spec.rb
+++ b/spec/still_active/artifactory_client_spec.rb
@@ -160,6 +160,21 @@ RSpec.describe(StillActive::ArtifactoryClient::AqlClient) do
       expect(result.map { |h| h["number"] }).to(eq(["2.0.0"]))
     end
 
+    it("builds well-formed JSON when the gem name contains a quote") do
+      evil_gem_name = %(evil"name)
+      stub_request(:post, aql_url)
+        .to_return(status: 200, body: { "results" => [] }.to_json, headers: { "Content-Type" => "application/json" })
+
+      described_class.versions(gem_name: evil_gem_name, source_uri: source_uri)
+
+      expect(WebMock).to(have_requested(:post, aql_url).with do |request|
+        criteria = request.body[/\Aitems\.find\((.*)\)\.include/, 1]
+        parsed = JSON.parse(criteria)
+        expect(parsed.dig("name", "$match")).to(eq(%(evil"name-*.gem)))
+        true
+      end)
+    end
+
     it("returns empty and warns when the source URI cannot be parsed") do
       bad_uri = "https://my-org.jfrog.io/no-api/here/"
 

--- a/spec/still_active/artifactory_client_spec.rb
+++ b/spec/still_active/artifactory_client_spec.rb
@@ -50,6 +50,20 @@ RSpec.describe(StillActive::ArtifactoryClient) do
 
       expect(result).to(eq([]))
     end
+
+    it("does not send the global token on AQL fallback when artifactory_host is not configured") do
+      StillActive.config.artifactory_token = "secret-global-token"
+      attacker_uri = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/"
+      attacker_versions_api = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/api/v1/versions/#{gem_name}.json"
+      attacker_aql_url = "https://attacker.jfrog.io/artifactory/api/search/aql"
+      stub_request(:get, attacker_versions_api).to_return(status: 404)
+      stub_request(:post, attacker_aql_url).to_return(status: 404)
+
+      described_class.versions(gem_name: gem_name, source_uri: attacker_uri)
+
+      expect(WebMock).to(have_requested(:get, attacker_versions_api).with { |req| !req.headers.key?("Authorization") })
+      expect(WebMock).to(have_requested(:post, attacker_aql_url).with { |req| !req.headers.key?("Authorization") })
+    end
   end
 end
 
@@ -79,29 +93,56 @@ RSpec.describe(StillActive::ArtifactoryClient::RubygemsClient) do
       expect(result).to(eq([]))
     end
 
-    it("sends Bearer auth from config.artifactory_token") do
-      StillActive.config.artifactory_token = "bearer-token"
-      api_body = [{ "number" => "1.0.0", "prerelease" => false, "created_at" => "2025-06-01T00:00:00Z" }]
-      stub_request(:get, versions_api_url)
-        .with(headers: { "Authorization" => "Bearer bearer-token" })
-        .to_return(status: 200, body: api_body.to_json, headers: { "Content-Type" => "application/json" })
+    describe("authentication") do
+      it("does not send the global token to a host the lockfile names but the user never opted into") do
+        StillActive.config.artifactory_token = "secret-global-token"
+        attacker_uri = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/"
+        attacker_api = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/api/v1/versions/#{gem_name}.json"
+        stub_request(:get, attacker_api).to_return(status: 404)
+        stub_request(:post, "https://attacker.jfrog.io/artifactory/api/search/aql").to_return(status: 404)
 
-      described_class.versions(gem_name: gem_name, source_uri: source_uri)
+        described_class.versions(gem_name: gem_name, source_uri: attacker_uri)
 
-      expect(WebMock).to(have_requested(:get, versions_api_url))
-    end
+        expect(WebMock).to(have_requested(:get, attacker_api).with { |req| !req.headers.key?("Authorization") })
+      end
 
-    it("URL-decodes Bundler credentials before Basic auth") do
-      allow(Bundler.settings).to(receive(:[]).with(source_uri).and_return("user%40example.com:pa%3Ass"))
-      allow(Bundler.settings).to(receive(:[]).with("my-org.jfrog.io").and_return(nil))
-      api_body = [{ "number" => "1.0.0", "prerelease" => false, "created_at" => "2025-06-01T00:00:00Z" }]
-      stub_request(:get, versions_api_url)
-        .with(headers: { "Authorization" => "Basic #{["user@example.com:pa:ss"].pack("m0")}" })
-        .to_return(status: 200, body: api_body.to_json, headers: { "Content-Type" => "application/json" })
+      it("does not send the global token when artifactory_host does not match the request host") do
+        StillActive.config.artifactory_token = "secret-global-token"
+        StillActive.config.artifactory_host  = "my-org.jfrog.io"
+        attacker_uri = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/"
+        attacker_api = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/api/v1/versions/#{gem_name}.json"
+        stub_request(:get, attacker_api).to_return(status: 404)
 
-      described_class.versions(gem_name: gem_name, source_uri: source_uri)
+        described_class.versions(gem_name: gem_name, source_uri: attacker_uri)
 
-      expect(WebMock).to(have_requested(:get, versions_api_url))
+        expect(WebMock).to(have_requested(:get, attacker_api).with { |req| !req.headers.key?("Authorization") })
+      end
+
+      it("does send the global token to the host the user named") do
+        StillActive.config.artifactory_token = "secret-global-token"
+        StillActive.config.artifactory_host  = "my-org.jfrog.io"
+        uri  = "https://my-org.jfrog.io/artifactory/api/gems/my-repo/"
+        api  = "https://my-org.jfrog.io/artifactory/api/gems/my-repo/api/v1/versions/#{gem_name}.json"
+        body = [{ "number" => "1.0.0", "prerelease" => false, "created_at" => "2025-06-01T00:00:00Z" }]
+        stub_request(:get, api).to_return(status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" })
+
+        described_class.versions(gem_name: gem_name, source_uri: uri)
+
+        expect(WebMock).to(have_requested(:get, api).with(headers: { "Authorization" => "Bearer secret-global-token" }))
+      end
+
+      it("URL-decodes Bundler credentials before Basic auth") do
+        allow(Bundler.settings).to(receive(:[]).with(source_uri).and_return("user%40example.com:pa%3Ass"))
+        allow(Bundler.settings).to(receive(:[]).with("my-org.jfrog.io").and_return(nil))
+        api_body = [{ "number" => "1.0.0", "prerelease" => false, "created_at" => "2025-06-01T00:00:00Z" }]
+        stub_request(:get, versions_api_url)
+          .with(headers: { "Authorization" => "Basic #{["user@example.com:pa:ss"].pack("m0")}" })
+          .to_return(status: 200, body: api_body.to_json, headers: { "Content-Type" => "application/json" })
+
+        described_class.versions(gem_name: gem_name, source_uri: source_uri)
+
+        expect(WebMock).to(have_requested(:get, versions_api_url))
+      end
     end
   end
 end
@@ -185,6 +226,56 @@ RSpec.describe(StillActive::ArtifactoryClient::AqlClient) do
 
       expect(result).to(eq([]))
       expect(WebMock).not_to(have_requested(:post, aql_url))
+    end
+
+    describe("authentication") do
+      let(:gem_name) { "private_gem" }
+
+      it("does not send the global token to a host the lockfile names but the user never opted into") do
+        StillActive.config.artifactory_token = "secret-global-token"
+        attacker_uri = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/"
+        attacker_aql = "https://attacker.jfrog.io/artifactory/api/search/aql"
+        stub_request(:post, attacker_aql).to_return(status: 404)
+
+        described_class.versions(gem_name: gem_name, source_uri: attacker_uri)
+
+        expect(WebMock).to(have_requested(:post, attacker_aql).with { |req| !req.headers.key?("Authorization") })
+      end
+
+      it("does not send the global token when artifactory_host does not match the request host") do
+        StillActive.config.artifactory_token = "secret-global-token"
+        StillActive.config.artifactory_host  = "my-org.jfrog.io"
+        attacker_uri = "https://attacker.jfrog.io/artifactory/api/gems/some-repo/"
+        attacker_aql = "https://attacker.jfrog.io/artifactory/api/search/aql"
+        stub_request(:post, attacker_aql).to_return(status: 404)
+
+        described_class.versions(gem_name: gem_name, source_uri: attacker_uri)
+
+        expect(WebMock).to(have_requested(:post, attacker_aql).with { |req| !req.headers.key?("Authorization") })
+      end
+
+      it("does send the global token to the host the user named") do
+        StillActive.config.artifactory_token = "secret-global-token"
+        StillActive.config.artifactory_host  = "my-org.jfrog.io"
+        stub_request(:post, aql_url)
+          .to_return(status: 200, body: { "results" => [] }.to_json, headers: { "Content-Type" => "application/json" })
+
+        described_class.versions(gem_name: gem_name, source_uri: source_uri)
+
+        expect(WebMock).to(have_requested(:post, aql_url).with(headers: { "Authorization" => "Bearer secret-global-token" }))
+      end
+
+      it("URL-decodes Bundler credentials before Basic auth") do
+        allow(Bundler.settings).to(receive(:[]).with(source_uri).and_return("user%40example.com:pa%3Ass"))
+        allow(Bundler.settings).to(receive(:[]).with("my-org.jfrog.io").and_return(nil))
+        stub_request(:post, aql_url)
+          .with(headers: { "Authorization" => "Basic #{["user@example.com:pa:ss"].pack("m0")}" })
+          .to_return(status: 200, body: { "results" => [] }.to_json, headers: { "Content-Type" => "application/json" })
+
+        described_class.versions(gem_name: gem_name, source_uri: source_uri)
+
+        expect(WebMock).to(have_requested(:post, aql_url))
+      end
     end
   end
 end

--- a/spec/still_active/artifactory_client_spec.rb
+++ b/spec/still_active/artifactory_client_spec.rb
@@ -2,13 +2,12 @@
 
 require_relative "../../lib/still_active/artifactory_client"
 
+# rubocop:disable RSpec/MultipleDescribes
 RSpec.describe(StillActive::ArtifactoryClient) do
   before { StillActive.reset }
 
   let(:source_uri) { "https://my-org.jfrog.io/artifactory/api/gems/my-repo/" }
   let(:gem_name) { "private_gem" }
-  let(:versions_api_url) { "https://my-org.jfrog.io/artifactory/api/gems/my-repo/api/v1/versions/#{gem_name}.json" }
-  let(:aql_url) { "https://my-org.jfrog.io/artifactory/api/search/aql" }
 
   describe(".artifactory_uri?") do
     it("returns true for a jfrog.io host") do
@@ -25,7 +24,44 @@ RSpec.describe(StillActive::ArtifactoryClient) do
   end
 
   describe(".versions") do
-    it("returns versions from the versions API") do
+    it("returns versions from the RubyGems client when available") do
+      api_versions = [{ "number" => "1.0.0", "prerelease" => false, "created_at" => "2025-06-01T00:00:00Z" }]
+      allow(StillActive::ArtifactoryClient::RubygemsClient).to(receive(:versions).and_return(api_versions))
+
+      result = described_class.versions(gem_name: gem_name, source_uri: source_uri)
+
+      expect(result).to(eq(api_versions))
+    end
+
+    it("falls back to the AQL client when the RubyGems client returns empty") do
+      aql_versions = [{ "number" => "7.0.0", "prerelease" => false, "created_at" => "2024-07-01T00:00:00Z" }]
+      allow(StillActive::ArtifactoryClient::RubygemsClient).to(receive(:versions).and_return([]))
+      allow(StillActive::ArtifactoryClient::AqlClient).to(receive(:versions).and_return(aql_versions))
+
+      result = described_class.versions(gem_name: gem_name, source_uri: source_uri)
+
+      expect(result).to(eq(aql_versions))
+    end
+
+    it("returns empty on network errors") do
+      allow(StillActive::ArtifactoryClient::RubygemsClient).to(receive(:versions).and_raise(SocketError))
+
+      result = described_class.versions(gem_name: gem_name, source_uri: source_uri)
+
+      expect(result).to(eq([]))
+    end
+  end
+end
+
+RSpec.describe(StillActive::ArtifactoryClient::RubygemsClient) do
+  before { StillActive.reset }
+
+  let(:source_uri) { "https://my-org.jfrog.io/artifactory/api/gems/my-repo/" }
+  let(:gem_name) { "private_gem" }
+  let(:versions_api_url) { "https://my-org.jfrog.io/artifactory/api/gems/my-repo/api/v1/versions/#{gem_name}.json" }
+
+  describe(".versions") do
+    it("returns versions on success") do
       body = [{ "number" => "1.0.0", "prerelease" => false, "created_at" => "2025-06-01T00:00:00Z" }]
       stub_request(:get, versions_api_url)
         .to_return(status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" })
@@ -33,6 +69,14 @@ RSpec.describe(StillActive::ArtifactoryClient) do
       result = described_class.versions(gem_name: gem_name, source_uri: source_uri)
 
       expect(result).to(eq(body))
+    end
+
+    it("returns empty on 404") do
+      stub_request(:get, versions_api_url).to_return(status: 404)
+
+      result = described_class.versions(gem_name: gem_name, source_uri: source_uri)
+
+      expect(result).to(eq([]))
     end
 
     it("sends Bearer auth from config.artifactory_token") do
@@ -59,10 +103,17 @@ RSpec.describe(StillActive::ArtifactoryClient) do
 
       expect(WebMock).to(have_requested(:get, versions_api_url))
     end
+  end
+end
 
-    it("falls back to AQL and deduplicates platform variants") do
-      stub_request(:get, "https://my-org.jfrog.io/artifactory/api/gems/my-repo/api/v1/versions/rails.json")
-        .to_return(status: 404)
+RSpec.describe(StillActive::ArtifactoryClient::AqlClient) do
+  before { StillActive.reset }
+
+  let(:source_uri) { "https://my-org.jfrog.io/artifactory/api/gems/my-repo/" }
+  let(:aql_url) { "https://my-org.jfrog.io/artifactory/api/search/aql" }
+
+  describe(".versions") do
+    it("deduplicates platform variants") do
       aql_body = {
         "results" => [
           { "name" => "rails-7.0.0.gem", "created" => "2024-07-01T00:00:00Z" },
@@ -79,8 +130,6 @@ RSpec.describe(StillActive::ArtifactoryClient) do
     end
 
     it("sorts versions descending by Gem::Version") do
-      stub_request(:get, "https://my-org.jfrog.io/artifactory/api/gems/my-repo/api/v1/versions/widget.json")
-        .to_return(status: 404)
       aql_body = {
         "results" => [
           { "name" => "widget-1.10.0.gem", "created" => "2024-01-01T00:00:00Z" },
@@ -97,8 +146,6 @@ RSpec.describe(StillActive::ArtifactoryClient) do
     end
 
     it("ignores unrelated artifacts that share a name prefix") do
-      stub_request(:get, "https://my-org.jfrog.io/artifactory/api/gems/my-repo/api/v1/versions/datadog.json")
-        .to_return(status: 404)
       aql_body = {
         "results" => [
           { "name" => "datadog-2.0.0.gem", "created" => "2024-01-01T00:00:00Z" },
@@ -113,14 +160,12 @@ RSpec.describe(StillActive::ArtifactoryClient) do
       expect(result.map { |h| h["number"] }).to(eq(["2.0.0"]))
     end
 
-    it("returns empty and warns when the source URI cannot be parsed for AQL") do
+    it("returns empty and warns when the source URI cannot be parsed") do
       bad_uri = "https://my-org.jfrog.io/no-api/here/"
-      stub_request(:get, "https://my-org.jfrog.io/no-api/here/api/v1/versions/private_gem.json")
-        .to_return(status: 404)
 
       result = nil
       expect do
-        result = described_class.versions(gem_name: gem_name, source_uri: bad_uri)
+        result = described_class.versions(gem_name: "private_gem", source_uri: bad_uri)
       end.to(output(/unrecognized Artifactory source URL/).to_stderr)
 
       expect(result).to(eq([]))
@@ -128,3 +173,4 @@ RSpec.describe(StillActive::ArtifactoryClient) do
     end
   end
 end
+# rubocop:enable RSpec/MultipleDescribes

--- a/spec/still_active/artifactory_client_spec.rb
+++ b/spec/still_active/artifactory_client_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/still_active/artifactory_client"
+
+RSpec.describe(StillActive::ArtifactoryClient) do
+  before { StillActive.reset }
+
+  let(:source_uri) { "https://my-org.jfrog.io/artifactory/api/gems/my-repo/" }
+  let(:gem_name) { "private_gem" }
+  let(:versions_api_url) { "https://my-org.jfrog.io/artifactory/api/gems/my-repo/api/v1/versions/#{gem_name}.json" }
+  let(:aql_url) { "https://my-org.jfrog.io/artifactory/api/search/aql" }
+
+  describe(".artifactory_uri?") do
+    it("returns true for a jfrog.io host") do
+      expect(described_class.artifactory_uri?("https://my-org.jfrog.io/artifactory/api/gems/my-repo/")).to(be(true))
+    end
+
+    it("returns false for rubygems.org") do
+      expect(described_class.artifactory_uri?("https://rubygems.org")).to(be(false))
+    end
+
+    it("returns false for an invalid URI") do
+      expect(described_class.artifactory_uri?("not a uri")).to(be(false))
+    end
+  end
+
+  describe(".versions") do
+    it("returns versions from the versions API") do
+      body = [{ "number" => "1.0.0", "prerelease" => false, "created_at" => "2025-06-01T00:00:00Z" }]
+      stub_request(:get, versions_api_url)
+        .to_return(status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" })
+
+      result = described_class.versions(gem_name: gem_name, source_uri: source_uri)
+
+      expect(result).to(eq(body))
+    end
+
+    it("sends Bearer auth from config.artifactory_token") do
+      StillActive.config.artifactory_token = "bearer-token"
+      api_body = [{ "number" => "1.0.0", "prerelease" => false, "created_at" => "2025-06-01T00:00:00Z" }]
+      stub_request(:get, versions_api_url)
+        .with(headers: { "Authorization" => "Bearer bearer-token" })
+        .to_return(status: 200, body: api_body.to_json, headers: { "Content-Type" => "application/json" })
+
+      described_class.versions(gem_name: gem_name, source_uri: source_uri)
+
+      expect(WebMock).to(have_requested(:get, versions_api_url))
+    end
+
+    it("URL-decodes Bundler credentials before Basic auth") do
+      allow(Bundler.settings).to(receive(:[]).with(source_uri).and_return("user%40example.com:pa%3Ass"))
+      allow(Bundler.settings).to(receive(:[]).with("my-org.jfrog.io").and_return(nil))
+      api_body = [{ "number" => "1.0.0", "prerelease" => false, "created_at" => "2025-06-01T00:00:00Z" }]
+      stub_request(:get, versions_api_url)
+        .with(headers: { "Authorization" => "Basic #{["user@example.com:pa:ss"].pack("m0")}" })
+        .to_return(status: 200, body: api_body.to_json, headers: { "Content-Type" => "application/json" })
+
+      described_class.versions(gem_name: gem_name, source_uri: source_uri)
+
+      expect(WebMock).to(have_requested(:get, versions_api_url))
+    end
+
+    it("falls back to AQL and deduplicates platform variants") do
+      stub_request(:get, "https://my-org.jfrog.io/artifactory/api/gems/my-repo/api/v1/versions/rails.json")
+        .to_return(status: 404)
+      aql_body = {
+        "results" => [
+          { "name" => "rails-7.0.0.gem", "created" => "2024-07-01T00:00:00Z" },
+          { "name" => "rails-7.0.0-x86_64-linux.gem", "created" => "2024-07-02T00:00:00Z" },
+          { "name" => "rails-6.1.0.gem", "created" => "2024-01-01T00:00:00Z" },
+        ],
+      }
+      stub_request(:post, aql_url)
+        .to_return(status: 200, body: aql_body.to_json, headers: { "Content-Type" => "application/json" })
+
+      result = described_class.versions(gem_name: "rails", source_uri: source_uri)
+
+      expect(result.map { |h| h["number"] }).to(eq(["7.0.0", "6.1.0"]))
+    end
+
+    it("sorts versions descending by Gem::Version") do
+      stub_request(:get, "https://my-org.jfrog.io/artifactory/api/gems/my-repo/api/v1/versions/widget.json")
+        .to_return(status: 404)
+      aql_body = {
+        "results" => [
+          { "name" => "widget-1.10.0.gem", "created" => "2024-01-01T00:00:00Z" },
+          { "name" => "widget-2.0.0.gem", "created" => "2024-02-01T00:00:00Z" },
+          { "name" => "widget-10.0.0.gem", "created" => "2024-03-01T00:00:00Z" },
+        ],
+      }
+      stub_request(:post, aql_url)
+        .to_return(status: 200, body: aql_body.to_json, headers: { "Content-Type" => "application/json" })
+
+      result = described_class.versions(gem_name: "widget", source_uri: source_uri)
+
+      expect(result.map { |h| h["number"] }).to(eq(["10.0.0", "2.0.0", "1.10.0"]))
+    end
+
+    it("ignores unrelated artifacts that share a name prefix") do
+      stub_request(:get, "https://my-org.jfrog.io/artifactory/api/gems/my-repo/api/v1/versions/datadog.json")
+        .to_return(status: 404)
+      aql_body = {
+        "results" => [
+          { "name" => "datadog-2.0.0.gem", "created" => "2024-01-01T00:00:00Z" },
+          { "name" => "datadog-ruby_core_source.gem", "created" => "2024-01-01T00:00:00Z" },
+        ],
+      }
+      stub_request(:post, aql_url)
+        .to_return(status: 200, body: aql_body.to_json, headers: { "Content-Type" => "application/json" })
+
+      result = described_class.versions(gem_name: "datadog", source_uri: source_uri)
+
+      expect(result.map { |h| h["number"] }).to(eq(["2.0.0"]))
+    end
+
+    it("returns empty and warns when the source URI cannot be parsed for AQL") do
+      bad_uri = "https://my-org.jfrog.io/no-api/here/"
+      stub_request(:get, "https://my-org.jfrog.io/no-api/here/api/v1/versions/private_gem.json")
+        .to_return(status: 404)
+
+      result = nil
+      expect do
+        result = described_class.versions(gem_name: gem_name, source_uri: bad_uri)
+      end.to(output(/unrecognized Artifactory source URL/).to_stderr)
+
+      expect(result).to(eq([]))
+      expect(WebMock).not_to(have_requested(:post, aql_url))
+    end
+  end
+end

--- a/spec/still_active/options_spec.rb
+++ b/spec/still_active/options_spec.rb
@@ -91,6 +91,11 @@ RSpec.describe(StillActive::Options) do
       expect(StillActive.config.artifactory_token).to(eq("art-token"))
     end
 
+    it("sets artifactory host") do
+      described_class.new.parse!(["--artifactory-host=my-org.jfrog.io", "--gems=rails"])
+      expect(StillActive.config.artifactory_host).to(eq("my-org.jfrog.io"))
+    end
+
     it("sets safe range end") do
       described_class.new.parse!(["--safe-range-end=2", "--gems=rails"])
       expect(StillActive.config.no_warning_range_end).to(eq(2))

--- a/spec/still_active/options_spec.rb
+++ b/spec/still_active/options_spec.rb
@@ -86,6 +86,11 @@ RSpec.describe(StillActive::Options) do
       expect(StillActive.config.gitlab_token).to(eq("glpat-123"))
     end
 
+    it("sets artifactory token") do
+      described_class.new.parse!(["--artifactory-token=art-token", "--gems=rails"])
+      expect(StillActive.config.artifactory_token).to(eq("art-token"))
+    end
+
     it("sets safe range end") do
       described_class.new.parse!(["--safe-range-end=2", "--gems=rails"])
       expect(StillActive.config.no_warning_range_end).to(eq(2))

--- a/spec/still_active/workflow_spec.rb
+++ b/spec/still_active/workflow_spec.rb
@@ -216,6 +216,79 @@ RSpec.describe(StillActive::Workflow) do
       end
     end
 
+    context("when a gem is from Artifactory") do
+      let(:source_uri) { "https://my-org.jfrog.io/artifactory/api/gems/my-repo/" }
+      let(:versions_api_url) { "https://my-org.jfrog.io/artifactory/api/gems/my-repo/api/v1/versions/private_gem.json" }
+      let(:aql_url) { "https://my-org.jfrog.io/artifactory/api/search/aql" }
+      let(:artifactory_versions) do
+        [
+          { "number" => "1.0.0", "prerelease" => false, "created_at" => "2025-06-01T00:00:00Z", "licenses" => ["MIT"] },
+        ]
+      end
+
+      before do
+        StillActive.config.gems = [{
+          name: "private_gem",
+          version: "1.0.0",
+          source_type: :rubygems,
+          source_uri: source_uri,
+        }]
+        allow(Gems).to(receive(:info).with("private_gem").and_return({
+          "homepage_uri" => nil,
+          "source_code_uri" => nil,
+        }))
+        allow(StillActive::DepsDevClient).to(receive(:version_info).and_return(nil))
+      end
+
+      it("fetches versions from the Artifactory versions API with Bearer auth") do
+        StillActive.config.artifactory_token = "art-test-token"
+        stub_request(:get, versions_api_url)
+          .to_return(status: 200, body: artifactory_versions.to_json, headers: { "Content-Type" => "application/json" })
+
+        result
+
+        expect(WebMock).to(have_requested(:get, versions_api_url)
+          .with(headers: { "Authorization" => "Bearer art-test-token" }))
+        expect(result).to(include(
+          "private_gem" => hash_including(latest_version: "1.0.0"),
+        ))
+      end
+
+      it("sends Basic auth when Bundler.settings has user:password credentials") do
+        allow(Bundler.settings).to(receive(:[]).with(source_uri).and_return("alice:secret"))
+        allow(Bundler.settings).to(receive(:[]).with("my-org.jfrog.io").and_return(nil))
+        stub_request(:get, versions_api_url)
+          .with(headers: { "Authorization" => /^Basic / })
+          .to_return(status: 200, body: artifactory_versions.to_json, headers: { "Content-Type" => "application/json" })
+
+        result
+
+        expect(WebMock).to(have_requested(:get, versions_api_url))
+        expect(result).to(include(
+          "private_gem" => hash_including(latest_version: "1.0.0"),
+        ))
+      end
+
+      it("falls back to AQL when the versions API returns 404") do
+        StillActive.config.artifactory_token = "art-test-token"
+        stub_request(:get, versions_api_url).to_return(status: 404)
+        aql_body = {
+          "results" => [
+            { "name" => "private_gem-2.0.0.gem", "created" => "2025-07-01T00:00:00Z" },
+            { "name" => "private_gem-2.0.0-x86_64-linux.gem", "created" => "2025-07-02T00:00:00Z" },
+            { "name" => "private_gem-1.0.0.gem", "created" => "2025-06-01T00:00:00Z" },
+          ],
+        }
+        stub_request(:post, aql_url)
+          .with(body: /private_gem-\*\.gem/)
+          .to_return(status: 200, body: aql_body.to_json, headers: { "Content-Type" => "application/json" })
+
+        expect(result).to(include(
+          "private_gem" => hash_including(latest_version: "2.0.0"),
+        ))
+      end
+    end
+
     context("when a progress block is given") do
       before do
         StillActive.config.gems = [

--- a/spec/still_active/workflow_spec.rb
+++ b/spec/still_active/workflow_spec.rb
@@ -242,6 +242,7 @@ RSpec.describe(StillActive::Workflow) do
 
       it("fetches versions from the Artifactory versions API with Bearer auth") do
         StillActive.config.artifactory_token = "art-test-token"
+        StillActive.config.artifactory_host  = "my-org.jfrog.io"
         stub_request(:get, versions_api_url)
           .to_return(status: 200, body: artifactory_versions.to_json, headers: { "Content-Type" => "application/json" })
 
@@ -271,6 +272,7 @@ RSpec.describe(StillActive::Workflow) do
 
       it("falls back to AQL when the versions API returns 404") do
         StillActive.config.artifactory_token = "art-test-token"
+        StillActive.config.artifactory_host  = "my-org.jfrog.io"
         stub_request(:get, versions_api_url).to_return(status: 404)
         aql_body = {
           "results" => [

--- a/still_active.gemspec
+++ b/still_active.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
     "(last commit dates via GitHub and GitLab, release dates), outdated versions, archived repos, " \
     "OpenSSF Scorecard security scores, known vulnerabilities via deps.dev, and libyear drift. " \
     "Ruby version freshness with EOL detection. " \
-    "Handles rubygems, git, path, and GitHub Packages sources. " \
+    "Handles rubygems, git, path, GitHub Packages, and SaaS JFrog / Artifactory sources. " \
     "Outputs coloured terminal tables, markdown, or JSON. " \
     "CI quality gates with --fail-if-critical, --fail-if-warning, --fail-if-vulnerable, --fail-if-outdated, and --ignore. " \
     "A comprehensive alternative to running bundle outdated, bundler-audit, and libyear-bundler separately."


### PR DESCRIPTION
This change supports SaaS JFrog / Artifactory as detected by the gem source URI. It attempts to use the standard versions api, but will fall back to [AQL](https://docs.jfrog.com/artifactory/docs/artifactory-query-language) if that doesn't seem to work.

I was able to successfully test this on a JFrog Artifactory source.

Running `still_active` before these changes against a private artifactory was:

```
private-git_hub_token                  1.1.0            ok        -        0      -                                                                    
private-sidekiq_utils                  4.1.0.pre.rc1    ok        -        0      -  
```

After this change
```
private-git_hub_token                  1.1.0 (latest)         ok        -        0      - 
private-sidekiq_utils                  4.1.0.pre.rc1 → 4.1.0  ok        -        0      -   
```

I generated the lion's share of this PR with Cursor, but have also read/reviewed/iterated on it also. A couple things that stood out to me:
* I do think there's an opportunity to reduce boilerplate in `HttpHelper.get_json` and `post_json`, 
* `workflow.rb` contains github packages version fetching, but I extracted artifactory's out into `ArtifactoryClient`.. that was a deviation, but felt in the right spirit to separate the 3rd party integration, and had a similar feel to the gitlab_client in my mind. I'm not sure that there's a well-established pattern about that.

I didn't want to go ham on refactoring yet in the interests of making this PR clear and targeted (not changing too much).

This was based loosely on my work on [this libyear-bundler fork](https://github.com/stitchfix/libyear-bundler/) where I also was adding Artifactory support to libyear. I did go ham on refactors in that one 😅 

ANYWAY, I hope you consider these changes. Cheers
