### PR TITLE
ci: least-privilege permissions on rspec and rubocop workflows

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: '0 0 1 * *'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/rubocop-analysis.yml
+++ b/.github/workflows/rubocop-analysis.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 0 1 * *'
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   rubocop:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds least-privilege `permissions:` blocks to the two workflows that were inheriting the repo default token scope:

- `rspec.yml`: `contents: read`.
- `rubocop-analysis.yml`: `contents: read` plus `security-events: write` (it uploads a SARIF).

Came out of a wider workflow audit (#34). The rest of the pipeline already looked solid: OIDC trusted publishing, no `pull_request_target`, fork-PR comment step gated to same-repo. SHA-pinning the publish actions was considered and declined; see #34 for the reasoning.

No behaviour change. Closes #34.
