### PR TITLE
fix(markdown): escape untrusted metadata in PR-comment tables (#38)

### DIFF
--- a/lib/helpers/diff_markdown_helper.rb
+++ b/lib/helpers/diff_markdown_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "markdown_escape"
+
 module StillActive
   # Renders a StillActive::Diff::Result as PR-comment-friendly markdown.
   # Section taxonomy mirrors GitHub's dependency-review-action so reviewers
@@ -49,7 +51,7 @@ module StillActive
     def regressions_section(regressions)
       return "" if regressions.empty?
 
-      lines = regressions.map { |r| "- **#{r.kind}** `#{r.gem}` — #{r.detail}" }
+      lines = regressions.map { |r| "- **#{r.kind}** #{MarkdownEscape.code_span(r.gem)} — #{MarkdownEscape.inline(r.detail)}" }
       section("Regressions (CI-failable)", lines)
     end
 
@@ -63,7 +65,7 @@ module StillActive
     def removed_section(removed)
       return "" if removed.empty?
 
-      lines = removed.map { |r| "- `#{r.name}` (was #{(r.data || {})["version_used"] || "?"})" }
+      lines = removed.map { |r| "- #{MarkdownEscape.code_span(r.name)} (was #{MarkdownEscape.inline((r.data || {})["version_used"] || "?")})" }
       section("Removed", lines)
     end
 
@@ -88,9 +90,9 @@ module StillActive
       lines = []
       if ruby[:version_changed]
         eol_suffix = ruby[:newly_eol] ? " (now EOL)" : ""
-        lines << "- Ruby `#{ruby[:from]}` → `#{ruby[:to]}`#{eol_suffix}"
+        lines << "- Ruby #{MarkdownEscape.code_span(ruby[:from])} → #{MarkdownEscape.code_span(ruby[:to])}#{eol_suffix}"
       elsif ruby[:newly_eol]
-        lines << "- Ruby `#{ruby[:to]}` is now EOL"
+        lines << "- Ruby #{MarkdownEscape.code_span(ruby[:to])} is now EOL"
       end
       section("Ruby", lines)
     end
@@ -108,30 +110,31 @@ module StillActive
         (data["archived"] ? "archived" : nil),
         data["libyear"] && "#{data["libyear"]}y behind",
       ].compact
-      "`#{added.name}` (#{bits.join(", ")})"
+      "#{MarkdownEscape.code_span(added.name)} (#{MarkdownEscape.inline(bits.join(", "))})"
     end
 
     def format_bump(bump)
       label = BUMP_KIND_LABELS[bump.kind]
       suffix = label ? " (#{label})" : ""
-      "- `#{bump.name}` #{bump.before_version} → #{bump.after_version}#{suffix}"
+      "- #{MarkdownEscape.code_span(bump.name)} #{MarkdownEscape.inline(bump.before_version)} → #{MarkdownEscape.inline(bump.after_version)}#{suffix}"
     end
 
     def format_signal_change_lines(sc)
+      name = MarkdownEscape.code_span(sc.name)
       sc.changes.filter_map do |ch|
         case ch[:kind]
         when :archived
-          "- `#{sc.name}` — archived (false → true)"
+          "- #{name} — archived (false → true)"
         when :new_vulnerability
-          ids = Array(ch[:ids]).join(", ")
-          "- `#{sc.name}` — new vulnerability (#{ch[:from]} → #{ch[:to]}#{" — #{ids}" unless ids.empty?})"
+          ids = MarkdownEscape.inline(Array(ch[:ids]).join(", "))
+          "- #{name} — new vulnerability (#{MarkdownEscape.inline(ch[:from])} → #{MarkdownEscape.inline(ch[:to])}#{" — #{ids}" unless ids.empty?})"
         when :scorecard_dropped
           note = ch[:crossed_good] ? " (crossed 7.0)" : ""
-          "- `#{sc.name}` — scorecard #{ch[:from]} → #{ch[:to]}#{note}"
+          "- #{name} — scorecard #{MarkdownEscape.inline(ch[:from])} → #{MarkdownEscape.inline(ch[:to])}#{note}"
         when :version_yanked
-          "- `#{sc.name}` — version yanked from rubygems"
+          "- #{name} — version yanked from rubygems"
         when :libyear_worsened
-          "- `#{sc.name}` — libyear #{ch[:from]} → #{ch[:to]} (+#{ch[:delta]}y; same pinned version)"
+          "- #{name} — libyear #{MarkdownEscape.inline(ch[:from])} → #{MarkdownEscape.inline(ch[:to])} (+#{ch[:delta]}y; same pinned version)"
         end
       end
     end

--- a/lib/helpers/markdown_escape.rb
+++ b/lib/helpers/markdown_escape.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module StillActive
+  # Escaping for untrusted metadata (gem names, licences, versions, repo URLs,
+  # advisory ids) rendered into GitHub-Flavored Markdown. These values come
+  # from registry/repo metadata, a Gemfile/lockfile, a --baseline file, or
+  # --gems input, so they can contain markdown-structural characters. Centralised
+  # so the table renderer (MarkdownHelper) and the diff renderer
+  # (DiffMarkdownHelper) can't drift apart on what's safe.
+  module MarkdownEscape
+    extend self
+
+    # Table cell: a literal "|" or newline would forge columns or break the row.
+    # Backslash is escaped first so it can't escape a following delimiter.
+    def cell(text)
+      return text if text.nil?
+
+      text.to_s.gsub(/[\\|\r\n]/, "\\" => "\\\\", "|" => "\\|", "\r" => " ", "\n" => " ")
+    end
+
+    # Link text additionally must not contain "[" or "]", which could forge or
+    # truncate the link.
+    def link_text(text)
+      return text if text.nil?
+
+      cell(text).gsub(/[\[\]]/, "[" => "\\[", "]" => "\\]")
+    end
+
+    # Link destination: percent-encode the characters that would break out of a
+    # "(...)" destination or the table row. Lossless for legitimate http(s) URLs.
+    def url(value)
+      return value if value.nil?
+
+      value.to_s.gsub(/[|() \t\r\n]/, "|" => "%7C", "(" => "%28", ")" => "%29", " " => "%20", "\t" => "%09", "\r" => "%0D", "\n" => "%0A")
+    end
+
+    # Inline (non-table) free text in a bullet list: neutralise newlines (which
+    # would break the list) and brackets/backslash (which could forge a link).
+    def inline(text)
+      return text if text.nil?
+
+      text.to_s.gsub(/[\\\[\]\r\n]/, "\\" => "\\\\", "[" => "\\[", "]" => "\\]", "\r" => " ", "\n" => " ")
+    end
+
+    # Wrap arbitrary text in an inline code span safely. A backtick in the text
+    # would otherwise close the span early, so use a backtick fence longer than
+    # the longest run in the content (and pad when it starts/ends with one), per
+    # the GFM code-span rules. Newlines collapse to spaces.
+    def code_span(text)
+      content = text.to_s.tr("\r\n", "  ")
+      return "`#{content}`" unless content.include?("`")
+
+      fence = "`" * (content.scan(/`+/).map(&:length).max + 1)
+      pad = content.start_with?("`") || content.end_with?("`") ? " " : ""
+      "#{fence}#{pad}#{content}#{pad}#{fence}"
+    end
+  end
+end

--- a/lib/helpers/markdown_helper.rb
+++ b/lib/helpers/markdown_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "markdown_escape"
 require_relative "vulnerability_helper"
 
 module StillActive
@@ -91,7 +92,7 @@ module StillActive
       return "" if flagged.empty?
 
       lines = ["", "**Alternatives** (Ruby Toolbox leads, verify fit):"]
-      flagged.each { |name, data| lines << "- `#{escape_cell(name)}`: #{escape_cell(data[:alternatives].join(", "))}" }
+      flagged.each { |name, data| lines << "- #{MarkdownEscape.code_span(name)}: #{MarkdownEscape.inline(data[:alternatives].join(", "))}" }
       lines.join("\n")
     end
 
@@ -128,7 +129,7 @@ module StillActive
     def format_license(license)
       return "-" if license.nil? || license.empty?
 
-      escape_cell(license)
+      MarkdownEscape.cell(license)
     end
 
     def format_vulns(data)
@@ -141,42 +142,15 @@ module StillActive
       ids = vulnerabilities.flat_map { |v| [v[:id], *v[:aliases]] }.compact.uniq.first(3)
 
       parts = [severity ? "#{count} (#{severity})" : count.to_s]
-      parts << escape_cell(ids.join(", ")) unless ids.empty?
+      parts << MarkdownEscape.cell(ids.join(", ")) unless ids.empty?
       parts.join(" ")
     end
 
     def markdown_url(text:, url:)
-      safe_text = escape_link_text(text)
+      safe_text = MarkdownEscape.link_text(text)
       return safe_text if url.nil?
 
-      "[#{safe_text}](#{escape_url(url)})"
-    end
-
-    # Untrusted gem names / licences / metadata land in GFM table cells. A
-    # literal "|" or newline would forge extra columns or break the row.
-    # Backslash is escaped first so it can't escape a following delimiter or a
-    # synthesized link bracket.
-    def escape_cell(text)
-      return text if text.nil?
-
-      text.to_s.gsub(/[\\|\r\n]/, "\\" => "\\\\", "|" => "\\|", "\r" => " ", "\n" => " ")
-    end
-
-    # Markdown link text additionally must not contain "[" or "]", which could
-    # forge or truncate the link.
-    def escape_link_text(text)
-      return text if text.nil?
-
-      escape_cell(text).gsub(/[\[\]]/, "[" => "\\[", "]" => "\\]")
-    end
-
-    # Percent-encode the few characters that would break out of a "(...)" link
-    # destination or the table row. Legitimate http(s) URLs never contain these
-    # literally, so encoding is lossless for real metadata.
-    def escape_url(url)
-      return url if url.nil?
-
-      url.to_s.gsub(/[|() \t\r\n]/, "|" => "%7C", "(" => "%28", ")" => "%29", " " => "%20", "\t" => "%09", "\r" => "%0D", "\n" => "%0A")
+      "[#{safe_text}](#{MarkdownEscape.url(url)})"
     end
 
     def year_month(time_object)

--- a/lib/helpers/markdown_helper.rb
+++ b/lib/helpers/markdown_helper.rb
@@ -91,7 +91,7 @@ module StillActive
       return "" if flagged.empty?
 
       lines = ["", "**Alternatives** (Ruby Toolbox leads, verify fit):"]
-      flagged.each { |name, data| lines << "- `#{name}`: #{data[:alternatives].join(", ")}" }
+      flagged.each { |name, data| lines << "- `#{escape_cell(name)}`: #{escape_cell(data[:alternatives].join(", "))}" }
       lines.join("\n")
     end
 
@@ -128,7 +128,7 @@ module StillActive
     def format_license(license)
       return "-" if license.nil? || license.empty?
 
-      license
+      escape_cell(license)
     end
 
     def format_vulns(data)
@@ -141,14 +141,42 @@ module StillActive
       ids = vulnerabilities.flat_map { |v| [v[:id], *v[:aliases]] }.compact.uniq.first(3)
 
       parts = [severity ? "#{count} (#{severity})" : count.to_s]
-      parts << ids.join(", ") unless ids.empty?
+      parts << escape_cell(ids.join(", ")) unless ids.empty?
       parts.join(" ")
     end
 
     def markdown_url(text:, url:)
-      return text if url.nil?
+      safe_text = escape_link_text(text)
+      return safe_text if url.nil?
 
-      "[#{text}](#{url})"
+      "[#{safe_text}](#{escape_url(url)})"
+    end
+
+    # Untrusted gem names / licences / metadata land in GFM table cells. A
+    # literal "|" or newline would forge extra columns or break the row.
+    # Backslash is escaped first so it can't escape a following delimiter or a
+    # synthesized link bracket.
+    def escape_cell(text)
+      return text if text.nil?
+
+      text.to_s.gsub(/[\\|\r\n]/, "\\" => "\\\\", "|" => "\\|", "\r" => " ", "\n" => " ")
+    end
+
+    # Markdown link text additionally must not contain "[" or "]", which could
+    # forge or truncate the link.
+    def escape_link_text(text)
+      return text if text.nil?
+
+      escape_cell(text).gsub(/[\[\]]/, "[" => "\\[", "]" => "\\]")
+    end
+
+    # Percent-encode the few characters that would break out of a "(...)" link
+    # destination or the table row. Legitimate http(s) URLs never contain these
+    # literally, so encoding is lossless for real metadata.
+    def escape_url(url)
+      return url if url.nil?
+
+      url.to_s.gsub(/[|() \t\r\n]/, "|" => "%7C", "(" => "%28", ")" => "%29", " " => "%20", "\t" => "%09", "\r" => "%0D", "\n" => "%0A")
     end
 
     def year_month(time_object)

--- a/spec/still_active/diff_markdown_helper_spec.rb
+++ b/spec/still_active/diff_markdown_helper_spec.rb
@@ -157,5 +157,32 @@ RSpec.describe(StillActive::DiffMarkdownHelper) do
         expect(md).not_to(include("### Ruby"))
       end
     end
+
+    context("with hostile gem names (from a crafted lockfile or --baseline file)") do
+      it("fences a backtick in a regression gem name so the code span can't break out") do
+        result = StillActive::Diff::Result.new(
+          added: [],
+          removed: [],
+          bumped: [],
+          signal_changes: [],
+          ruby: nil,
+          regressions: [StillActive::Diff::Regression.new(kind: :archived, gem: "ev`il", detail: "x")],
+        )
+        # longest backtick run is 1, so a 2-backtick fence keeps the name intact
+        expect(described_class.render(result)).to(include("``ev`il``"))
+      end
+
+      it("neutralises a newline in an added gem name so the bullet list can't be forged") do
+        result = StillActive::Diff::Result.new(
+          added: [StillActive::Diff::Added.new(name: "foo\n- INJECTED", data: { "version_used" => "1.0" })],
+          removed: [],
+          bumped: [],
+          signal_changes: [],
+          regressions: [],
+          ruby: nil,
+        )
+        expect(described_class.render(result)).not_to(include("foo\n- INJECTED"))
+      end
+    end
   end
 end

--- a/spec/still_active/markdown_escape_spec.rb
+++ b/spec/still_active/markdown_escape_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/helpers/markdown_escape"
+
+RSpec.describe(StillActive::MarkdownEscape) do
+  describe(".cell") do
+    it("escapes pipes, backslashes, and newlines") do
+      expect(described_class.cell("a|b")).to(eq("a\\|b"))
+      expect(described_class.cell("a\\b")).to(eq("a\\\\b"))
+      expect(described_class.cell("a\nb")).to(eq("a b"))
+    end
+
+    it("escapes the backslash before the pipe it precedes") do
+      expect(described_class.cell("a\\|b")).to(eq("a\\\\\\|b"))
+    end
+
+    it("passes nil through") do
+      expect(described_class.cell(nil)).to(be_nil)
+    end
+  end
+
+  describe(".link_text") do
+    it("escapes brackets in addition to cell characters") do
+      expect(described_class.link_text("[x]")).to(eq("\\[x\\]"))
+    end
+  end
+
+  describe(".url") do
+    it("percent-encodes characters that would break the destination or row") do
+      expect(described_class.url("https://h/a b|c(d)")).to(eq("https://h/a%20b%7Cc%28d%29"))
+    end
+
+    it("leaves a normal http(s) URL untouched") do
+      expect(described_class.url("https://github.com/rails/rails")).to(eq("https://github.com/rails/rails"))
+    end
+  end
+
+  describe(".inline") do
+    it("neutralises newlines and brackets but leaves pipes (not a table)") do
+      expect(described_class.inline("a\n- x [y]")).to(eq("a - x \\[y\\]"))
+      expect(described_class.inline("a|b")).to(eq("a|b"))
+    end
+  end
+
+  describe(".code_span") do
+    it("wraps plain text in single backticks") do
+      expect(described_class.code_span("rails")).to(eq("`rails`"))
+    end
+
+    it("uses a longer fence than the longest internal backtick run") do
+      expect(described_class.code_span("a`b")).to(eq("``a`b``"))
+      expect(described_class.code_span("a``b")).to(eq("```a``b```"))
+    end
+
+    it("pads when the content starts or ends with a backtick") do
+      expect(described_class.code_span("`x")).to(eq("`` `x ``"))
+    end
+
+    it("collapses newlines so the span stays on one line") do
+      expect(described_class.code_span("a\nb")).to(eq("`a b`"))
+    end
+  end
+end

--- a/spec/still_active/markdown_helper_spec.rb
+++ b/spec/still_active/markdown_helper_spec.rb
@@ -224,6 +224,71 @@ RSpec.describe(StillActive::MarkdownHelper) do
     end
   end
 
+  describe(".markdown_table_body_line with hostile metadata") do
+    # Gem names, licences, and repo URLs come from untrusted registry/repo
+    # metadata and are rendered into PR comments. A literal "|" must not add
+    # table columns, and "[]" in a name must not forge a markdown link.
+    def body_line(gem_name:, data:)
+      described_class.markdown_table_body_line(gem_name: gem_name, data: data)
+    end
+
+    # A valid 11-column row has exactly 12 unescaped pipe delimiters.
+    def delimiter_count(line)
+      line.scan(/(?<!\\)\|/).length
+    end
+
+    let(:base_data) do
+      {
+        last_activity_warning_emoji: "",
+        up_to_date_emoji: "✅",
+        version_used: "1.0.0",
+        latest_version: "1.0.0",
+        repository_url: "https://github.com/ex/gem",
+        ruby_gems_url: "https://rubygems.org/gems/gem",
+        vulnerability_count: 0,
+        license: "MIT",
+      }
+    end
+
+    it("escapes a pipe in the gem name so the column count is preserved") do
+      line = body_line(gem_name: "evil|name", data: base_data)
+      expect(delimiter_count(line)).to(eq(12))
+    end
+
+    it("escapes a pipe in the licence so the column count is preserved") do
+      line = body_line(gem_name: "gem", data: base_data.merge(license: "MIT | --:|--: | EVIL"))
+      expect(delimiter_count(line)).to(eq(12))
+    end
+
+    it("escapes a pipe in the repository URL so the column count is preserved") do
+      line = body_line(gem_name: "gem", data: base_data.merge(repository_url: "https://evil.test/a|b"))
+      expect(delimiter_count(line)).to(eq(12))
+    end
+
+    it("escapes brackets in the gem name so no nested markdown link is forged") do
+      line = body_line(gem_name: "[click](javascript:alert(1))", data: base_data)
+      expect(line).not_to(include("[click](javascript:alert(1))"))
+    end
+
+    it("escapes a backslash in the gem name so it can't escape the closing bracket") do
+      line = body_line(gem_name: "trail\\", data: base_data)
+      expect(line).to(include("[trail\\\\](https://github.com/ex/gem)"))
+    end
+
+    it("escapes a pipe in a vulnerability id so the column count is preserved") do
+      data = base_data.merge(
+        vulnerability_count: 1,
+        vulnerabilities: [{ id: "GHSA-a|b", aliases: [], cvss3_score: 5.0 }],
+      )
+      expect(delimiter_count(body_line(gem_name: "gem", data: data))).to(eq(12))
+    end
+
+    it("still renders a normal gem name as a clean markdown link") do
+      line = body_line(gem_name: "rails", data: base_data.merge(repository_url: "https://github.com/rails/rails"))
+      expect(line).to(include("[rails](https://github.com/rails/rails)"))
+    end
+  end
+
   describe(".alternatives_section") do
     it("lists alternatives for flagged gems") do
       result = { "paperclip" => { source_type: :rubygems, archived: true, alternatives: ["shrine", "carrierwave"] } }
@@ -240,6 +305,13 @@ RSpec.describe(StillActive::MarkdownHelper) do
     it("is empty when the alternatives array is empty") do
       result = { "paperclip" => { source_type: :rubygems, archived: true, alternatives: [] } }
       expect(described_class.alternatives_section(result)).to(eq(""))
+    end
+
+    it("neutralises a newline in an alternative so the list can't be broken") do
+      result = { "paperclip" => { source_type: :rubygems, archived: true, alternatives: ["shrine\ninjected"] } }
+      out = described_class.alternatives_section(result)
+      expect(out).not_to(include("shrine\ninjected"))
+      expect(out).to(include("shrine injected"))
     end
   end
 


### PR DESCRIPTION
Closes #38.

## What

Escape untrusted metadata before it's rendered into GitHub-Flavored-Markdown PR comments — in **both** markdown sinks #38 named: the audit table (`MarkdownHelper`) and the PR diff (`DiffMarkdownHelper`).

## Why

Gem names, licences, repository URLs, versions, and advisory ids all come from registry/repo metadata — or, for names/versions, from a `Gemfile`/lockfile, a `--baseline` JSON file, or `--gems` input — and were interpolated into markdown with no escaping. So a hostile value could:

- forge extra **table columns** with a literal `|` (free-form licence or gem name),
- forge or break a **markdown link** with `[ ]`, or escape the closing `]` with a trailing `\`,
- break a **code span** in the diff with a backtick, or
- forge a **list item / heading** in the diff with a newline.

These render in PR comments, so the corruption lands in front of a reviewer.

## How

A shared `StillActive::MarkdownEscape` module so the two renderers can't drift on what's safe:

- `cell` — escapes `\`, `|`, newlines (table/row integrity). Backslash first so it can't escape a following delimiter.
- `link_text` — also escapes `[` `]`.
- `url` — percent-encodes `|`, `(`, `)`, whitespace; lossless for real http(s) URLs.
- `inline` — for bullet-list free text: neutralises newlines (list/heading injection) and brackets/backslash (link forging); leaves `|` (not a table).
- `code_span` — wraps arbitrary text in an inline code span using a backtick **fence longer than the longest internal run** (per GFM), padding when the content starts/ends with a backtick.

`MarkdownHelper` delegates to it (behaviour-identical for the table/link path); `DiffMarkdownHelper` now routes every untrusted value — gem names and ruby versions via `code_span`, versions/ids/detail via `inline` — through it. Only trusted internal values (enum kinds, hardcoded labels) stay raw.

## Tests

24 new specs across `markdown_escape_spec` (incl. the backtick-fence edge cases), `markdown_helper_spec`, and `diff_markdown_helper_spec`. Full suite **474 examples, 0 failures**; rubocop clean. Reviewed by the code-reviewer agent twice — the first pass caught the trailing-backslash vector (now tested), the second verified `code_span`/`inline` against the libcmark-gfm reference parser and found no breakout.

The `nil`-passthrough in `cell` is intentional: `link_text` → `markdown_url` relies on it so `version_with_date` still skips a missing version.

No file overlap with #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
