### PR TITLE
fix(deps.dev): keep full GitLab subgroup path in scorecard project id (#44)

### DIFF
--- a/lib/still_active/deps_dev_client.rb
+++ b/lib/still_active/deps_dev_client.rb
@@ -58,15 +58,36 @@ module StillActive
 
     private
 
-    # Extracts "host/owner/repo" from the SOURCE_REPO link URL.
-    # URLs may have trailing slashes or extra path segments (e.g. /tree/v1.0).
+    # Builds a deps.dev project id ("host/owner/repo", or a deeper path for
+    # GitLab subgroups) from the SOURCE_REPO link URL. GitHub/Bitbucket projects
+    # are always host/owner/repo, but GitLab namespaces nest arbitrarily
+    # (host/group/subgroup/.../project), so we can't just keep three segments.
     def extract_project_id(body)
       url = body.dig("links")&.find { |l| l["label"] == "SOURCE_REPO" }&.dig("url")
       return if url.nil?
 
-      path = url.delete_prefix("https://").delete_prefix("http://")
-      segments = path.split("/")
-      segments[0..2].join("/") if segments.length >= 3
+      host, *segments = url.sub(%r{\Ahttps?://}, "").split("/")
+      segments = repo_path_segments(host, segments)
+      return if host.nil? || segments.empty?
+
+      [host, *segments].join("/")
+    end
+
+    # Trims a repo URL's path to just the project. On GitLab the project path
+    # ends at the "/-/" separator (before tree/blob/etc) and may be nested;
+    # elsewhere it's owner/repo. Drops trailing slashes and a ".git" suffix.
+    def repo_path_segments(host, segments)
+      segments = segments.reject(&:empty?)
+
+      if host.to_s.start_with?("gitlab.")
+        separator = segments.index("-")
+        segments = segments[0...separator] if separator
+      else
+        segments = segments.first(2)
+      end
+
+      segments[-1] = segments[-1].delete_suffix(".git") unless segments.empty?
+      segments
     end
 
     def encode(value)

--- a/spec/still_active/deps_dev_client_spec.rb
+++ b/spec/still_active/deps_dev_client_spec.rb
@@ -108,4 +108,43 @@ RSpec.describe(StillActive::DepsDevClient) do
       expect(described_class.project_scorecard(project_id: "github.com/sparklemotion/nokogiri")).to(be_nil)
     end
   end
+
+  describe("#extract_project_id (SOURCE_REPO URL parsing)") do
+    def project_id(url)
+      described_class.send(:extract_project_id, { "links" => [{ "label" => "SOURCE_REPO", "url" => url }] })
+    end
+
+    it("keeps the full path for a GitLab subgroup project") do
+      expect(project_id("https://gitlab.com/group/subgroup/project")).to(eq("gitlab.com/group/subgroup/project"))
+    end
+
+    it("keeps deeply nested GitLab subgroups") do
+      expect(project_id("https://gitlab.com/a/b/c/project")).to(eq("gitlab.com/a/b/c/project"))
+    end
+
+    it("strips GitLab's /-/ tree suffix but keeps the subgroup path") do
+      expect(project_id("https://gitlab.com/group/sub/project/-/tree/main")).to(eq("gitlab.com/group/sub/project"))
+    end
+
+    it("keeps a plain two-level GitLab project") do
+      expect(project_id("https://gitlab.com/owner/project")).to(eq("gitlab.com/owner/project"))
+    end
+
+    it("keeps owner/repo for GitHub") do
+      expect(project_id("https://github.com/rails/rails")).to(eq("github.com/rails/rails"))
+    end
+
+    it("strips GitHub tree/blob extras") do
+      expect(project_id("https://github.com/rails/rails/tree/v7.1.0")).to(eq("github.com/rails/rails"))
+    end
+
+    it("strips a trailing slash and .git suffix") do
+      expect(project_id("https://github.com/rails/rails/")).to(eq("github.com/rails/rails"))
+      expect(project_id("https://github.com/rails/rails.git")).to(eq("github.com/rails/rails"))
+    end
+
+    it("returns nil when there is no SOURCE_REPO link") do
+      expect(described_class.send(:extract_project_id, { "links" => [] })).to(be_nil)
+    end
+  end
 end


### PR DESCRIPTION
Closes #44.

## What

Fix `DepsDevClient#extract_project_id` so GitLab **subgroup** projects produce the correct deps.dev project id (and therefore the correct OpenSSF Scorecard lookup).

## Why

The old code kept the first three URL path segments:

```ruby
segments[0..2].join("/")
```

That assumes every repo is `host/owner/repo`. GitLab namespaces nest, so `gitlab.com/group/subgroup/project` was truncated to `gitlab.com/group/subgroup` — pointing the scorecard query at the **subgroup**, not the project. Any subgrouped GitLab gem got a wrong or missing OpenSSF score, silently.

## How

Keep the full GitLab namespace and only `owner/repo` elsewhere:

- GitLab hosts: keep every path segment up to GitLab's `/-/` separator (which precedes `tree`/`blob`/etc.), so nested subgroups survive.
- GitHub / Bitbucket / others: `owner/repo` (first two segments), dropping `/tree/…` extras.
- Both: drop a trailing slash and a `.git` suffix.

## Verification

The deps.dev project-key format was confirmed against the **live API**, not assumed: `GET /v3alpha/projects/gitlab.com%2Fgitlab-org%2Fsecurity-products%2Fgemnasium-db` (a real 3-level subgroup project) returns 200 — deps.dev does key subgroup projects by their full path.

8 new unit specs (gitlab subgroup / deeply nested / `/-/` tree suffix / two-level; github owner-repo / tree extras / trailing-slash / `.git`; no-SOURCE_REPO → nil). GitHub behaviour is unchanged. Full suite **482 examples, 0 failures**; rubocop clean. Reviewed by the code-reviewer agent (verified against the live deps.dev API; no defects).

No file overlap with #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
