### PR TITLE
fix(cyclonedx): give every component a purl so the SBOM is SCA-ingestible (#45)

### DIFF
--- a/lib/helpers/cyclonedx_helper.rb
+++ b/lib/helpers/cyclonedx_helper.rb
@@ -55,7 +55,7 @@ module StillActive
       component = { "type" => "library", "name" => name }
       component["version"] = version if version
       component["bom-ref"] = bom_ref(name, data)
-      component["purl"] = purl(name, version) if data[:source_type] == :rubygems && version
+      component["purl"] = purl(name, version, data[:source_type]) if version
       component["licenses"] = licenses(data[:license]) if data[:license]
       if data[:repository_url]
         component["externalReferences"] = [{ "type" => "vcs", "url" => data[:repository_url] }]
@@ -67,13 +67,19 @@ module StillActive
 
     def bom_ref(name, data)
       version = data[:version_used]
-      return purl(name, version) if data[:source_type] == :rubygems && version
+      return purl(name, version, data[:source_type]) if version
 
-      "#{data[:source_type]}-source:#{name}@#{version || "unknown"}"
+      "#{data[:source_type]}-source:#{name}@unknown"
     end
 
-    def purl(name, version)
-      "pkg:gem/#{name}@#{version}"
+    # Datadog SCA (and strict CycloneDX consumers) hard-reject a versioned
+    # library component with no purl, so every gem with a version needs one.
+    # A path gem is local and not on rubygems, so it gets pkg:generic to avoid
+    # false-matching a public gem of the same name; git/rubygems-sourced gems
+    # get pkg:gem so a fork still matches the upstream gem's advisories.
+    def purl(name, version, source_type)
+      type = source_type == :path ? "generic" : "gem"
+      "pkg:#{type}/#{name}@#{version}"
     end
 
     # VersionHelper joins multiple SPDX ids with ", " for terminal/markdown
@@ -93,12 +99,22 @@ module StillActive
       }.filter_map { |name, value| { "name" => name, "value" => value } unless value.nil? }
     end
 
+    # The Ruby interpreter. CycloneDX's "platform" type fits semantically, but
+    # nothing consumes it and strict SCA validators (Datadog) only accept
+    # "library" + a purl. We follow Syft's convention for an unmanaged runtime:
+    # type "library", purl pkg:generic/ruby@<ver>, plus a CPE — the CPE is what
+    # actually lets a matcher (NVD/Grype) hit interpreter CVEs, since no purl
+    # type maps the Ruby runtime in OSV. The EOL/libyear signals stay as
+    # still_active properties.
     def ruby_component(ruby_info)
+      version = ruby_info[:version]
       {
-        "type" => "platform",
+        "type" => "library",
         "name" => "ruby",
-        "version" => ruby_info[:version],
-        "bom-ref" => "platform:ruby@#{ruby_info[:version]}",
+        "version" => version,
+        "bom-ref" => "pkg:generic/ruby@#{version}",
+        "purl" => "pkg:generic/ruby@#{version}",
+        "cpe" => "cpe:2.3:a:ruby-lang:ruby:#{version}:*:*:*:*:*:*:*",
         "properties" => [
           { "name" => "still_active:eol", "value" => boolean_property(ruby_info[:eol]) },
           { "name" => "still_active:libyear", "value" => ruby_info[:libyear]&.to_s },

--- a/spec/still_active/cyclonedx_helper_spec.rb
+++ b/spec/still_active/cyclonedx_helper_spec.rb
@@ -99,16 +99,37 @@ RSpec.describe(StillActive::CyclonedxHelper) do
       ))
     end
 
-    it("omits the purl for a path-sourced gem but still gives it a bom-ref") do
+    it("gives a path-sourced gem a pkg:generic purl (avoids false rubygems vuln matches)") do
       local = components.find { |c| c["name"] == "local_gem" }
-      expect(local).not_to(have_key("purl"))
-      expect(local["bom-ref"]).not_to(be_empty)
+      expect(local["purl"]).to(eq("pkg:generic/local_gem@0.1.0"))
+      expect(local["bom-ref"]).to(eq("pkg:generic/local_gem@0.1.0"))
     end
 
-    it("includes Ruby as a platform component") do
+    it("gives a git-sourced gem a pkg:gem purl (matches upstream advisories for forks)") do
+      result["forked"] = { source_type: :git, version_used: "1.2.3" }
+      forked = components.find { |c| c["name"] == "forked" }
+      expect(forked["purl"]).to(eq("pkg:gem/forked@1.2.3"))
+      expect(forked["bom-ref"]).to(eq("pkg:gem/forked@1.2.3"))
+    end
+
+    it("gives every versioned component a purl (CycloneDX/SCA ingestion requirement)") do
+      versioned = components.select { |c| c["version"] }
+      expect(versioned).not_to(be_empty)
+      expect(versioned).to(all(have_key("purl")))
+    end
+
+    it("emits Ruby as a library with a pkg:generic purl and CPE (portable + ingestible)") do
       ruby = components.find { |c| c["name"] == "ruby" }
-      expect(ruby["type"]).to(eq("platform"))
+      expect(ruby["type"]).to(eq("library"))
       expect(ruby["version"]).to(eq("3.4.0"))
+      expect(ruby["purl"]).to(eq("pkg:generic/ruby@3.4.0"))
+      expect(ruby["cpe"]).to(eq("cpe:2.3:a:ruby-lang:ruby:3.4.0:*:*:*:*:*:*:*"))
+    end
+
+    it("keeps the Ruby EOL/libyear maintenance signals as properties") do
+      ruby = components.find { |c| c["name"] == "ruby" }
+      props = ruby["properties"].to_h { |p| [p["name"], p["value"]] }
+      expect(props).to(include("still_active:eol" => "false", "still_active:libyear" => "0.0"))
     end
   end
 


### PR DESCRIPTION
Closes #45.

## What

Make the CycloneDX SBOM ingestible by Datadog SCA (and friendlier to Trivy / Dependency-Track / Snyk): every component now carries a `purl`, and the Ruby runtime is a `type: library` component with a purl + CPE.

## Why (the part worth keeping)

The original assumption — "Datadog rejects the SBOM because Ruby is `type: platform`" — was **wrong**. Reading Datadog's actual client ([`datadog-ci` `plugin-sbom/src/validation.ts`](https://github.com/DataDog/datadog-ci/blob/master/packages/plugin-sbom/src/validation.ts)) shows it only hard-rejects a component with **no `type`**, or a **versioned `type: library` with no `purl`**. `platform` components are tolerated and silently dropped.

So the real blocker was our **git/path gems**: `type: library`, versioned, **no purl**. (Verified by rendering an SBOM and checking the rule directly — git/path gems hit it, the Ruby `platform` component did not.)

## How

- **Purl for every versioned gem**, not just rubygems:
  - path → `pkg:generic/<name>@<ver>` (local gem; avoids false-matching a public gem of the same name)
  - git / rubygems → `pkg:gem/<name>@<ver>` (a fork still matches the upstream gem's advisories)
  - `bom-ref` tracks the purl for consistency (vuln `affects[].ref` and the deterministic serial stay aligned).
- **Ruby runtime → `type: library` + `pkg:generic/ruby@<ver>` + `cpe:2.3:a:ruby-lang:ruby:<ver>:*`** (was `type: platform`). EOL/libyear stay as `still_active:*` properties.

### Prior art for the Ruby runtime
CycloneDX's `platform` type is *semantically* correct for a runtime, but no official example uses it and downstream tools ignore it. [Syft](https://github.com/anchore/syft/blob/main/syft/pkg/cataloger/binary/classifiers.go) — the dominant SBOM generator — represents an unmanaged runtime as exactly `pkg:generic/ruby` + `cpe:…:ruby-lang:ruby`, so we follow that rather than invent convention. There's no purl type that maps the Ruby interpreter in OSV (a runtime purl matches **zero** CVEs there), so the **CPE** is the part that can actually match interpreter CVEs via NVD/Grype. `library` (over Syft's `application`) is CycloneDX's recommended default and what strict validators accept.

## Verification

Rendered an SBOM with rubygems + git + path gems and the Ruby runtime: every component is `type: library` with a valid purl, and the set of Datadog-rejecting components is **empty**.

5 spec changes/additions (path → `pkg:generic`, git → `pkg:gem`, the "every versioned component has a purl" invariant, Ruby library+purl+CPE, EOL/libyear properties retained). Full suite **485 examples, 0 failures**; rubocop clean. Reviewed by the code-reviewer agent — CPE confirmed well-formed against NVD's `ruby-lang:ruby`, bom-ref/affects/serial consistent, no regressions.

No file overlap with #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
