### PR TITLE
fix(github-packages): escape gem name in version-lookup path

### DIFF
--- a/lib/still_active/workflow.rb
+++ b/lib/still_active/workflow.rb
@@ -15,6 +15,7 @@ require_relative "../helpers/vulnerability_helper"
 require "async"
 require "async/barrier"
 require "async/semaphore"
+require "cgi"
 require "gems"
 
 module StillActive
@@ -207,7 +208,7 @@ module StillActive
     def fetch_github_packages_versions(gem_name:, source_uri:)
       base = URI(source_uri.chomp("/"))
       namespace_path = base.path
-      path = "#{namespace_path}/api/v1/gems/#{gem_name}/versions.json"
+      path = "#{namespace_path}/api/v1/gems/#{CGI.escape(gem_name)}/versions.json"
       token = StillActive.config.github_oauth_token
       headers = token ? { "Authorization" => "Bearer #{token}" } : {}
       HttpHelper.get_json(base, path, headers: headers) || []

--- a/spec/still_active/workflow_spec.rb
+++ b/spec/still_active/workflow_spec.rb
@@ -214,6 +214,45 @@ RSpec.describe(StillActive::Workflow) do
           "private_gem" => hash_including(latest_version: "1.0.0"),
         ))
       end
+
+      # A `/` in the (lockfile-controlled) gem name does NOT raise; unescaped it
+      # silently redirects the lookup to an attacker-chosen path on the trusted
+      # host. Assert the literal path string, because WebMock normalizes `%2F`
+      # back to `/` and so can't tell the escaped request from the injected one.
+      it("escapes path separators so a crafted gem name can't redirect the request to another path") do
+        StillActive.config.gems = [{
+          name: "evil/../secrets",
+          version: "1.0.0",
+          source_type: :rubygems,
+          source_uri: "https://rubygems.pkg.github.com/my-org",
+        }]
+        allow(Gems).to(receive(:info).with("evil/../secrets").and_return({ "homepage_uri" => nil, "source_code_uri" => nil }))
+        requested_path = nil
+        allow(StillActive::HttpHelper).to(receive(:get_json)) do |_base, path, **_kwargs|
+          requested_path = path
+          ghp_versions
+        end
+
+        result
+
+        expect(requested_path).to(eq("/my-org/api/v1/gems/evil%2F..%2Fsecrets/versions.json"))
+      end
+
+      # A space raises URI::InvalidComponentError on `uri.path =`; the swallowing
+      # rescue in #call hides the crash, so the gem silently yields no versions.
+      it("escapes a gem name that would otherwise raise on an invalid URI path, instead of silently yielding nothing") do
+        StillActive.config.gems = [{
+          name: "bad name",
+          version: "1.0.0",
+          source_type: :rubygems,
+          source_uri: "https://rubygems.pkg.github.com/my-org",
+        }]
+        allow(Gems).to(receive(:info).with("bad name").and_return({ "homepage_uri" => nil, "source_code_uri" => nil }))
+        stub_request(:get, "https://rubygems.pkg.github.com/my-org/api/v1/gems/bad+name/versions.json")
+          .to_return(status: 200, body: ghp_versions.to_json, headers: { "Content-Type" => "application/json" })
+
+        expect(result).to(include("bad name" => hash_including(latest_version: "1.0.0")))
+      end
     end
 
     context("when a gem is from Artifactory") do


### PR DESCRIPTION
Closes #50. Surfaced during the #29 security review. **This is defensive hardening, not a fix for a practically-exploitable credential vuln — see the honest impact note below.**

## What

`fetch_github_packages_versions` interpolated the lockfile-derived gem name into the request path unescaped:

```ruby
path = "#{namespace_path}/api/v1/gems/#{gem_name}/versions.json"
```

The project treats lockfile input as untrusted, and the sibling Artifactory path (added in #29) already `CGI.escape`s the name via `RubygemsClient#encode`. This brings the GitHub Packages path to parity.

## Reachability and honest impact

Confirmed (PoC against `Bundler::LockfileParser`) that a lockfile gem name containing `/` or a space does survive parsing, so the input reaches this code. But the impact is modest:

- **Space / URL-invalid char:** raises `URI::InvalidComponentError` on `uri.path =`. `HttpHelper` only rescues timeout/socket/JSON, so it propagates to the broad `rescue StandardError` in `Workflow#call` and that gem silently yields no version data. For an audit tool that's an integrity gap (a gem could be named to evade the report), but it needs a hand-tampered lockfile since RubyGems/GitHub Packages reject such names at publish time.
- **`/`:** does not raise; it only changes the request *path* on the fixed `rubygems.pkg.github.com` host. `uri.path =` never changes the host, so the GitHub token is **not** exfiltrated anywhere. This is path-only SSRF on a trusted host — negligible on its own.

So the real value here is robustness + consistency with the untrusted-input stance, not stopping an attack.

## Fix

`CGI.escape(gem_name)`, mirroring `ArtifactoryClient::RubygemsClient#encode`, plus an explicit `require "cgi"`.

## Tests

Two regression tests, proven red-before / green-after:

- Path containment asserts the literal built path is `.../gems/evil%2F..%2Fsecrets/versions.json`, checked directly rather than via WebMock (WebMock normalizes `%2F`->`/` and so can't distinguish the escaped request from the raw one).
- The space case asserts the gem resolves `latest_version` instead of silently yielding nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
