### PR TITLE
fix(http-helper): handle missing and malformed redirect Location

### DIFF
--- a/lib/helpers/http_helper.rb
+++ b/lib/helpers/http_helper.rb
@@ -27,7 +27,13 @@ module StillActive
         response = http.request(request)
 
         if response.is_a?(Net::HTTPRedirection)
-          redirect_uri = uri + response["Location"]
+          location = response["Location"]
+          if location.nil? || location.empty?
+            $stderr.puts("warning: #{uri.host}#{uri.path} returned HTTP #{response.code} with no Location header")
+            return
+          end
+
+          redirect_uri = uri + location
           unless TRUSTED_HOSTS.include?(redirect_uri.host)
             $stderr.puts("warning: #{uri.host}#{uri.path} redirected to untrusted host #{redirect_uri.host}, skipping")
             return
@@ -53,6 +59,9 @@ module StillActive
       nil
     rescue JSON::ParserError => e
       $stderr.puts("warning: #{uri.host}#{uri.path} returned invalid JSON: #{e.message}")
+      nil
+    rescue URI::InvalidURIError => e
+      $stderr.puts("warning: #{uri.host}#{uri.path} returned an invalid redirect Location: #{e.message}")
       nil
     end
 
@@ -73,7 +82,13 @@ module StillActive
         response = http.request(request)
 
         if response.is_a?(Net::HTTPRedirection)
-          redirect_uri = uri + response["Location"]
+          location = response["Location"]
+          if location.nil? || location.empty?
+            $stderr.puts("warning: #{uri.host}#{uri.path} returned HTTP #{response.code} with no Location header")
+            return
+          end
+
+          redirect_uri = uri + location
           unless TRUSTED_HOSTS.include?(redirect_uri.host)
             $stderr.puts("warning: #{uri.host}#{uri.path} redirected to untrusted host #{redirect_uri.host}, skipping")
             return
@@ -99,6 +114,9 @@ module StillActive
       nil
     rescue JSON::ParserError => e
       $stderr.puts("warning: #{uri.host}#{uri.path} returned invalid JSON: #{e.message}")
+      nil
+    rescue URI::InvalidURIError => e
+      $stderr.puts("warning: #{uri.host}#{uri.path} returned an invalid redirect Location: #{e.message}")
       nil
     end
   end

--- a/spec/still_active/http_helper_spec.rb
+++ b/spec/still_active/http_helper_spec.rb
@@ -63,6 +63,25 @@ RSpec.describe(StillActive::HttpHelper) do
       # The loop runs MAX_REDIRECTS (3) times, so the fourth hop is never requested.
       expect(landing).not_to(have_been_requested)
     end
+
+    it("returns nil instead of raising when a 3xx response has no Location header") do
+      stub_request(:get, "https://api.deps.dev/x").to_return(status: 302)
+
+      result = nil
+      expect { result = described_class.get_json(URI("https://api.deps.dev"), "/x", headers: auth) }
+        .not_to(raise_error)
+      expect(result).to(be_nil)
+    end
+
+    it("returns nil instead of raising when a 3xx Location is malformed") do
+      stub_request(:get, "https://api.deps.dev/x")
+        .to_return(status: 302, headers: { "Location" => "http://[bad" })
+
+      result = nil
+      expect { result = described_class.get_json(URI("https://api.deps.dev"), "/x", headers: auth) }
+        .not_to(raise_error)
+      expect(result).to(be_nil)
+    end
   end
 
   # post_json carries the AQL fallback, so it must enforce the same boundary as
@@ -102,6 +121,37 @@ RSpec.describe(StillActive::HttpHelper) do
 
       expect(result).to(be_nil)
       expect(evil).not_to(have_been_requested)
+    end
+
+    it("returns nil instead of raising when a 3xx response has no Location header") do
+      stub_request(:post, "https://my-org.jfrog.io/api/search/aql").to_return(status: 302)
+
+      result = nil
+      expect do
+        result = described_class.post_json(
+          URI("https://my-org.jfrog.io"),
+          "/api/search/aql",
+          body: "items.find({})",
+          headers: auth,
+        )
+      end.not_to(raise_error)
+      expect(result).to(be_nil)
+    end
+
+    it("returns nil instead of raising when a 3xx Location is malformed") do
+      stub_request(:post, "https://my-org.jfrog.io/api/search/aql")
+        .to_return(status: 302, headers: { "Location" => "http://[bad" })
+
+      result = nil
+      expect do
+        result = described_class.post_json(
+          URI("https://my-org.jfrog.io"),
+          "/api/search/aql",
+          body: "items.find({})",
+          headers: auth,
+        )
+      end.not_to(raise_error)
+      expect(result).to(be_nil)
     end
   end
 end


### PR DESCRIPTION
Closes #39.

## Bug

`HttpHelper`'s redirect handling did `redirect_uri = uri + response["Location"]`. Two unrescued crashes:

- **Absent Location:** a 3xx with no `Location` header → `uri + nil` → `ArgumentError: bad argument (expected URI object or URI string)`.
- **Malformed Location:** a present-but-malformed value → `uri + location` → `URI::InvalidURIError`. This includes whitespace-only (`"  "`), which passes `empty?`. (Found in review, same root cause as the reported bug.)

Neither class is in the rescue lists (only Net/socket/JSON), so both propagate out of the per-gem lookup and get swallowed by `Workflow#call`'s broad `rescue StandardError`, silently dropping that gem from the audit. A gem-source redirect is lockfile-influenced, so a hostile/broken server response is reachable on untrusted input.

## Fix

Guard `nil`/empty `Location` and rescue `URI::InvalidURIError`, both returning `nil` with a warning — matching the existing non-success and untrusted-host handling. Applied symmetrically to `get_json` and `post_json`.

## Tests

Regression tests for both methods, each covering the absent and malformed cases. Verified red-before / green-after, and mutation-checked (removing the `URI::InvalidURIError` rescue fails the malformed tests).

Confirmed the exact exception classes with a PoC rather than assuming: `uri + nil` → `ArgumentError`; `uri + "http://[bad"` / `uri + "  "` → `URI::InvalidURIError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
