### PR TITLE
fix(http-helper): cap response body size to bound memory

### DIFF
--- a/lib/helpers/http_helper.rb
+++ b/lib/helpers/http_helper.rb
@@ -7,6 +7,13 @@ module StillActive
   module HttpHelper
     TRUSTED_HOSTS = ["github.com", "gitlab.com", "api.deps.dev", "endoflife.date", "rubygems.pkg.github.com"].freeze
     MAX_REDIRECTS = 3
+    # Ceiling on a single response body. These are metadata endpoints (version
+    # lists, scorecards, advisories); legitimate responses are well under this.
+    # A source URL is lockfile-derived and a `*.jfrog.io` host is attacker-
+    # registerable, so without a cap a hostile or broken source could stream a
+    # multi-GB body and OOM the process. 16 MiB leaves generous headroom for a
+    # gem with thousands of versions while bounding worst-case memory.
+    MAX_BODY_BYTES = 16 * 1024 * 1024
 
     extend self
 
@@ -15,21 +22,46 @@ module StillActive
       uri.path = path
       uri.query = URI.encode_www_form(params) unless params.empty?
 
+      request_json(uri, headers) { |target| Net::HTTP::Get.new(target) }
+    end
+
+    def post_json(base_uri, path, body:, headers: {})
+      uri = base_uri.dup
+      uri.path = path
+
+      request_json(uri, headers) do |target|
+        request = Net::HTTP::Post.new(target)
+        request.body = body
+        request
+      end
+    end
+
+    private
+
+    # Runs the request, following up to MAX_REDIRECTS trusted-host redirects,
+    # and returns the parsed JSON (or nil). The block is yielded each URI and
+    # returns the request object, so GET and POST share the redirect/auth/cap
+    # logic.
+    def request_json(uri, headers)
       MAX_REDIRECTS.times do
         http = Net::HTTP.new(uri.host, uri.port)
         http.use_ssl = true
         http.open_timeout = 10
         http.read_timeout = 10
 
-        request = Net::HTTP::Get.new(uri)
+        request = yield(uri)
         headers.each { |key, value| request[key] = value }
 
-        response = http.request(request)
-
-        if response.is_a?(Net::HTTPRedirection)
-          location = response["Location"]
+        outcome, payload = perform(http, request, uri)
+        case outcome
+        when :done
+          return payload
+        when :stop
+          return
+        when :redirect
+          location = payload["Location"]
           if location.nil? || location.empty?
-            $stderr.puts("warning: #{uri.host}#{uri.path} returned HTTP #{response.code} with no Location header")
+            $stderr.puts("warning: #{uri.host}#{uri.path} returned HTTP #{payload.code} with no Location header")
             return
           end
 
@@ -41,15 +73,7 @@ module StillActive
           $stderr.puts("warning: #{uri.host}#{uri.path} redirected to #{redirect_uri.host}#{redirect_uri.path} (stale metadata?)")
           headers = {} if redirect_uri.host != uri.host
           uri = redirect_uri
-          next
         end
-
-        unless response.is_a?(Net::HTTPSuccess)
-          $stderr.puts("warning: #{uri.host}#{uri.path} returned HTTP #{response.code}") unless response.is_a?(Net::HTTPNotFound)
-          return
-        end
-
-        return JSON.parse(response.body)
       end
 
       $stderr.puts("warning: #{uri.host}#{uri.path} too many redirects")
@@ -65,59 +89,42 @@ module StillActive
       nil
     end
 
-    def post_json(base_uri, path, body:, headers: {})
-      uri = base_uri.dup
-      uri.path = path
-
-      MAX_REDIRECTS.times do
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = true
-        http.open_timeout = 10
-        http.read_timeout = 10
-
-        request = Net::HTTP::Post.new(uri)
-        headers.each { |key, value| request[key] = value }
-        request.body = body
-
-        response = http.request(request)
-
-        if response.is_a?(Net::HTTPRedirection)
-          location = response["Location"]
-          if location.nil? || location.empty?
-            $stderr.puts("warning: #{uri.host}#{uri.path} returned HTTP #{response.code} with no Location header")
-            return
-          end
-
-          redirect_uri = uri + location
-          unless TRUSTED_HOSTS.include?(redirect_uri.host)
-            $stderr.puts("warning: #{uri.host}#{uri.path} redirected to untrusted host #{redirect_uri.host}, skipping")
-            return
-          end
-          $stderr.puts("warning: #{uri.host}#{uri.path} redirected to #{redirect_uri.host}#{redirect_uri.path} (stale metadata?)")
-          headers = {} if redirect_uri.host != uri.host
-          uri = redirect_uri
-          next
-        end
+    # Issues the request in streaming form so the body is read against a size
+    # cap rather than buffered whole. Returns one of:
+    #   [:redirect, response]  a 3xx, for the caller to follow
+    #   [:stop, nil]           non-success (warns unless 404), or body over cap
+    #   [:done, parsed]        a 2xx with parsed JSON
+    # Redirect and non-success bodies are never read: returning from the block
+    # unwinds through Net::HTTP, which closes the connection without draining
+    # the body, so a huge error/redirect body can't OOM us either.
+    def perform(http, request, uri)
+      http.request(request) do |response|
+        return [:redirect, response] if response.is_a?(Net::HTTPRedirection)
 
         unless response.is_a?(Net::HTTPSuccess)
           $stderr.puts("warning: #{uri.host}#{uri.path} returned HTTP #{response.code}") unless response.is_a?(Net::HTTPNotFound)
-          return
+          return [:stop, nil]
         end
 
-        return JSON.parse(response.body)
-      end
+        body = read_capped_body(response, uri)
+        return [:stop, nil] if body.nil?
 
-      $stderr.puts("warning: #{uri.host}#{uri.path} too many redirects")
-      nil
-    rescue Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNREFUSED, Errno::ECONNRESET => e
-      $stderr.puts("warning: #{uri.host}#{uri.path} failed: #{e.class} (#{e.message})")
-      nil
-    rescue JSON::ParserError => e
-      $stderr.puts("warning: #{uri.host}#{uri.path} returned invalid JSON: #{e.message}")
-      nil
-    rescue URI::InvalidURIError => e
-      $stderr.puts("warning: #{uri.host}#{uri.path} returned an invalid redirect Location: #{e.message}")
-      nil
+        return [:done, JSON.parse(body)]
+      end
+    end
+
+    # Reads the body in chunks, abandoning the read (returns nil) as soon as it
+    # exceeds MAX_BODY_BYTES so an oversized body is never fully materialized.
+    def read_capped_body(response, uri)
+      body = +""
+      response.read_body do |chunk|
+        body << chunk
+        if body.bytesize > MAX_BODY_BYTES
+          $stderr.puts("warning: #{uri.host}#{uri.path} response exceeded #{MAX_BODY_BYTES} bytes, skipping")
+          return nil
+        end
+      end
+      body
     end
   end
 end

--- a/spec/still_active/http_helper_spec.rb
+++ b/spec/still_active/http_helper_spec.rb
@@ -82,6 +82,15 @@ RSpec.describe(StillActive::HttpHelper) do
         .not_to(raise_error)
       expect(result).to(be_nil)
     end
+
+    it("returns nil instead of parsing a response body over the size cap") do
+      stub_const("StillActive::HttpHelper::MAX_BODY_BYTES", 50)
+      # Valid JSON, but larger than the cap: the cap must win before parsing.
+      stub_request(:get, "https://api.deps.dev/big")
+        .to_return(status: 200, body: "[#{"0," * 100}0]", headers: { "Content-Type" => "application/json" })
+
+      expect(described_class.get_json(URI("https://api.deps.dev"), "/big")).to(be_nil)
+    end
   end
 
   # post_json carries the AQL fallback, so it must enforce the same boundary as
@@ -151,6 +160,20 @@ RSpec.describe(StillActive::HttpHelper) do
           headers: auth,
         )
       end.not_to(raise_error)
+      expect(result).to(be_nil)
+    end
+
+    it("returns nil instead of parsing a response body over the size cap") do
+      stub_const("StillActive::HttpHelper::MAX_BODY_BYTES", 50)
+      stub_request(:post, "https://my-org.jfrog.io/api/search/aql")
+        .to_return(status: 200, body: "[#{"0," * 100}0]", headers: { "Content-Type" => "application/json" })
+
+      result = described_class.post_json(
+        URI("https://my-org.jfrog.io"),
+        "/api/search/aql",
+        body: "items.find({})",
+      )
+
       expect(result).to(be_nil)
     end
   end


### PR DESCRIPTION
Closes #40. **Stacked on #55** (fix/http-helper-nil-location) — review/merge that first, or review this against the #55 branch. Once #55 merges this rebases cleanly onto main.

## Problem

`get_json`/`post_json` used non-block `http.request` (which buffers the **entire** body into memory) then `JSON.parse(response.body)`, with no size limit. The OOM happens at the buffer, before any parse. A source URL is lockfile-derived and a `*.jfrog.io` host is attacker-registerable, so a hostile/broken source can stream a multi-GB body and OOM the process, unauthenticated and triggerable by lockfile content alone (the request fires even with no token).

## Fix

- Stream in block form and read the body in chunks against a **16 MiB** cap (`read_capped_body`), abandoning the read the moment it's exceeded so an oversized body is never fully materialized.
- Redirect and non-success responses return from the request block **without** reading the body, so Net::HTTP closes the connection without draining — a huge error/redirect body can't OOM us either.
- The near-identical `get_json`/`post_json` fold into a shared `request_json` + `perform`; redirect / auth-drop / Location-guard / status handling are unchanged.

16 MiB is generous for metadata (a gem with thousands of versions) while bounding worst-case memory.

## Tests

- Cap fires on both `get_json` and `post_json` (valid-but-oversized JSON → nil, not parsed), mutation-verified (removing the cap check fails them).
- The 10 inherited HttpHelper specs (redirects, cross-host auth-drop, Location guards) still pass, confirming behavior preservation.

**Honest test caveat:** WebMock yields the whole stubbed body in one `read_body` chunk, so the unit tests prove the cap *fires and skips parsing*, but not the streaming-*abandonment* property (that an oversized body is never fully buffered). That property was verified out-of-band against a real TCP server streaming 50 MB: on a 302/500 the connection reset after ~0.5 MB, and on an over-cap 200 it peaked at cap + one chunk then reset. A real-socket fixture would be needed to assert it in-suite; left out per the project's WebMock-only convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
