### PR TITLE
fix(workflow): don't substitute public rubygems data for private-source gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - GitHub Packages version lookups now URL-escape the (lockfile-derived) gem name, matching the Artifactory path. A name with URL-unsafe characters previously raised `URI::InvalidComponentError`, which was swallowed and silently dropped that gem from the audit. Defensive hardening for the untrusted-lockfile stance; the GitHub token is never sent off the fixed `rubygems.pkg.github.com` host. (#50)
 - `--gemfile` is now honoured under `bundle exec`. Dependency loading and the Ruby-version lookup derived their target from a memoized `Bundler.definition` / the ambient `BUNDLE_GEMFILE`, so an explicit `--gemfile` was ignored; both now read the given path directly. (#42)
 - `HttpHelper` no longer crashes on a 3xx response with a missing or malformed `Location` header. `uri + nil` raised `ArgumentError` and a malformed value raised `URI::InvalidURIError`, neither rescued, so the gem was silently dropped; both now return nil with a warning. (#39)
+- Gems from an unqueryable private source (Gemfury, Gemstash, geminabox, a private mirror) are no longer silently looked up on public rubygems.org. A private name with no public match reported blank data, and one that collided with a public gem reported the *public* gem's versions/dates/libyear/repository as if they were the private gem's. still_active now detects a non-rubygems.org rubygems source, warns, and skips both the public version lookup and the public repository-metadata fallback rather than substituting public data. (#43)
 
 ### Security
 

--- a/lib/still_active/workflow.rb
+++ b/lib/still_active/workflow.rb
@@ -217,7 +217,8 @@ module StillActive
     def unqueryable_private_source?(source_uri)
       return false unless source_uri.is_a?(String)
 
-      host = URI(source_uri).host&.downcase # hostnames are case-insensitive
+      # Hostnames are case-insensitive; a trailing dot (FQDN form) is equivalent.
+      host = URI(source_uri).host&.downcase&.chomp(".")
       return false if host.nil?
 
       host != "rubygems.org" && !host.end_with?(".rubygems.org")

--- a/lib/still_active/workflow.rb
+++ b/lib/still_active/workflow.rb
@@ -89,7 +89,7 @@ module StillActive
 
     def gem_info_rubygems(gem_name:, gem_version:, result_object:, source_uri:, advisory_db: nil)
       vs = versions(gem_name: gem_name, source_uri: source_uri)
-      repo_info = repository_info(gem_name: gem_name, versions: vs)
+      repo_info = repository_info(gem_name: gem_name, versions: vs, source_uri: source_uri)
       commit_date = last_commit_date(
         source: repo_info[:source],
         repository_owner: repo_info[:owner],
@@ -189,6 +189,9 @@ module StillActive
         fetch_github_packages_versions(gem_name: gem_name, source_uri: source_uri)
       elsif ArtifactoryClient.artifactory_uri?(source_uri)
         ArtifactoryClient.versions(gem_name: gem_name, source_uri: source_uri)
+      elsif unqueryable_private_source?(source_uri)
+        warn_unqueryable_private_source(gem_name: gem_name, source_uri: source_uri)
+        []
       else
         Gems.versions(gem_name)
       end
@@ -203,6 +206,31 @@ module StillActive
       uri.is_a?(String) && URI(uri).host == "rubygems.pkg.github.com"
     rescue URI::InvalidURIError
       false
+    end
+
+    # A rubygems-type source that isn't public rubygems.org and that we have no
+    # client for (Gemfury, Gemstash, geminabox, a private mirror). We must NOT
+    # fall through to Gems.versions, which always hits public rubygems.org: that
+    # would silently report a public name-collision's data, or blanks, as if it
+    # were the private gem's. github_packages/artifactory are handled above, so
+    # anything left with a non-rubygems.org host is unqueryable. Refs #43.
+    def unqueryable_private_source?(source_uri)
+      return false unless source_uri.is_a?(String)
+
+      host = URI(source_uri).host&.downcase # hostnames are case-insensitive
+      return false if host.nil?
+
+      host != "rubygems.org" && !host.end_with?(".rubygems.org")
+    rescue URI::InvalidURIError
+      false
+    end
+
+    def warn_unqueryable_private_source(gem_name:, source_uri:)
+      host = URI(source_uri).host
+      $stderr.puts(
+        "warning: #{gem_name} resolves from a private source (#{host}) still_active cannot query; " \
+          "reporting no version/latest/libyear data for it rather than substituting public rubygems.org data",
+      )
     end
 
     def fetch_github_packages_versions(gem_name:, source_uri:)
@@ -236,12 +264,23 @@ module StillActive
       repo.merge(project_id: project_id)
     end
 
-    def repository_info(gem_name:, versions:)
+    def repository_info(gem_name:, versions:, source_uri: nil)
       valid_repository_url =
         installed_gem_urls(gem_name: gem_name).find { |url| Repository.valid?(url: url) } ||
         rubygems_versions_repository_url(versions: versions).find { |url| Repository.valid?(url: url) } ||
-        rubygems_gem_repository_url(gem_name: gem_name).find { |url| Repository.valid?(url: url) }
+        public_rubygems_repository_url(gem_name: gem_name, source_uri: source_uri)
       Repository.url_with_owner_and_name(url: valid_repository_url)
+    end
+
+    # Locally-installed gem metadata and the gem's own version payload are
+    # source-accurate. This public rubygems.org Gems.info lookup is the last
+    # resort, and is skipped for an unqueryable private source: otherwise a
+    # public name-collision's repo/archived/last-commit data would stand in for
+    # the private gem, the same substitution #43 prevents for versions.
+    def public_rubygems_repository_url(gem_name:, source_uri:)
+      return if unqueryable_private_source?(source_uri)
+
+      rubygems_gem_repository_url(gem_name: gem_name).find { |url| Repository.valid?(url: url) }
     end
 
     def installed_gem_urls(gem_name:)

--- a/spec/still_active/workflow_spec.rb
+++ b/spec/still_active/workflow_spec.rb
@@ -444,4 +444,59 @@ RSpec.describe(StillActive::Workflow) do
       end
     end
   end
+
+  describe(".versions") do
+    before { allow(Gems).to(receive(:versions).and_return([{ "number" => "9.9.9" }])) }
+
+    it("queries public rubygems for a gem from the public source") do
+      result = described_class.send(:versions, gem_name: "rake", source_uri: "https://rubygems.org/")
+
+      expect(result).to(eq([{ "number" => "9.9.9" }]))
+      expect(Gems).to(have_received(:versions).with("rake"))
+    end
+
+    it("queries public rubygems when no source is known (e.g. --gems mode)") do
+      described_class.send(:versions, gem_name: "rake", source_uri: nil)
+
+      expect(Gems).to(have_received(:versions).with("rake"))
+    end
+
+    it("does not query public rubygems for a gem from an unqueryable private source") do
+      result = nil
+      expect do
+        result = described_class.send(:versions, gem_name: "internalgem", source_uri: "https://gems.internal.example.com/")
+      end.to(output(/private source/i).to_stderr)
+
+      expect(result).to(eq([]))
+      expect(Gems).not_to(have_received(:versions))
+    end
+
+    it("treats rubygems.org subdomains as public") do
+      described_class.send(:versions, gem_name: "rake", source_uri: "https://index.rubygems.org/")
+
+      expect(Gems).to(have_received(:versions).with("rake"))
+    end
+
+    it("treats an uppercase RubyGems.org host as public (hostnames are case-insensitive)") do
+      described_class.send(:versions, gem_name: "rake", source_uri: "https://RubyGems.org/")
+
+      expect(Gems).to(have_received(:versions).with("rake"))
+    end
+  end
+
+  describe(".repository_info") do
+    before { allow(Gems).to(receive(:info).and_return({ "homepage_uri" => nil, "source_code_uri" => nil })) }
+
+    it("does not consult public rubygems.org metadata for an unqueryable private source") do
+      described_class.send(:repository_info, gem_name: "internalgem_xyz", versions: [], source_uri: "https://gems.internal.example.com/")
+
+      expect(Gems).not_to(have_received(:info))
+    end
+
+    it("falls back to public rubygems.org metadata for a public-source gem") do
+      described_class.send(:repository_info, gem_name: "publicgem_xyz", versions: [], source_uri: "https://rubygems.org/")
+
+      expect(Gems).to(have_received(:info).with("publicgem_xyz"))
+    end
+  end
 end

--- a/spec/still_active/workflow_spec.rb
+++ b/spec/still_active/workflow_spec.rb
@@ -482,6 +482,12 @@ RSpec.describe(StillActive::Workflow) do
 
       expect(Gems).to(have_received(:versions).with("rake"))
     end
+
+    it("treats a trailing-dot FQDN rubygems.org host as public") do
+      described_class.send(:versions, gem_name: "rake", source_uri: "https://rubygems.org./")
+
+      expect(Gems).to(have_received(:versions).with("rake"))
+    end
   end
 
   describe(".repository_info") do


### PR DESCRIPTION
Closes #43.

## Bug

`Workflow.versions` special-cased GitHub Packages and Artifactory, then fell through to `Gems.versions(gem_name)` for everything else — and `Gems.versions` always hits **public rubygems.org**. So a gem from a private rubygems-compatible source (Gemfury, Gemstash, geminabox, a private mirror):

- with no public match → reported blank version/latest/libyear, silently;
- whose name **collides** with a public gem → reported the *public* gem's versions, dates, libyear, license, and repository as if they were the private gem's.

This is the likely explanation for libyear discrepancies vs `libyear-bundler` on org-internal gems (reported in the wild: still_active ≈1 where libyear-bundler reported ~7).

## Fix

`unqueryable_private_source?` flags a rubygems `source_uri` whose host isn't `rubygems.org` (case-insensitive, `*.rubygems.org` subdomains allowed). For those, `versions` warns and returns `[]` instead of querying public rubygems.

**Review caught a second leak on the same path** (now fixed): `repository_info` still called `Gems.info(gem_name)` on public rubygems for `repository_url`/`archived`/`last_commit_date`. That public fallback is now skipped for private sources too, so repo metadata can't come from a name-collision either. Locally-installed gem metadata and the gem's own version payload (both source-accurate) are still used.

## Scope / not in this PR

`deps.dev` lookups (scorecard, advisories) are a *separate* external source and could in principle also name-collide for a private gem; that's outside #43's "looked up on public rubygems.org" scope and worth a follow-up if it matters. The "not checked (private source)" row label the issue mentions as a nice-to-have is also a follow-up — this PR does the correctness core (stop substituting public data + warn).

## Tests

`.versions`: public source / nil source (--gems) / subdomain / uppercase host all query public; private source warns, returns [], and does **not** call `Gems.versions` (mutation-verified). `.repository_info`: private source does not call `Gems.info`; public source does. Full suite 530 green, rubocop clean, reviewed + simplified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
