### PR TITLE
fix(workflow): sort resolved gems by name for deterministic output

### DIFF
--- a/lib/still_active/workflow.rb
+++ b/lib/still_active/workflow.rb
@@ -56,7 +56,10 @@ module StillActive
           end
         end
         barrier.wait
-        result_object
+        # Gems are inserted as their async tasks finish, so the natural order is
+        # nondeterministic completion order. Sort by name once here so every
+        # consumer (JSON, SARIF, the baseline diff) gets a stable, diffable order.
+        result_object.sort_by { |name, _| name }.to_h
       end
       task.wait
     end

--- a/spec/still_active/workflow_spec.rb
+++ b/spec/still_active/workflow_spec.rb
@@ -352,6 +352,28 @@ RSpec.describe(StillActive::Workflow) do
       end
     end
 
+    context("when gems resolve in a non-alphabetical order") do
+      # Gems land in the result hash as their async tasks finish, so insertion
+      # order is completion order (nondeterministic across runs). Every consumer
+      # (JSON, SARIF, the baseline diff) needs a stable order to be diffable.
+      before do
+        StillActive.config.gems = [
+          { name: "zebra", version: "1.0.0" },
+          { name: "mango", version: "1.0.0" },
+          { name: "apple", version: "1.0.0" },
+        ]
+        allow(Gems).to(receive_messages(
+          versions: [{ "number" => "1.0.0", "prerelease" => false, "created_at" => "2025-01-01T00:00:00Z" }],
+          info: { "homepage_uri" => nil, "source_code_uri" => nil },
+        ))
+        allow(StillActive::DepsDevClient).to(receive(:version_info).and_return(nil))
+      end
+
+      it("returns gems in a deterministic, name-sorted order") do
+        expect(result.keys).to(eq(["apple", "mango", "zebra"]))
+      end
+    end
+
     context("when --alternatives is enabled and a gem is archived") do
       before do
         StillActive.config.gems = [{ name: "paperclip", version: "6.0.0" }]


### PR DESCRIPTION
## Bug

still_active resolves gems concurrently (async). Each gem's data was written into a shared result hash *as its task completed*, so the hash's key order was **completion order, nondeterministic across runs** on the same lockfile.

The JSON (`cli.rb`) and SARIF (`sarif_helper.rb`) emitters serialize that order directly, so their output was non-diffable run-to-run, and the baseline-diff feature was working against unstable input. (Terminal, markdown, and CycloneDX already self-sorted, so they were never broken.)

## Fix

Sort the result hash by gem name **once** at the single return point in `Workflow.call`, so every downstream consumer inherits a stable, name-sorted order. No per-emitter duplication, and the already-sorted consumers are unaffected (now redundantly stable).

```ruby
result_object.sort_by { |name, _| name }.to_h
```

## Test

Regression test in `workflow_spec.rb`: gems configured in reverse-alphabetical order (`zebra, mango, apple`) must come back name-sorted. Verified RED on `main` (returns `["zebra","mango","apple"]`) and GREEN with the fix. Full suite 550 green, rubocop clean. Reviewed (clean) + simplifier (already minimal).

Closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
