### PR TITLE
refactor(github): extract repo signals into a GithubClient provider

### DIFF
--- a/lib/still_active/github_client.rb
+++ b/lib/still_active/github_client.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "time"
+require "octokit"
+
+module StillActive
+  # Repo signals (archived?, last commit date) for github.com-hosted gems.
+  # Wraps Octokit so the rest of the workflow dispatches to a provider with the
+  # same shape as GitlabClient, rather than reaching into Octokit inline. The
+  # Octokit dependency stays internal to this module.
+  module GithubClient
+    extend self
+
+    def archived(owner:, name:)
+      return if owner.nil? || name.nil?
+
+      StillActive.config.github_client.repository("#{owner}/#{name}")&.archived
+    rescue Octokit::Error, Faraday::Error => e
+      $stderr.puts("warning: archived check failed for #{owner}/#{name}: #{e.class}")
+      nil
+    end
+
+    def last_commit_date(owner:, name:)
+      return if owner.nil? || name.nil?
+
+      commit = StillActive.config.github_client.commits("#{owner}/#{name}", per_page: 1)&.first
+      date = commit&.commit&.author&.date
+      case date
+      when Time then date
+      when String then parse_commit_date(date, owner, name)
+      end
+    rescue Octokit::Error, Faraday::Error => e
+      $stderr.puts("warning: last commit check failed for #{owner}/#{name}: #{e.class}")
+      nil
+    end
+
+    private
+
+    def parse_commit_date(date, owner, name)
+      Time.parse(date)
+    rescue ArgumentError
+      $stderr.puts("warning: could not parse commit date for #{owner}/#{name}: #{date.inspect}")
+      nil
+    end
+  end
+end

--- a/lib/still_active/workflow.rb
+++ b/lib/still_active/workflow.rb
@@ -2,6 +2,7 @@
 
 require_relative "artifactory_client"
 require_relative "deps_dev_client"
+require_relative "github_client"
 require_relative "gitlab_client"
 require_relative "repository"
 require_relative "../helpers/activity_helper"
@@ -318,37 +319,19 @@ module StillActive
     def repo_archived(source:, repository_owner:, repository_name:)
       case source
       when :github
-        repo = StillActive.config.github_client.repository("#{repository_owner}/#{repository_name}")
-        repo&.archived
+        GithubClient.archived(owner: repository_owner, name: repository_name)
       when :gitlab
         GitlabClient.archived(owner: repository_owner, name: repository_name)
       end
-    rescue Octokit::Error, Faraday::Error => e
-      $stderr.puts("warning: archived check failed for #{repository_owner}/#{repository_name}: #{e.class}")
-      nil
     end
 
     def last_commit_date(source:, repository_owner:, repository_name:)
       case source
       when :github
-        commit = StillActive.config.github_client.commits("#{repository_owner}/#{repository_name}", per_page: 1)&.first
-        date = commit&.commit&.author&.date
-        case date
-        when Time then date
-        when String
-          begin
-            Time.parse(date)
-          rescue ArgumentError
-            $stderr.puts("warning: could not parse commit date for #{repository_owner}/#{repository_name}: #{date.inspect}")
-            nil
-          end
-        end
+        GithubClient.last_commit_date(owner: repository_owner, name: repository_name)
       when :gitlab
         GitlabClient.last_commit_date(owner: repository_owner, name: repository_name)
       end
-    rescue Octokit::Error, Faraday::Error => e
-      $stderr.puts("warning: last commit check failed for #{repository_owner}/#{repository_name}: #{e.class}")
-      nil
     end
   end
 end

--- a/spec/still_active/github_client_spec.rb
+++ b/spec/still_active/github_client_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/still_active/github_client"
+
+RSpec.describe(StillActive::GithubClient) do
+  let(:owner) { "rails" }
+  let(:name) { "rails" }
+  let(:client) { instance_double(Octokit::Client) }
+
+  before do
+    StillActive.reset
+    allow(StillActive.config).to(receive(:github_client).and_return(client))
+  end
+
+  def commit_with(date)
+    double(commit: double(author: double(date: date)))
+  end
+
+  describe(".archived") do
+    it("returns true for an archived repo") do
+      allow(client).to(receive(:repository).with("rails/rails").and_return(double(archived: true)))
+      expect(described_class.archived(owner: owner, name: name)).to(be(true))
+    end
+
+    it("returns false for an active repo") do
+      allow(client).to(receive(:repository).with("rails/rails").and_return(double(archived: false)))
+      expect(described_class.archived(owner: owner, name: name)).to(be(false))
+    end
+
+    it("returns nil when owner is nil, without calling the API") do
+      allow(client).to(receive(:repository))
+      expect(described_class.archived(owner: nil, name: name)).to(be_nil)
+      expect(client).not_to(have_received(:repository))
+    end
+
+    it("returns nil and warns on an Octokit error") do
+      allow(client).to(receive(:repository).and_raise(Octokit::NotFound))
+      expect { expect(described_class.archived(owner: owner, name: name)).to(be_nil) }
+        .to(output(/archived check failed/).to_stderr)
+    end
+  end
+
+  describe(".last_commit_date") do
+    it("returns the commit date as a Time") do
+      t = Time.now
+      allow(client).to(receive(:commits).with("rails/rails", per_page: 1).and_return([commit_with(t)]))
+      expect(described_class.last_commit_date(owner: owner, name: name)).to(eq(t))
+    end
+
+    it("parses a string commit date") do
+      allow(client).to(receive(:commits).and_return([commit_with("2026-02-15T14:30:00Z")]))
+      expect(described_class.last_commit_date(owner: owner, name: name)).to(be_a(Time))
+    end
+
+    it("returns nil when there are no commits") do
+      allow(client).to(receive(:commits).and_return([]))
+      expect(described_class.last_commit_date(owner: owner, name: name)).to(be_nil)
+    end
+
+    it("returns nil when owner is nil, without calling the API") do
+      allow(client).to(receive(:commits))
+      expect(described_class.last_commit_date(owner: nil, name: name)).to(be_nil)
+      expect(client).not_to(have_received(:commits))
+    end
+
+    it("returns nil and warns on an Octokit error") do
+      allow(client).to(receive(:commits).and_raise(Octokit::TooManyRequests))
+      expect { expect(described_class.last_commit_date(owner: owner, name: name)).to(be_nil) }
+        .to(output(/last commit check failed/).to_stderr)
+    end
+
+    it("returns nil and warns on an unparseable date string") do
+      allow(client).to(receive(:commits).and_return([commit_with("not-a-date")]))
+      expect { expect(described_class.last_commit_date(owner: owner, name: name)).to(be_nil) }
+        .to(output(/could not parse commit date/).to_stderr)
+    end
+  end
+end


### PR DESCRIPTION
Closes #30.

## Motivation

GitHub repo signals (`archived?`, last commit date) were called inline via Octokit inside `Workflow#repo_archived` / `#last_commit_date`, while GitLab already had a clean `GitlabClient` module. The asymmetry meant the GitHub path was untested and Octokit leaked into the workflow.

## Change

- New `GithubClient` (`lib/still_active/github_client.rb`) exposing `archived(owner:, name:)` and `last_commit_date(owner:, name:)`, mirroring `GitlabClient`. Octokit stays internal; `config.github_client` is unchanged.
- `Workflow`'s two methods now dispatch symmetrically to `GithubClient` / `GitlabClient`. The workflow-level `rescue Octokit::Error, Faraday::Error` is dropped — each client self-handles its errors (GitlabClient already did, through `HttpHelper`), and the per-gem `rescue StandardError` in the fan-out remains as a backstop.
- New `github_client_spec.rb` covers the GitHub path that previously had **no tests**: archived true/false, commit `Time` passthrough and `String` parsing, no-commits, nil-owner short-circuit (asserting no API call), and error → warn → nil for both methods.

## Behaviour

Unchanged. Same archived value, the same `Time`/`String` date handling, the same warning strings, and the same nil-on-error. A new nil-owner/name guard short-circuits before the API call instead of making a doomed request — same result, slightly cheaper, and symmetric with `GitlabClient`.

Naming follows `GitlabClient`: `archived` (no `?`), `last_commit_date`.

## Verification

Full suite 570 green, rubocop clean. Dogfooded: `still_active --gems=paperclip,rails` still reports `paperclip archived=true` (its repo is archived) and `rails` a recent commit — GitHub signals flow correctly through the new client. Reviewed (no issues, behaviour-equivalence confirmed) + simplifier (reads as a sibling of GitlabClient).

## Unblocks

This is the provider seam **#31** (Forgejo/Codeberg) and **#32 Signal B** (commits-since-release) build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
