### PR TITLE
feat(json): expose the derived activity_level verdict per gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- JSON output now includes a derived `activity_level` per gem (`"ok"`, `"stale"`, `"critical"`, `"archived"`, or `"unknown"`), so a machine or LLM consumer reads still_active's maintenance verdict directly instead of re-deriving it from the raw dates. Documented in `docs/schema.md`. (#33)
 - JFrog Artifactory gem registry support: fetches versions from `.jfrog.io` RubyGems-compatible registries via the versions API with an AQL search fallback. Auth reuses Bundler's per-source credentials when present, otherwise a global token via `--artifactory-token` or `STILL_ACTIVE_ARTIFACTORY_TOKEN` (requires a matching `--artifactory-host` / `STILL_ACTIVE_ARTIFACTORY_HOST`).
 
 ### Changed

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -40,6 +40,7 @@
 | `repository_url` | string \| nil | Canonical GitHub/GitLab URL when found. |
 | `last_commit_date` | string \| nil | ISO-8601 timestamp of the latest commit. |
 | `archived` | bool \| nil | `true` if the repo is archived; `nil` if unknown. |
+| `activity_level` | string | Derived maintenance verdict: `"ok"`, `"stale"`, `"critical"`, `"archived"`, or `"unknown"`. Driven by release recency, with the last commit used only as a fallback when a gem has no releases. |
 | `scorecard_score` | float \| nil | OpenSSF Scorecard score 0.0–10.0 from deps.dev. |
 | `vulnerability_count` | integer | Number of advisories affecting `version_used`. |
 | `vulnerabilities` | array | One entry per advisory (see below). |

--- a/lib/still_active/cli.rb
+++ b/lib/still_active/cli.rb
@@ -53,7 +53,9 @@ module StillActive
             schema_version: 1,
             tool: { name: "still_active", version: StillActive::VERSION },
             generated_at: Time.now.utc.iso8601,
-            gems: result,
+            # Surface the derived verdict so a machine/LLM consumer reads it
+            # directly instead of re-deriving it from the raw dates.
+            gems: result.transform_values { |data| data.merge(activity_level: ActivityHelper.activity_level(data)) },
           }
           output[:ruby] = ruby_info if ruby_info
           output[:pr_context] = pr_context if pr_context

--- a/spec/still_active/cli_spec.rb
+++ b/spec/still_active/cli_spec.rb
@@ -192,6 +192,15 @@ RSpec.describe(StillActive::CLI) do
       expect(payload["ruby"]).to(eq("version" => "3.4.0", "eol" => false))
     end
 
+    it("exposes the computed activity_level verdict per gem, so machine consumers need not recompute it") do
+      captured = nil
+      allow($stdout).to(receive(:puts)) { |arg| captured = arg }
+      cli.run(["--gems=rails", "--json"])
+      payload = JSON.parse(captured)
+      # rails has a recent commit and no releases here, so it lands :ok.
+      expect(payload.dig("gems", "rails", "activity_level")).to(eq("ok"))
+    end
+
     it("omits ruby key when ruby info is nil") do
       allow(StillActive::Workflow).to(receive(:ruby_freshness).and_return(nil))
       captured = nil


### PR DESCRIPTION
Refs #33 (AI-first output).

## Gap

The JSON output exposed the raw maintenance signals (last commit / release dates, `archived`, `scorecard_score`) but **not** the computed `activity_level` verdict. A machine or LLM consumer had to re-derive "is this gem stale?" from the dates and thresholds, duplicating the tool's own logic. (Surfaced while fixing the SARIF SA002 path in #63.)

## Change

- Add `activity_level` (`"ok"`, `"stale"`, `"critical"`, `"archived"`, `"unknown"`) to each gem in the JSON output, computed via `ActivityHelper.activity_level`. `transform_values { |data| data.merge(...) }` is **non-mutating**, so the sarif / cyclonedx / baseline-diff branches that share the same `result` hash are unaffected.
- Documented in `docs/schema.md`; CHANGELOG under Added.

## Verification

`cli_spec` asserts the verdict appears with the right value. Full suite 571 green, rubocop clean. Dogfooded: `still_active --gems=paperclip,rails,mime-types --json` reports `paperclip → "archived"`, `rails → "ok"`, `mime-types → "ok"`. Confirmed it does not pollute the baseline diff (`collect_signal_changes` compares only specific named keys, and the diff branch rebuilds from the pristine `result`).

## Scope note

JSON-only by design. The terminal/markdown render the verdict visually and SARIF expresses it as `SA002` findings, so they already carry it. CycloneDX is deliberately left out for now: the SBOM advertises content-stability for a data snapshot, and `activity_level` is clock-relative (computed against `Time.now` + the configured thresholds) unlike the absolute date fields already in it. Adding it to the SBOM is a conscious change to that contract, tracked as a possible follow-up rather than bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
