### PR TITLE
feat(forgejo): add Codeberg/Forgejo repo-signal provider (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Forgejo/Codeberg repos are now a recognised source for the archived and last-commit signals, alongside GitHub and GitLab. A gem whose canonical `source_code_uri` points at `codeberg.org` previously fell through to no repo signals at all; it now resolves through a new `ForgejoClient` (the Gitea `/api/v1` surface every Forgejo/Gitea instance shares), so the host is a parameter for later self-hosted support. Reads are anonymous by default; `STILL_ACTIVE_FORGEJO_TOKEN`/`CODEBERG_TOKEN` only raise the rate limit or reach private repos. Codeberg-hosted repos are correctly left out of deps.dev OpenSSF Scorecard lookups (deps.dev indexes only github.com/gitlab.com) rather than minting a bogus `github.com/owner/name` project id. (#31)
 - JSON output now includes a derived `activity_level` per gem (`"ok"`, `"stale"`, `"critical"`, `"archived"`, or `"unknown"`), so a machine or LLM consumer reads still_active's maintenance verdict directly instead of re-deriving it from the raw dates. Documented in `docs/schema.md`. (#33)
 - JFrog Artifactory gem registry support: fetches versions from `.jfrog.io` RubyGems-compatible registries via the versions API with an AQL search fallback. Auth reuses Bundler's per-source credentials when present, otherwise a global token via `--artifactory-token` or `STILL_ACTIVE_ARTIFACTORY_TOKEN` (requires a matching `--artifactory-host` / `STILL_ACTIVE_ARTIFACTORY_HOST`).
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Without a token, GitHub API calls are unauthenticated and rate-limited to 60 req
 
 GitLab cascade mirrors GitHub: `--gitlab-token` → `GITLAB_TOKEN` → `glab auth status --show-token`. Optional for public repos, required for private ones.
 
+Forgejo/Codeberg (the rare gem whose canonical `source_code_uri` is `codeberg.org`) is read anonymously by default; set `STILL_ACTIVE_FORGEJO_TOKEN` (or `CODEBERG_TOKEN`) only to raise the rate limit or reach a private repo. There is no CLI flag, since Codeberg has no ubiquitous CLI to borrow a token from the way `gh`/`glab` do.
+
 Artifactory auth prefers Bundler's per-source credentials (`Bundler.settings` for the source URL or hostname) so private registries work the same way `bundle install` does and multiple hosts need no extra configuration. If none are set, still_active falls back to a global token via `--artifactory-token` or `STILL_ACTIVE_ARTIFACTORY_TOKEN`; that path requires `--artifactory-host` / `STILL_ACTIVE_ARTIFACTORY_HOST` to prevent sending the token to an unexpected host from the lockfile. Use `user:password` in Bundler settings for Basic auth, or a bare token for Bearer auth. Required for private JFrog gem registries (`.jfrog.io`).
 
 When providing the artifactory token via flag or env, you must also set `--artifactory-host` or `STILL_ACTIVE_ARTIFACTORY_HOST` to the expected registry hostname (e.g. `my-org.jfrog.io`). still_active only sends the token to a matching host, so a lockfile cannot redirect it elsewhere to prevent leaking the token to an unverified host. Providing a token/host in this manner will work only for a single-host. To support multiple Artifactory hosts, use Bundler's credentials per source URL or hostname (`bundle config set credentials.my-org.jfrog.io user:pass`).
@@ -365,7 +367,7 @@ These are **leads, not recommendations**: same-category does not mean drop-in re
 ### Data sources
 
 - **Versions, release dates, and licenses** from [RubyGems.org](https://rubygems.org), [GitHub Packages](https://docs.github.com/en/packages), or [JFrog Artifactory](https://jfrog.com/artifactory/) gem registries
-- **Last commit date and archived status** from the [GitHub](https://docs.github.com/en/rest) or [GitLab](https://docs.gitlab.com/ee/api/) API
+- **Last commit date and archived status** from the [GitHub](https://docs.github.com/en/rest), [GitLab](https://docs.gitlab.com/ee/api/), or [Forgejo/Gitea](https://forgejo.org/docs/latest/user/api-usage/) (Codeberg) API
 - **OpenSSF Scorecard**, **vulnerability counts**, and **CVSS severity** from Google's [deps.dev](https://deps.dev) API
 - **Additional advisories** from [ruby-advisory-db](https://github.com/rubysec/ruby-advisory-db), merged in when `bundler-audit` is installed alongside (run `bundle audit update` to keep its checkout current)
 - **Ruby version freshness** from [endoflife.date](https://endoflife.date)

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -37,7 +37,7 @@
 | `latest_version_release_date` | string \| nil | ISO-8601 timestamp. |
 | `latest_pre_release_version` | string \| nil | Latest pre-release version if any. |
 | `latest_pre_release_version_release_date` | string \| nil | ISO-8601 timestamp. |
-| `repository_url` | string \| nil | Canonical GitHub/GitLab URL when found. |
+| `repository_url` | string \| nil | Canonical GitHub/GitLab/Codeberg URL when found. |
 | `last_commit_date` | string \| nil | ISO-8601 timestamp of the latest commit. |
 | `archived` | bool \| nil | `true` if the repo is archived; `nil` if unknown. |
 | `activity_level` | string | Derived maintenance verdict: `"ok"`, `"stale"`, `"critical"`, `"archived"`, or `"unknown"`. Driven by release recency, with the last commit used only as a fallback when a gem has no releases. |

--- a/lib/helpers/http_helper.rb
+++ b/lib/helpers/http_helper.rb
@@ -5,7 +5,7 @@ require "json"
 
 module StillActive
   module HttpHelper
-    TRUSTED_HOSTS = ["github.com", "gitlab.com", "api.deps.dev", "endoflife.date", "rubygems.pkg.github.com"].freeze
+    TRUSTED_HOSTS = ["github.com", "gitlab.com", "codeberg.org", "api.deps.dev", "endoflife.date", "rubygems.pkg.github.com"].freeze
     MAX_REDIRECTS = 3
     # Ceiling on a single response body. These are metadata endpoints (version
     # lists, scorecards, advisories); legitimate responses are well under this.

--- a/lib/still_active/config.rb
+++ b/lib/still_active/config.rb
@@ -6,7 +6,7 @@ require "open3"
 
 module StillActive
   class Config
-    attr_writer :github_oauth_token, :gitlab_token, :artifactory_token, :artifactory_host, :gemfile_path
+    attr_writer :github_oauth_token, :gitlab_token, :forgejo_token, :artifactory_token, :artifactory_host, :gemfile_path
     attr_accessor :alternatives,
       :baseline_path,
       :critical_warning_emoji,
@@ -39,6 +39,7 @@ module StillActive
       @ignored_gems = []
       @github_oauth_token = nil
       @gitlab_token = nil
+      @forgejo_token = nil
       @artifactory_token = nil
       @artifactory_host = nil
 
@@ -75,6 +76,14 @@ module StillActive
 
     def gitlab_token
       @gitlab_token ||= presence(ENV["GITLAB_TOKEN"]) || glab_cli_token
+    end
+
+    # Codeberg/Forgejo has no ubiquitous CLI to borrow a token from (unlike
+    # gh/glab), so it's env-var only. Anonymous works for public repos; a token
+    # only raises the rate limit. CODEBERG_TOKEN is accepted as a convenience
+    # alias for the codeberg.org default host.
+    def forgejo_token
+      @forgejo_token ||= presence(ENV["STILL_ACTIVE_FORGEJO_TOKEN"]) || presence(ENV["CODEBERG_TOKEN"])
     end
 
     def artifactory_token

--- a/lib/still_active/forgejo_client.rb
+++ b/lib/still_active/forgejo_client.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "time"
+require_relative "../helpers/http_helper"
+
+module StillActive
+  # Repo signals (archived?, last commit date) for Forgejo/Gitea-hosted gems.
+  # Codeberg.org is the only host wired into the workflow today, but every
+  # Forgejo/Gitea instance speaks the same `/api/v1` surface, so the host is a
+  # parameter for later self-hosted support. Mirrors GitlabClient: HttpHelper
+  # against a documented JSON API, anonymous by default with an optional token.
+  module ForgejoClient
+    extend self
+
+    DEFAULT_HOST = "codeberg.org"
+
+    def archived(owner:, name:, host: DEFAULT_HOST)
+      return if owner.nil? || name.nil?
+
+      body = HttpHelper.get_json(base_uri(host), "/api/v1/repos/#{owner}/#{name}", headers: auth_headers)
+      return if body.nil?
+
+      body["archived"] == true
+    end
+
+    def last_commit_date(owner:, name:, host: DEFAULT_HOST)
+      return if owner.nil? || name.nil?
+
+      # stat/verification/files default on and pull per-commit diffs and GPG
+      # checks we don't use; turn them off so a single-commit lookup stays cheap.
+      params = { limit: 1, stat: false, verification: false, files: false }
+      body = HttpHelper.get_json(base_uri(host), "/api/v1/repos/#{owner}/#{name}/commits", headers: auth_headers, params: params)
+      return if body.nil? || body.empty?
+
+      date = body.first.dig("commit", "committer", "date") || body.first.dig("commit", "author", "date")
+      return unless date
+
+      begin
+        Time.parse(date)
+      rescue ArgumentError
+        $stderr.puts("warning: could not parse commit date for #{owner}/#{name}: #{date.inspect}")
+        nil
+      end
+    end
+
+    private
+
+    def base_uri(host)
+      URI("https://#{host}/")
+    end
+
+    def auth_headers
+      token = StillActive.config.forgejo_token
+      token ? { "Authorization" => "token #{token}" } : {}
+    end
+  end
+end

--- a/lib/still_active/repository.rb
+++ b/lib/still_active/repository.rb
@@ -2,7 +2,15 @@
 
 module StillActive
   module Repository
-    REPO_REGEX = %r{(https?://(?:www\.)?(github|gitlab)\.com/([\w.\-]+)/([\w.\-]+))}i
+    # codeberg.org is the one Forgejo/Gitea host wired up today; it speaks the
+    # same Gitea API as any self-hosted instance, so its source is :forgejo (the
+    # forge software, what ForgejoClient handles), not :codeberg (the host).
+    SOURCE_BY_HOST = {
+      "github.com" => :github,
+      "gitlab.com" => :gitlab,
+      "codeberg.org" => :forgejo,
+    }.freeze
+    REPO_REGEX = %r{(?<url>https?://(?:www\.)?(?<host>github\.com|gitlab\.com|codeberg\.org)/(?<owner>[\w.\-]+)/(?<name>[\w.\-]+))}i
 
     extend self
 
@@ -16,10 +24,10 @@ module StillActive
       match = url&.match(REPO_REGEX)
       return { source: :unhandled, owner: nil, name: nil } unless match
 
-      url = match[1].delete_suffix(".git")
-      name = match[4].delete_suffix(".git")
+      clean_url = match[:url].delete_suffix(".git")
+      name = match[:name].delete_suffix(".git")
 
-      { url: url, source: match[2].to_sym, owner: match[3], name: name }
+      { url: clean_url, source: SOURCE_BY_HOST.fetch(match[:host].downcase), owner: match[:owner], name: name }
     end
   end
 end

--- a/lib/still_active/workflow.rb
+++ b/lib/still_active/workflow.rb
@@ -2,6 +2,7 @@
 
 require_relative "artifactory_client"
 require_relative "deps_dev_client"
+require_relative "forgejo_client"
 require_relative "github_client"
 require_relative "gitlab_client"
 require_relative "repository"
@@ -251,22 +252,26 @@ module StillActive
       valid_repository_url =
         [source_uri, *installed_gem_urls(gem_name: gem_name)].find { |url| Repository.valid?(url: url) }
       repo = Repository.url_with_owner_and_name(url: valid_repository_url)
-      project_id = if repo[:url]
-        host = repo[:source] == :gitlab ? "gitlab.com" : "github.com"
-        "#{host}/#{repo[:owner]}/#{repo[:name]}"
-      end
-      repo.merge(project_id: project_id)
+      repo.merge(project_id: deps_dev_project_id(repo))
     end
 
     def repository_info_from_installed_gem(gem_name:)
       valid_repository_url =
         installed_gem_urls(gem_name: gem_name).find { |url| Repository.valid?(url: url) }
       repo = Repository.url_with_owner_and_name(url: valid_repository_url)
-      project_id = if repo[:url]
-        host = repo[:source] == :gitlab ? "gitlab.com" : "github.com"
-        "#{host}/#{repo[:owner]}/#{repo[:name]}"
-      end
-      repo.merge(project_id: project_id)
+      repo.merge(project_id: deps_dev_project_id(repo))
+    end
+
+    # deps.dev scorecards index github.com and gitlab.com only. A Forgejo/Codeberg
+    # repo has no deps.dev project, so leave its project_id nil rather than minting
+    # a bogus github.com/owner/name that would fetch the wrong (or no) scorecard.
+    DEPS_DEV_HOST_BY_SOURCE = { github: "github.com", gitlab: "gitlab.com" }.freeze
+
+    def deps_dev_project_id(repo)
+      host = DEPS_DEV_HOST_BY_SOURCE[repo[:source]]
+      return unless repo[:url] && host
+
+      "#{host}/#{repo[:owner]}/#{repo[:name]}"
     end
 
     def repository_info(gem_name:, versions:, source_uri: nil)
@@ -322,6 +327,8 @@ module StillActive
         GithubClient.archived(owner: repository_owner, name: repository_name)
       when :gitlab
         GitlabClient.archived(owner: repository_owner, name: repository_name)
+      when :forgejo
+        ForgejoClient.archived(owner: repository_owner, name: repository_name)
       end
     end
 
@@ -331,6 +338,8 @@ module StillActive
         GithubClient.last_commit_date(owner: repository_owner, name: repository_name)
       when :gitlab
         GitlabClient.last_commit_date(owner: repository_owner, name: repository_name)
+      when :forgejo
+        ForgejoClient.last_commit_date(owner: repository_owner, name: repository_name)
       end
     end
   end

--- a/spec/still_active/config_spec.rb
+++ b/spec/still_active/config_spec.rb
@@ -82,6 +82,43 @@ RSpec.describe(StillActive::Config) do
     end
   end
 
+  describe("forgejo_token discovery") do
+    around do |example|
+      original = ENV.to_hash
+      ENV.delete("STILL_ACTIVE_FORGEJO_TOKEN")
+      ENV.delete("CODEBERG_TOKEN")
+      example.run
+    ensure
+      ENV.clear
+      original.each { |k, v| ENV[k] = v }
+    end
+
+    it("uses STILL_ACTIVE_FORGEJO_TOKEN when set") do
+      ENV["STILL_ACTIVE_FORGEJO_TOKEN"] = "fj_from_env"
+      expect(described_class.new.forgejo_token).to(eq("fj_from_env"))
+    end
+
+    it("accepts CODEBERG_TOKEN as an alias") do
+      ENV["CODEBERG_TOKEN"] = "fj_from_codeberg"
+      expect(described_class.new.forgejo_token).to(eq("fj_from_codeberg"))
+    end
+
+    it("prefers STILL_ACTIVE_FORGEJO_TOKEN over CODEBERG_TOKEN") do
+      ENV["STILL_ACTIVE_FORGEJO_TOKEN"] = "fj_primary"
+      ENV["CODEBERG_TOKEN"] = "fj_alias"
+      expect(described_class.new.forgejo_token).to(eq("fj_primary"))
+    end
+
+    it("treats an empty token as unset") do
+      ENV["STILL_ACTIVE_FORGEJO_TOKEN"] = ""
+      expect(described_class.new.forgejo_token).to(be_nil)
+    end
+
+    it("returns nil when no token env var is set (anonymous reads)") do
+      expect(described_class.new.forgejo_token).to(be_nil)
+    end
+  end
+
   describe("gitlab_token discovery") do
     around do |example|
       original = ENV.to_hash

--- a/spec/still_active/forgejo_client_spec.rb
+++ b/spec/still_active/forgejo_client_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+RSpec.describe(StillActive::ForgejoClient) do
+  before { StillActive.reset }
+
+  let(:owner) { "forgejo" }
+  let(:name) { "forgejo" }
+  let(:repo_url) { "https://codeberg.org/api/v1/repos/#{owner}/#{name}" }
+  let(:commits_url) { "https://codeberg.org/api/v1/repos/#{owner}/#{name}/commits" }
+
+  describe(".archived") do
+    it("returns true for an archived repo") do
+      stub_request(:get, repo_url).to_return(status: 200, body: { "archived" => true }.to_json, headers: { "Content-Type" => "application/json" })
+      expect(described_class.archived(owner: owner, name: name)).to(be(true))
+    end
+
+    it("returns false for an active repo") do
+      stub_request(:get, repo_url).to_return(status: 200, body: { "archived" => false }.to_json, headers: { "Content-Type" => "application/json" })
+      expect(described_class.archived(owner: owner, name: name)).to(be(false))
+    end
+
+    it("returns nil when owner is nil") do
+      expect(described_class.archived(owner: nil, name: name)).to(be_nil)
+    end
+
+    it("returns nil on a non-success status") do
+      stub_request(:get, repo_url).to_return(status: 404)
+      expect(described_class.archived(owner: owner, name: name)).to(be_nil)
+    end
+
+    it("targets a custom host when given one") do
+      custom = stub_request(:get, "https://git.example.org/api/v1/repos/#{owner}/#{name}")
+        .to_return(status: 200, body: { "archived" => false }.to_json, headers: { "Content-Type" => "application/json" })
+      described_class.archived(owner: owner, name: name, host: "git.example.org")
+      expect(custom).to(have_been_requested)
+    end
+  end
+
+  describe(".last_commit_date") do
+    let(:body) { [{ "commit" => { "committer" => { "date" => "2026-02-15T14:30:00Z" }, "author" => { "date" => "2026-01-01T00:00:00Z" } } }] }
+
+    it("returns the committer date as a Time") do
+      stub_request(:get, commits_url).with(query: hash_including("limit" => "1"))
+        .to_return(status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" })
+
+      result = described_class.last_commit_date(owner: owner, name: name)
+
+      expect(result).to(eq(Time.parse("2026-02-15T14:30:00Z")))
+    end
+
+    it("falls back to the author date when committer date is absent") do
+      author_only = [{ "commit" => { "author" => { "date" => "2026-01-01T00:00:00Z" } } }]
+      stub_request(:get, commits_url).with(query: hash_including("limit" => "1"))
+        .to_return(status: 200, body: author_only.to_json, headers: { "Content-Type" => "application/json" })
+
+      expect(described_class.last_commit_date(owner: owner, name: name)).to(eq(Time.parse("2026-01-01T00:00:00Z")))
+    end
+
+    it("returns nil when owner is nil") do
+      expect(described_class.last_commit_date(owner: nil, name: name)).to(be_nil)
+    end
+
+    it("returns nil for an empty response body") do
+      stub_request(:get, commits_url).with(query: hash_including("limit" => "1")).to_return(status: 200, body: "[]", headers: { "Content-Type" => "application/json" })
+      expect(described_class.last_commit_date(owner: owner, name: name)).to(be_nil)
+    end
+
+    it("returns nil on timeout") do
+      stub_request(:get, commits_url).with(query: hash_including("limit" => "1")).to_timeout
+      expect(described_class.last_commit_date(owner: owner, name: name)).to(be_nil)
+    end
+
+    it("returns nil and warns on an unparseable date string") do
+      bad = [{ "commit" => { "committer" => { "date" => "not-a-date" } } }]
+      stub_request(:get, commits_url).with(query: hash_including("limit" => "1"))
+        .to_return(status: 200, body: bad.to_json, headers: { "Content-Type" => "application/json" })
+
+      expect { expect(described_class.last_commit_date(owner: owner, name: name)).to(be_nil) }
+        .to(output(/could not parse commit date/).to_stderr)
+    end
+
+    it("sends a token header when forgejo_token is configured") do
+      StillActive.config { |config| config.forgejo_token = "fj-test-token" }
+      stub = stub_request(:get, commits_url)
+        .with(query: hash_including("limit" => "1"), headers: { "Authorization" => "token fj-test-token" })
+        .to_return(status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" })
+
+      described_class.last_commit_date(owner: owner, name: name)
+
+      expect(stub).to(have_been_requested)
+    ensure
+      StillActive.config { |config| config.forgejo_token = nil }
+    end
+
+    it("does not send an Authorization header when forgejo_token is nil") do
+      stub_request(:get, commits_url)
+        .with(query: hash_including("limit" => "1")) { |req| !req.headers.key?("Authorization") }
+        .to_return(status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" })
+
+      expect(described_class.last_commit_date(owner: owner, name: name)).to(be_a(Time))
+    end
+  end
+end

--- a/spec/still_active/repository_spec.rb
+++ b/spec/still_active/repository_spec.rb
@@ -15,8 +15,15 @@ RSpec.describe(StillActive::Repository) do
       "https://gitlab.com/gitlab-org/gitlab.git",
     ]
   end
+  let(:valid_codeberg_urls) do
+    [
+      "https://codeberg.org/forgejo/forgejo",
+      "https://codeberg.org/forgejo/forgejo/src/branch/main",
+      "https://codeberg.org/forgejo/forgejo.git",
+    ]
+  end
   let(:valid_urls) do
-    [valid_github_urls, valid_gitlab_urls].flatten
+    [valid_github_urls, valid_gitlab_urls, valid_codeberg_urls].flatten
   end
 
   describe("#valid?") do
@@ -55,6 +62,16 @@ RSpec.describe(StillActive::Repository) do
           valid_gitlab_urls.each do |url|
             subject = described_class.url_with_owner_and_name(url: url)
             expected_result = { source: :gitlab, owner: "gitlab-org", name: "gitlab" }
+            expect(subject).to(include(expected_result))
+          end
+        end
+      end
+
+      context("with a Codeberg URL") do
+        it("maps codeberg.org to the :forgejo source") do
+          valid_codeberg_urls.each do |url|
+            subject = described_class.url_with_owner_and_name(url: url)
+            expected_result = { source: :forgejo, owner: "forgejo", name: "forgejo" }
             expect(subject).to(include(expected_result))
           end
         end

--- a/spec/still_active/workflow_spec.rb
+++ b/spec/still_active/workflow_spec.rb
@@ -527,4 +527,18 @@ RSpec.describe(StillActive::Workflow) do
       expect(Gems).to(have_received(:info).with("publicgem_xyz"))
     end
   end
+
+  describe(".repository_info_for_non_rubygems") do
+    it("builds a deps.dev project_id for a github-hosted source") do
+      info = described_class.send(:repository_info_for_non_rubygems, gem_name: "ghgem_xyz", source_uri: "https://github.com/owner/ghgem_xyz")
+
+      expect(info).to(include(source: :github, project_id: "github.com/owner/ghgem_xyz"))
+    end
+
+    it("leaves project_id nil for a codeberg/forgejo source deps.dev does not index") do
+      info = described_class.send(:repository_info_for_non_rubygems, gem_name: "cbgem_xyz", source_uri: "https://codeberg.org/owner/cbgem_xyz")
+
+      expect(info).to(include(source: :forgejo, project_id: nil))
+    end
+  end
 end


### PR DESCRIPTION
## What

Adds a Forgejo/Codeberg provider for the archived and last-commit maintenance signals, alongside the existing GitHub and GitLab providers. Closes #31.

A gem whose canonical `source_code_uri` points at `codeberg.org` previously resolved **no** repo signals at all: the dispatch in `workflow.rb` only knew `github.com` and `gitlab.com`, so a Forgejo repo fell through to `nil` for `archived`, `last_commit_date`, and (downstream) `activity_level`. Codeberg is the one alternative forge with real, accelerating Ruby presence, and its Gitea API is deliberately GitHub-shaped, so covering it is cheap.

## How

- **`ForgejoClient`** (new) mirrors `GitlabClient` against the Gitea `/api/v1` surface: the repo object's `archived` boolean, and `/commits?limit=1` for the last-commit date (committer date, falling back to author date). `stat`/`verification`/`files` are turned off so a single-commit lookup stays cheap. The `host:` arg defaults to `codeberg.org` but is a parameter so a later self-hosted Forgejo instance reuses the same client.
- **Auth:** anonymous by default; `STILL_ACTIVE_FORGEJO_TOKEN` / `CODEBERG_TOKEN` only raise the rate limit or reach a private repo. No CLI flag, since Codeberg has no ubiquitous CLI to borrow a token from the way `gh`/`glab` do, and the token only ever goes to the hardcoded `codeberg.org` default host (never a lockfile-derived one).
- **`Repository`** now maps host to source via `SOURCE_BY_HOST` + a named-group regex (`codeberg.org` -> `:forgejo`). The rewrite normalizes the host to lowercase before lookup, which also fixes a latent `:GitHub`-vs-`:github` mismatch the old `match[2].to_sym` had under the case-insensitive flag.
- **`workflow.rb`:** new `:forgejo` dispatch cases, plus the deps.dev `project_id` construction extracted to `deps_dev_project_id`. It maps only github/gitlab (the forges deps.dev indexes) and returns `nil` for forgejo, so a Codeberg repo no longer mints a bogus `github.com/owner/name` Scorecard lookup.
- `codeberg.org` added to `HttpHelper::TRUSTED_HOSTS` (redirect-following allowlist).

## Capability dispatch

Per the issue and the provider-seam design, the new source is a duck-typed sibling added to the existing `case source` dispatch — no base class, no formalized interface. (Divergent-capability signals like #32's commits-since-release are handled separately via `respond_to?`/nil when they land.)

## Verification

- `bundle exec rspec` — full suite green (592 examples, 0 failures); `bundle exec rubocop` — no offenses.
- New specs: `forgejo_client_spec.rb` (archived true/false, committer/author date fallback, nil guards, non-success, custom host, token header on/off), plus `repository_spec.rb` (codeberg -> `:forgejo`), `config_spec.rb` (token env cascade), and `workflow_spec.rb` (deps.dev `project_id` nil for forgejo).
- **Dogfooded live** against real repos (not stubs):
  - `bundle exec still_active --gems=link-header-parser --json` (canonical on Codeberg) resolved `repository_url` to `codeberg.org` and pulled `last_commit_date` + `archived: false` through the new client.
  - Direct live calls: GitHub `rails/rails` (fresh commit, `archived: false`) and `thoughtbot/capybara-webkit` + `turbolinks/turbolinks` (`archived: true`); GitLab `gitlab-org/gitlab`; Forgejo `forgejo/forgejo` (active) and a non-existent repo (graceful `nil`).

## Notes

- Private commercial gems (sidekiq-pro/-enterprise from `gems.contribsys.com`, etc.) are unaffected: #43's private-source guard fires first and no forge client is ever reached. A forge client only runs on a valid public github/gitlab/codeberg URL.
- sr.ht and Bitbucket Cloud are intentionally skipped (no `archived` concept / token required for public reads) until a canonical gem is reported there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
