### PR TITLE
feat(github): wait out and retry a near GitHub rate limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Changed
 
+- A GitHub rate-limit response is now waited out and retried once when its reset is near (at most 60 seconds away), instead of silently dropping that gem's repo signals. GitHub's concurrent fan-out can trip the secondary/burst limit even with a token, especially now that the full transitive graph is audited (#60); honouring the `Retry-After` / `x-ratelimit-reset` header lets the run self-heal rather than return blanks. Under the async reactor the wait yields to other fibers rather than blocking. A far-away reset (hourly-limit exhaustion) is not auto-waited; it still warns and moves on (set a token, or run less often). (#35)
 - A gem's activity level is now driven by release recency rather than the most recent of release-or-commit. A single trivial commit (a rubocop autofix, a README tweak) on a gem whose last real release was years ago previously masked the release drought and read as healthy; the commit date is now context only, and stands in for the level solely when a gem has no releases at all (e.g. a git-sourced gem). The "ok" ceiling also moves from 12 to 18 months, calibrated against real RubyGems release cadence rather than the npm-derived annual convention, since healthy mature gems (mime-types, bcrypt, mail) routinely go a year or more between releases. (#32)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ still_active --markdown
 3. `GH_TOKEN` environment variable (`gh` CLI convention)
 4. `gh auth token` (if `gh` is installed and authenticated)
 
-Without a token, GitHub API calls are unauthenticated and rate-limited to 60 requests/hour — you will hit the limit on anything beyond a handful of gems. With a token the limit is 5000 requests/hour.
+Without a token, GitHub API calls are unauthenticated and rate-limited to 60 requests/hour — you will hit the limit on anything beyond a handful of gems. With a token the limit is 5000 requests/hour. When a rate-limit response comes back with a reset that's near (within 60 seconds, typically a secondary/burst limit that the concurrent fan-out can trip even with a token), still_active waits it out and retries rather than dropping that gem's signals; a far-off reset (you've exhausted the hourly limit) isn't waited out, so add a token or run less often.
 
 GitLab cascade mirrors GitHub: `--gitlab-token` → `GITLAB_TOKEN` → `glab auth status --show-token`. Optional for public repos, required for private ones.
 

--- a/lib/still_active/github_client.rb
+++ b/lib/still_active/github_client.rb
@@ -11,10 +11,17 @@ module StillActive
   module GithubClient
     extend self
 
+    # A rate-limit response whose reset is at most this many seconds away is
+    # waited out and retried; a longer wait (hourly-limit exhaustion) is not
+    # auto-taken and falls through to the caller's rescue (warn + nil).
+    MAX_RATE_LIMIT_WAIT = 60
+
     def archived(owner:, name:)
       return if owner.nil? || name.nil?
 
-      StillActive.config.github_client.repository("#{owner}/#{name}")&.archived
+      with_rate_limit_retry("archived #{owner}/#{name}") do
+        StillActive.config.github_client.repository("#{owner}/#{name}")&.archived
+      end
     rescue Octokit::Error, Faraday::Error => e
       $stderr.puts("warning: archived check failed for #{owner}/#{name}: #{e.class}")
       nil
@@ -23,7 +30,9 @@ module StillActive
     def last_commit_date(owner:, name:)
       return if owner.nil? || name.nil?
 
-      commit = StillActive.config.github_client.commits("#{owner}/#{name}", per_page: 1)&.first
+      commit = with_rate_limit_retry("last commit #{owner}/#{name}") do
+        StillActive.config.github_client.commits("#{owner}/#{name}", per_page: 1)&.first
+      end
       date = commit&.commit&.author&.date
       case date
       when Time then date
@@ -47,7 +56,7 @@ module StillActive
 
       repo = "#{owner}/#{name}"
       ["v#{version}", version.to_s].each do |tag|
-        return StillActive.config.github_client.compare(repo, tag, "HEAD").ahead_by
+        return with_rate_limit_retry("unreleased-commits #{repo}") { StillActive.config.github_client.compare(repo, tag, "HEAD").ahead_by }
       rescue Octokit::NotFound
         # this tag form doesn't exist; fall through to try the next one
       end
@@ -58,6 +67,59 @@ module StillActive
     end
 
     private
+
+    # Pause-and-retry on a rate-limit response when the reset is near, so a
+    # transient secondary/burst limit (which GitHub's concurrent fan-out can
+    # trip even with a token) self-heals instead of dropping the gem's signal.
+    # Retries at most once. Under the async reactor, sleep yields to other
+    # fibers rather than blocking the thread.
+    def with_rate_limit_retry(label)
+      retried = false
+      begin
+        yield
+      rescue Octokit::TooManyRequests => e
+        wait = rate_limit_wait(e)
+        if retried || wait.nil? || wait > MAX_RATE_LIMIT_WAIT
+          # Hourly-limit exhaustion (or a far reset): not worth auto-waiting.
+          # Surface the one actionable hint rather than a generic class name,
+          # then return nil so this signal is simply absent for the gem.
+          $stderr.puts("rate limited on #{label}; set GITHUB_TOKEN to raise your limit, or run less often")
+          return
+        end
+
+        retried = true
+        $stderr.puts("rate limited on #{label}; waiting #{wait}s for reset")
+        sleep(wait)
+        retry
+      end
+    end
+
+    # Seconds to wait before retrying, from the Retry-After header (secondary
+    # limits) or x-ratelimit-reset (primary), or nil when neither is present.
+    def rate_limit_wait(error)
+      # Octokit normalises response headers to lowercase (Faraday is
+      # case-insensitive), so a single lowercase lookup covers any casing.
+      headers = response_headers(error)
+      return if headers.nil? || headers.empty?
+
+      if (retry_after = headers["retry-after"])
+        return retry_after.to_i
+      end
+
+      reset = headers["x-ratelimit-reset"]
+      return if reset.nil?
+
+      [reset.to_i - Time.now.to_i, 0].max
+    end
+
+    # Octokit raises NoMethodError reading headers off an error with no response
+    # attached; treat only that as "can't tell" so the limiter degrades to no
+    # wait, while a real NoMethodError elsewhere still surfaces.
+    def response_headers(error)
+      error.response_headers
+    rescue NoMethodError
+      nil
+    end
 
     def parse_commit_date(date, owner, name)
       Time.parse(date)

--- a/spec/still_active/github_client_spec.rb
+++ b/spec/still_active/github_client_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe(StillActive::GithubClient) do
     end
 
     it("returns nil and warns on an Octokit error") do
-      allow(client).to(receive(:commits).and_raise(Octokit::TooManyRequests))
+      allow(client).to(receive(:commits).and_raise(Octokit::InternalServerError))
       expect { expect(described_class.last_commit_date(owner: owner, name: name)).to(be_nil) }
         .to(output(/last commit check failed/).to_stderr)
     end
@@ -73,6 +73,57 @@ RSpec.describe(StillActive::GithubClient) do
       allow(client).to(receive(:commits).and_return([commit_with("not-a-date")]))
       expect { expect(described_class.last_commit_date(owner: owner, name: name)).to(be_nil) }
         .to(output(/could not parse commit date/).to_stderr)
+    end
+  end
+
+  describe("rate-limit retry") do
+    before { allow(described_class).to(receive(:sleep)) } # never actually wait in specs
+
+    def too_many(retry_after: nil, reset: nil)
+      headers = {}
+      headers["retry-after"] = retry_after.to_s if retry_after
+      headers["x-ratelimit-reset"] = reset.to_s if reset
+      error = Octokit::TooManyRequests.new
+      allow(error).to(receive(:response_headers).and_return(headers))
+      error
+    end
+
+    it("waits for a near reset and retries once, then succeeds") do
+      calls = 0
+      allow(client).to(receive(:repository)) do
+        calls += 1
+        raise too_many(retry_after: 2) if calls == 1
+
+        double(archived: false)
+      end
+
+      expect { expect(described_class.archived(owner: owner, name: name)).to(be(false)) }.to(output(/rate limited/).to_stderr)
+      expect(described_class).to(have_received(:sleep).with(2))
+    end
+
+    it("derives the wait from x-ratelimit-reset when retry-after is absent") do
+      calls = 0
+      allow(client).to(receive(:repository)) do
+        calls += 1
+        raise too_many(reset: Time.now.to_i + 3) if calls == 1
+
+        double(archived: true)
+      end
+
+      expect { expect(described_class.archived(owner: owner, name: name)).to(be(true)) }.to(output.to_stderr)
+      expect(described_class).to(have_received(:sleep))
+    end
+
+    it("does not auto-wait when the reset is far away; warns with the token hint and returns nil") do
+      allow(client).to(receive(:repository).and_raise(too_many(retry_after: 9999)))
+      expect { expect(described_class.archived(owner: owner, name: name)).to(be_nil) }.to(output(/set GITHUB_TOKEN/).to_stderr)
+      expect(described_class).not_to(have_received(:sleep))
+    end
+
+    it("retries at most once on a persistent rate limit, then gives up with the token hint") do
+      allow(client).to(receive(:repository).and_raise(too_many(retry_after: 1)))
+      expect { expect(described_class.archived(owner: owner, name: name)).to(be_nil) }.to(output(/waiting 1s.*set GITHUB_TOKEN/m).to_stderr)
+      expect(described_class).to(have_received(:sleep).once)
     end
   end
 
@@ -106,7 +157,7 @@ RSpec.describe(StillActive::GithubClient) do
     end
 
     it("returns nil and warns on a non-NotFound Octokit error") do
-      allow(client).to(receive(:compare).and_raise(Octokit::TooManyRequests))
+      allow(client).to(receive(:compare).and_raise(Octokit::InternalServerError))
       expect { expect(described_class.commits_since_release(owner: owner, name: name, version: "7.0.1")).to(be_nil) }
         .to(output(/unreleased-commits check failed/).to_stderr)
     end


### PR DESCRIPTION
## What

On a GitHub rate-limit response, still_active now waits out a *near* reset and retries once, instead of silently dropping that gem's repo signals. Part of the #35 roadmap (reliability of the live-API signals).

## Why now

`GithubClient` used to rescue `Octokit::TooManyRequests` and return `nil`, so a rate-limited call quietly lost the archived / last-commit / unreleased-commits signal for that gem. With the full transitive graph audited by default since #60, the concurrent fan-out can trip GitHub's **secondary/burst limit even with a token**, so a single audit of a large lockfile could come back with blanks for a chunk of the graph and no clear reason.

## How

`with_rate_limit_retry` wraps the three Octokit calls (`archived`, `last_commit_date`, `commits_since_release`). On `Octokit::TooManyRequests`:
- It reads the reset from `Retry-After` (secondary limit) or `x-ratelimit-reset` (primary).
- If the reset is **near (≤ 60s)**, it waits and retries **once**. Under the `async` reactor the `sleep` yields to other fibers rather than blocking the thread (confirmed the scheduler is `Async::Reactor`), and there's no shared state — each call owns a one-shot retry flag, so it can't loop.
- If the reset is **far off** (you've exhausted the hourly limit), it does *not* auto-wait. Instead of a generic "check failed: Octokit::TooManyRequests" it now prints the one actionable line, **`set GITHUB_TOKEN to raise your limit, or run less often`**, and moves on with the signal absent.

Scoped to the GitHub/Octokit path, which is the limit that actually bites; GitLab/Forgejo/deps.dev go through `HttpHelper` and rarely hit theirs.

This is the **reactive layer**. A proactive shared limiter that throttles *before* hitting zero (reading `X-RateLimit-Remaining` off each response) is a natural follow-up, and is tractable here precisely because the fan-out is single-threaded async fibers (a shared counter needs no locks).

## Verification

- `bundle exec rspec` — 667 examples, 0 failures; `bundle exec rubocop` — no offenses. New specs cover: retry-once-then-succeed, deriving the wait from `x-ratelimit-reset`, the far-reset give-up (token hint, no sleep), and the bounded one-retry-then-give-up.
- **Happy path dogfooded live** (`--gems=rails,sidekiq`): the wrapper doesn't disturb unthrottled calls — archived/last-commit resolve normally.
- Honest caveat: I can't summon a real 403 secondary limit on demand, so the throttle path itself is unit-tested and reasoned (async `sleep` semantics, header parsing), not live-triggered.

## Review notes

A silent-failure review caught that the exhaustion case was degrading the actionable "set a token" advice to a generic class name; fixed (the hint is now emitted at the point it's surfaced). The `NoMethodError` rescue (needed because Octokit raises it reading headers off a response-less error) was narrowed from the whole method to just the header read, so a real bug there still surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
