### PR TITLE
chore(release): bump to 2.0.0 + upgrade notes (prep — merge when ready)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Upgrading to 2.0
+
+2.0 is a major bump because two changes can alter `--fail-if-*` outcomes on upgrade (the CLI flags and JSON `schema_version` are otherwise backward-compatible):
+
+- **Transitive by default.** Maintenance signals now cover the full resolved lockfile, so a CI gate can newly fail on a transitive critical/vulnerable/outdated gem. Add `--direct-only` to restore the pre-2.0 declared-deps scope.
+- **Activity recalibration.** The "ok" ceiling moved 12 → 18 months and the level is release-driven, so some gems are reclassified. Tune with `--safe-range-end` / `--warning-range-end`.
+- **Baselines:** re-capture your `--baseline` JSON after upgrading. The transitive expansion shows the new gems as additions (and any unhealthy transitive deps as regressions) on the first run.
+
 ### Added
 
 - The `--json` output is now a **versioned, contract-tested machine schema** ([`docs/still_active.schema.json`](docs/still_active.schema.json), JSON Schema 2020-12), carried as a `$schema` URL so the output is self-describing, and it gains a `summary{}` digest, the audit's headline posture (total / direct / transitive, the activity-level breakdown, archived / up-to-date / outdated counts, and vulnerability totals) in one object so a machine or LLM consumer reads it without iterating every gem. The terminal summary line now derives from the same digest, so the human and machine summaries can't drift. Unlike SARIF (findings-only) and CycloneDX (SBOM-only), this is the complete correlation-layer view. (#33)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    still_active (1.6.0)
+    still_active (2.0.0)
       async (>= 2.2)
       bundler (>= 2.0)
       faraday-retry
@@ -244,7 +244,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   sawyer (0.9.3) sha256=0d0f19298408047037638639fe62f4794483fb04320269169bd41af2bdcf5e41
   simpleidn (0.2.3) sha256=08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29
-  still_active (1.6.0)
+  still_active (2.0.0)
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   traces (0.18.2) sha256=80f1649cb4daace1d7174b81f3b3b7427af0b93047759ba349960cb8f315e214

--- a/lib/still_active/version.rb
+++ b/lib/still_active/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module StillActive
-  VERSION = "1.6.0"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
**Prep only — does not publish anything.** `publish.yml` triggers on a *published GitHub Release*; pushing this to main just sets the in-development version. rubygems stays on 1.6.0 until you cut the release. Fully reversible.

- `version.rb` 1.6.0 → 2.0.0 (Gemfile.lock self-reference follows)
- CHANGELOG: an **Upgrading to 2.0** section (transitive-default → `--direct-only`, activity recalibration → `--safe-range-end`, re-baseline note)

**Left un-auto-merged on purpose** — merge once Bradley's weighed in and you've confirmed 2.0.0. At release time: flip the CHANGELOG `[Unreleased]` → `[2.0.0] - <date>`, then `gh release create v2.0.0`.