### PR TITLE
feat: OpenSSF Maintained sub-check + categorical gem status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Each gem now carries the OpenSSF Scorecard **`Maintained` sub-check** (`scorecard_maintained`, 0.0–10.0) alongside the aggregate `scorecard_score`. The sub-check scores recent commit and issue activity directly, the question still_active exists to answer, and it was already present in the deps.dev response still_active fetches (previously discarded). `nil` when a project has no scorecard, deliberately distinct from `0.0` ("measured: unmaintained") so absent data never reads as healthy.
+- A single categorical **`status`** per gem (`"vulnerable"`, `"archived"`, `"critical"`, `"stale"`, `"ok"`, or `"unknown"`) and a project-level `summary.status`, so a machine/LLM consumer or another tool reads one verdict instead of re-deriving it from `activity_level` + `archived` + `vulnerability_count`. Worst-concern wins (a vulnerability outranks staleness), an EOL Ruby raises the project floor to `critical`, and `"unknown"` is preserved rather than collapsed to `"ok"`. This is a display/threshold convenience layered over the raw fields, not the numeric 0–100 composite removed earlier (which let missing data read as perfect health). Documented in `docs/schema.md`. Both fields are additive, so `schema_version` stays `1`.
+
 ## [2.0.0] - 2026-06-14
 
 ### Upgrading to 2.0

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -46,6 +46,7 @@ A digest so a consumer reads the headline posture without iterating every gem. C
 | `outdated` | integer | Gems not on the latest version (`up_to_date == false`). |
 | `vulnerable_gems` | integer | Gems with at least one advisory. |
 | `vulnerabilities` | integer | Total advisories across all gems. |
+| `status` | string | The single worst per-gem `status` (see below), raised to `"critical"` when Ruby is EOL. `"unknown"` only when nothing better is known. The project-level posture in one word. |
 | `ruby_eol` | bool \| absent | `true` if the project's Ruby has reached EOL. Absent when Ruby info isn't detectable. |
 
 ## Per-gem fields
@@ -66,6 +67,8 @@ A digest so a consumer reads the headline posture without iterating every gem. C
 | `activity_level` | string | Derived maintenance verdict: `"ok"`, `"stale"`, `"critical"`, `"archived"`, or `"unknown"`. Driven by release recency, with the last commit used only as a fallback when a gem has no releases. |
 | `unreleased_commits` | integer \| null \| absent | Present only with `--unreleased-commits`. Commits on the default branch since the latest release's tag (GitHub-hosted gems only; `null` for non-GitHub sources or when the tag can't be resolved). Informational, never a gate. Inflated for monorepos and release-branch projects (the count covers the whole repo / the next-version trunk), so read it as a lead, not a verdict. |
 | `scorecard_score` | float \| nil | OpenSSF Scorecard score 0.0–10.0 from deps.dev. |
+| `scorecard_maintained` | float \| nil | OpenSSF Scorecard `Maintained` sub-check 0.0–10.0 (recent commit and issue activity) from deps.dev. `nil` when the project has no scorecard, distinct from `0.0` ("measured: unmaintained"). |
+| `status` | string | Single categorical verdict folding the signals together: `"vulnerable"`, `"archived"`, `"critical"`, `"stale"`, `"ok"`, or `"unknown"`. Worst-concern wins (a vulnerability outranks staleness); `"unknown"` when there's no data, never silently `"ok"`. A display/threshold convenience; the individual fields remain authoritative. |
 | `vulnerability_count` | integer | Number of advisories affecting `version_used`. |
 | `vulnerabilities` | array | One entry per advisory (see below). |
 | `alternatives` | array \| absent | Present only with `--alternatives` on an archived/critical **direct** gem: up to three maintained Ruby Toolbox leads to verify. Direct-only by design (you can't swap a gem you didn't choose). |

--- a/docs/still_active.schema.json
+++ b/docs/still_active.schema.json
@@ -53,6 +53,7 @@
         "outdated": { "type": "integer", "minimum": 0 },
         "vulnerable_gems": { "type": "integer", "minimum": 0 },
         "vulnerabilities": { "type": "integer", "minimum": 0 },
+        "status": { "type": "string", "enum": ["ok", "stale", "critical", "archived", "vulnerable", "unknown"] },
         "ruby_eol": { "type": "boolean" }
       }
     },
@@ -73,8 +74,10 @@
         "last_commit_date": { "type": ["string", "null"], "format": "date-time" },
         "archived": { "type": ["boolean", "null"] },
         "activity_level": { "type": "string", "enum": ["ok", "stale", "critical", "archived", "unknown"] },
+        "status": { "type": "string", "enum": ["ok", "stale", "critical", "archived", "vulnerable", "unknown"] },
         "unreleased_commits": { "type": ["integer", "null"] },
         "scorecard_score": { "type": ["number", "null"] },
+        "scorecard_maintained": { "type": ["number", "null"] },
         "vulnerability_count": { "type": "integer", "minimum": 0 },
         "vulnerabilities": { "type": "array", "items": { "$ref": "#/$defs/vulnerability" } },
         "alternatives": { "type": "array", "items": { "type": "string" } },

--- a/lib/helpers/status_helper.rb
+++ b/lib/helpers/status_helper.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative "activity_helper"
+
+module StillActive
+  # Collapses a gem's several maintenance signals into one categorical verdict,
+  # so a machine/LLM consumer (or another tool's report) can display and threshold
+  # a single value instead of re-deriving it from activity_level + archived +
+  # vulnerability_count. This is deliberately NOT a numeric composite: an earlier
+  # 0-100 score was removed because a weighted average let missing data read as
+  # "perfect health". Here, :unknown stays :unknown -- absence of data is never
+  # rendered as :ok.
+  module StatusHelper
+    extend self
+
+    # Worst-first. A known vulnerability is the most actionable single concern;
+    # below it, activity_level already ranks archived > critical > stale > ok;
+    # :unknown (no data) is least severe because it is an absence, not a finding.
+    SEVERITY = [:unknown, :ok, :stale, :critical, :archived, :vulnerable].freeze
+
+    # Returns :vulnerable, :archived, :critical, :stale, :ok, or :unknown.
+    def gem_status(gem_data)
+      return :vulnerable if gem_data[:vulnerability_count].to_i.positive?
+
+      ActivityHelper.activity_level(gem_data)
+    end
+
+    # The single worst gem status across the audit, with an EOL Ruby raising the
+    # floor to :critical. :unknown only wins when nothing better is known.
+    def project_status(result, ruby_info: nil)
+      statuses = result.each_value.map { |data| gem_status(data) }
+      statuses << :critical if ruby_info&.dig(:eol) == true
+      return :unknown if statuses.empty?
+
+      # Every value gem_status returns is in SEVERITY today; if a future status
+      # isn't, rank it most-severe so it surfaces in the rollup rather than being
+      # silently masked by a milder finding.
+      statuses.max_by { |status| SEVERITY.index(status) || SEVERITY.length }
+    end
+  end
+end

--- a/lib/helpers/summary_helper.rb
+++ b/lib/helpers/summary_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "activity_helper"
+require_relative "status_helper"
 
 module StillActive
   # Builds the JSON output's summary{} digest: the headline posture of the audit
@@ -40,6 +41,9 @@ module StillActive
         outdated: outdated,
         vulnerable_gems: vulnerable_gems,
         vulnerabilities: vulnerabilities,
+        # The single worst per-gem verdict (plus EOL Ruby), so a consumer reads
+        # one project-level posture without scanning every gem's status.
+        status: StatusHelper.project_status(result, ruby_info: ruby_info),
       }
       summary[:ruby_eol] = ruby_info[:eol] == true if ruby_info
       summary

--- a/lib/still_active/cli.rb
+++ b/lib/still_active/cli.rb
@@ -11,6 +11,7 @@ require_relative "../helpers/diff_markdown_helper"
 require_relative "../helpers/emoji_helper"
 require_relative "../helpers/markdown_helper"
 require_relative "../helpers/sarif_helper"
+require_relative "../helpers/status_helper"
 require_relative "../helpers/summary_helper"
 require_relative "../helpers/terminal_helper"
 require_relative "../helpers/version_helper"
@@ -74,7 +75,12 @@ module StillActive
             summary: SummaryHelper.summarize(result, ruby_info: ruby_info),
             # Surface the derived verdict so a machine/LLM consumer reads it
             # directly instead of re-deriving it from the raw dates.
-            gems: result.transform_values { |data| data.merge(activity_level: ActivityHelper.activity_level(data)) },
+            gems: result.transform_values do |data|
+              data.merge(
+                activity_level: ActivityHelper.activity_level(data),
+                status: StatusHelper.gem_status(data),
+              )
+            end,
           }
           output[:ruby] = ruby_info if ruby_info
           output[:pr_context] = pr_context if pr_context

--- a/lib/still_active/deps_dev_client.rb
+++ b/lib/still_active/deps_dev_client.rb
@@ -34,6 +34,11 @@ module StillActive
       {
         score: scorecard["overallScore"],
         date: scorecard["date"],
+        # The "Maintained" sub-check (0-10) scores recent commit and issue
+        # activity directly -- still_active's core question -- so we surface it
+        # alongside the aggregate. nil when the check is absent (never 0, which
+        # would read as "unmaintained" rather than "not measured").
+        maintained: maintained_check_score(scorecard),
       }
     end
 
@@ -57,6 +62,14 @@ module StillActive
     end
 
     private
+
+    # The OpenSSF "Maintained" check score (0-10), or nil when it's absent. A
+    # malformed (non-array) `checks` payload also yields nil rather than raising:
+    # this is a best-effort enrichment and must never crash the per-gem audit and
+    # vanish the gem from the output via the workflow's rescue.
+    def maintained_check_score(scorecard)
+      Array(scorecard["checks"]).find { |c| c.is_a?(Hash) && c["name"] == "Maintained" }&.dig("score")
+    end
 
     # Builds a deps.dev project id ("host/owner/repo", or a deeper path for
     # GitLab subgroups) from the SOURCE_REPO link URL. GitHub/Bitbucket projects

--- a/lib/still_active/workflow.rb
+++ b/lib/still_active/workflow.rb
@@ -163,8 +163,15 @@ module StillActive
       source, owner, name = repo_info.values_at(:source, :owner, :name)
       deps_dev = gem_version ? fetch_deps_dev_info(gem_name: gem_name, version: gem_version, advisory_db: advisory_db) : {}
 
-      # Fall back to repo-derived project_id for scorecard when deps.dev doesn't have the version
-      deps_dev[:scorecard_score] ||= DepsDevClient.project_scorecard(project_id: repo_info[:project_id])&.dig(:score)
+      # Fall back to repo-derived project_id for scorecard when deps.dev doesn't
+      # have the version. Use ||= so a maintained score already found via the
+      # version's scorecard is never clobbered by a nil from the repo fallback
+      # (0.0 is truthy, so a measured "unmaintained" is preserved too).
+      if deps_dev[:scorecard_score].nil?
+        fallback = DepsDevClient.project_scorecard(project_id: repo_info[:project_id])
+        deps_dev[:scorecard_score] ||= fallback&.dig(:score)
+        deps_dev[:scorecard_maintained] ||= fallback&.dig(:maintained)
+      end
 
       signals = repo_signals(source:, repository_owner: owner, repository_name: name)
       result_object[gem_name].merge!({
@@ -198,6 +205,7 @@ module StillActive
       vulnerabilities = VulnerabilityHelper.merge_advisories(deps_dev: deps_dev_vulns, ruby_advisory_db: radb_vulns)
       {
         scorecard_score: scorecard&.dig(:score),
+        scorecard_maintained: scorecard&.dig(:maintained),
         vulnerability_count: vulnerabilities.length,
         vulnerabilities: vulnerabilities,
       }

--- a/spec/still_active/deps_dev_client_spec.rb
+++ b/spec/still_active/deps_dev_client_spec.rb
@@ -119,6 +119,49 @@ RSpec.describe(StillActive::DepsDevClient) do
 
       expect(described_class.project_scorecard(project_id: "github.com/sparklemotion/nokogiri")).to(be_nil)
     end
+
+    it("extracts the OpenSSF 'Maintained' sub-check score") do
+      stub_request(:get, /api\.deps\.dev/).to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          scorecard: {
+            overallScore: 7.5,
+            date: "2026-01-02",
+            checks: [
+              { name: "Code-Review", score: 8 },
+              { name: "Maintained", score: 10 },
+            ],
+          },
+        }.to_json,
+      )
+
+      result = described_class.project_scorecard(project_id: "github.com/some/repo")
+
+      expect(result).to(include(score: 7.5, maintained: 10))
+    end
+
+    it("reports a nil 'Maintained' score when the check is absent") do
+      stub_request(:get, /api\.deps\.dev/).to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: { scorecard: { overallScore: 6.0, date: "2026-01-02", checks: [] } }.to_json,
+      )
+
+      expect(described_class.project_scorecard(project_id: "github.com/some/repo")).to(include(maintained: nil))
+    end
+
+    it("degrades to a nil 'Maintained' score on a malformed checks payload (does not crash the gem)") do
+      stub_request(:get, /api\.deps\.dev/).to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        # A non-array `checks` is a contract violation; it must not raise and
+        # vanish the gem from the whole audit via the per-gem rescue.
+        body: { scorecard: { overallScore: 6.0, date: "2026-01-02", checks: { "Maintained" => 10 } } }.to_json,
+      )
+
+      expect(described_class.project_scorecard(project_id: "github.com/some/repo")).to(include(maintained: nil))
+    end
   end
 
   describe("#extract_project_id (SOURCE_REPO URL parsing)") do

--- a/spec/still_active/status_helper_spec.rb
+++ b/spec/still_active/status_helper_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/helpers/status_helper"
+
+RSpec.describe(StillActive::StatusHelper) do
+  def recent = (Time.now - (30 * 24 * 60 * 60)) # ~1 month ago -> :ok
+  def ancient = (Time.now - (5 * 365 * 24 * 60 * 60)) # ~5 years ago -> :critical
+
+  describe(".gem_status") do
+    it("is :vulnerable when the gem has any vulnerability, even if otherwise fresh") do
+      data = { latest_version_release_date: recent, vulnerability_count: 1 }
+      expect(described_class.gem_status(data)).to(eq(:vulnerable))
+    end
+
+    it("is :vulnerable in preference to :archived") do
+      data = { archived: true, vulnerability_count: 2 }
+      expect(described_class.gem_status(data)).to(eq(:vulnerable))
+    end
+
+    it("is :archived for an archived repo with no vulnerabilities") do
+      data = { archived: true, vulnerability_count: 0 }
+      expect(described_class.gem_status(data)).to(eq(:archived))
+    end
+
+    it("is :ok for a recently released, unflagged gem") do
+      data = { latest_version_release_date: recent, vulnerability_count: 0 }
+      expect(described_class.gem_status(data)).to(eq(:ok))
+    end
+
+    it("is :critical for a gem whose last release is years old") do
+      data = { latest_version_release_date: ancient, vulnerability_count: 0 }
+      expect(described_class.gem_status(data)).to(eq(:critical))
+    end
+
+    it("is :unknown when there is no activity data and vulnerabilities were not measured") do
+      expect(described_class.gem_status({})).to(eq(:unknown))
+    end
+
+    it("does not let an unmeasured vulnerability count read as vulnerable") do
+      data = { latest_version_release_date: recent } # vulnerability_count absent
+      expect(described_class.gem_status(data)).to(eq(:ok))
+    end
+  end
+
+  describe(".project_status") do
+    it("is the worst status across all gems") do
+      result = {
+        "a" => { latest_version_release_date: recent, vulnerability_count: 0 }, # ok
+        "b" => { archived: true, vulnerability_count: 0 },                      # archived
+        "c" => { latest_version_release_date: ancient, vulnerability_count: 0 }, # critical
+      }
+      expect(described_class.project_status(result)).to(eq(:archived))
+    end
+
+    it("is :vulnerable when any gem is vulnerable") do
+      result = {
+        "a" => { latest_version_release_date: recent, vulnerability_count: 0 },
+        "b" => { latest_version_release_date: recent, vulnerability_count: 1 },
+      }
+      expect(described_class.project_status(result)).to(eq(:vulnerable))
+    end
+
+    it("is at least :critical when Ruby is EOL even if every gem is ok") do
+      result = { "a" => { latest_version_release_date: recent, vulnerability_count: 0 } }
+      expect(described_class.project_status(result, ruby_info: { eol: true })).to(eq(:critical))
+    end
+
+    it("is :unknown for an empty result") do
+      expect(described_class.project_status({})).to(eq(:unknown))
+    end
+
+    it("ignores :unknown gems when a known status is present") do
+      result = {
+        "a" => {}, # unknown
+        "b" => { latest_version_release_date: recent, vulnerability_count: 0 }, # ok
+      }
+      expect(described_class.project_status(result)).to(eq(:ok))
+    end
+  end
+end


### PR DESCRIPTION
## What

Two additive, machine-readable maintenance signals:

1. **`scorecard_maintained`** per gem — the OpenSSF Scorecard **`Maintained`** sub-check (0–10: recent commit + issue activity). deps.dev already returns the full `checks` array; still_active kept only the aggregate `scorecard_score` and discarded the rest, so this is surfaced at no extra fetch.
2. **`status`** per gem + a project-level **`summary.status`** — a single categorical verdict (`vulnerable` / `archived` / `critical` / `stale` / `ok` / `unknown`) so a consumer reads one value instead of re-deriving it from `activity_level` + `archived` + `vulnerability_count`.

## Design notes

- **Missing data never reads as healthy.** `scorecard_maintained` is `nil` (not `0.0`) when a project has no scorecard — `0.0` means "measured: unmaintained". `status` keeps `unknown` rather than collapsing it to `ok`. This is deliberately not a numeric composite, whose weighted average would let absent data read as perfect health.
- **`status` precedence:** worst-concern wins (`vulnerable > archived > critical > stale > ok`); an EOL Ruby floors the project at `critical`. It's a display/threshold convenience; the individual fields stay authoritative.
- Both fields are additive, so **`schema_version` stays 1**.

## Tests

TDD throughout. New `status_helper_spec` plus deps.dev `Maintained`-extraction and malformed-payload specs. Full suite green (rubocop clean). Real `--json` output validated against the shipped schema, and dogfooded across the full transitive graph and a git/path/vulnerable edge-case lockfile.

Documented in `docs/schema.md`; `CHANGELOG.md` updated.
