### PR TITLE
test: hermetic token resolution (local suite behaves like CI)

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,4 +15,19 @@ end
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
+
+  # Hermetic token resolution: neutralise the host's GitHub/GitLab CLI auth and
+  # ambient token env vars by default, so the suite behaves identically on a dev
+  # machine (which may have `gh`/`glab` logged in) and in CI (which doesn't). A
+  # GitHub token quietly present locally otherwise masks token-dependent
+  # failures -- e.g. the ecosyste.ms fallback only engages without a token --
+  # until they surface in CI. Specs that need a token set it explicitly;
+  # config_spec overrides these to exercise the real discovery cascade. Only the
+  # gh/glab auth shell-outs are stubbed (git calls in BotContext pass through).
+  config.before do
+    ["GITHUB_TOKEN", "GH_TOKEN", "GITLAB_TOKEN"].each { |var| ENV.delete(var) }
+    allow(Open3).to(receive(:capture3).and_call_original)
+    allow(Open3).to(receive(:capture3).with("gh", "auth", "token").and_raise(Errno::ENOENT))
+    allow(Open3).to(receive(:capture3).with("glab", "auth", "status", "--hostname=gitlab.com", "--show-token").and_raise(Errno::ENOENT))
+  end
 end

--- a/spec/still_active/config_spec.rb
+++ b/spec/still_active/config_spec.rb
@@ -3,6 +3,16 @@
 RSpec.describe(StillActive::Config) do
   before { StillActive.reset }
 
+  describe("hermetic test environment") do
+    # Proves the spec_helper guard works: even on a dev machine with `gh` logged
+    # in, the suite must not pick up a real token (which would mask the
+    # token-dependent ecosyste.ms fallback path). No env-stripping here on
+    # purpose -- the global spec_helper hook is what must neutralise the host.
+    it("resolves no GitHub token by default, regardless of the host") do
+      expect(described_class.new.github_oauth_token).to(be_nil)
+    end
+  end
+
   describe("github_oauth_token discovery") do
     around do |example|
       original = ENV.to_hash


### PR DESCRIPTION
## What

Make the test suite hermetic with respect to GitHub/GitLab CLI auth, so it behaves identically on a dev machine and in CI.

## Why

`#84` shipped with green local tests but **failed in CI**: the ecosyste.ms fallback dispatch reads `github_oauth_token`, and a token present locally (via `gh auth`) silently routed token-dependent specs down the GitHub path — masking failures that only surfaced in CI's no-token environment. The root cause is non-hermetic tests, not the runner; the fix is the suite, not a container.

## How

A global `spec_helper` hook clears `GITHUB_TOKEN`/`GH_TOKEN`/`GITLAB_TOKEN` and stubs the `gh`/`glab` auth shell-outs by default, so no spec can pick up the host's token. Only those two shell-outs are stubbed — `git` calls in `BotContext` pass through. Specs that need a token set it explicitly; `config_spec` overrides to exercise the real discovery cascade.

A guard spec asserts the default resolves **no** token even on a host with `gh` logged in.

## Verified

Full suite green **on a machine with `gh` authenticated** (731 examples) — proving the host token is neutralised without breaking any token-dependent spec. CI (no token) is the other half of the proof.

(Considered a Dockerised test env for host-independence; it's the wrong tool here — still_active is pure-Ruby with stubbed HTTP, so there are no system deps to containerise, and hermetic tests fix the bug class everywhere for free.)
