### PR TITLE
feat: SBOM reader surfaces unassessable deps (no silent drop of git/path/unsupported)

### DIFF
--- a/lib/still_active/sbom_reader.rb
+++ b/lib/still_active/sbom_reader.rb
@@ -6,18 +6,22 @@ require "package_url"
 module StillActive
   # Reads a CycloneDX SBOM (e.g. produced by Syft) into a clean, normalized
   # dependency set -- the breadth input for non-Ruby ecosystems, where the
-  # maintenance lens runs over deps.dev/ecosyste.ms. Encodes the filtering
-  # recipe validated against real repos:
-  #   - only `type: library` components (file/application carry no PURL);
-  #   - map the PURL type to an ecosystem we can look up; drop the rest
-  #     (pkg:github = GitHub Actions, pkg:generic = opaque binaries);
-  #   - strip Syft's `?package-id` qualifier and `#subpath`;
-  #   - reconstruct the registry name (npm `@scope/name`, maven `group:artifact`);
-  #   - dedup, since the same package surfaces from manifest + lock + install.
-  # Returns [{ ecosystem:, name:, version: }]. Never raises -- a bad/missing SBOM
-  # yields [], so a best-effort breadth input can't crash the run.
+  # maintenance lens runs over deps.dev/ecosyste.ms.
+  #
+  # `parse` returns both the assessable dependencies AND the components it could
+  # NOT assess (a real dependency in an unsupported ecosystem, or a library with
+  # no PURL -- typically a git/path/local source). Surfacing those is the point:
+  # silently dropping them would let an audit report "all clear" while ignoring
+  # the deps that are often the riskiest. Genuine non-package noise (GitHub
+  # Actions `pkg:github`, opaque binaries `pkg:generic`, and file/application
+  # components) is excluded, not surfaced.
+  #
+  # `read` keeps the simple "just the dependencies" shape. Never raises -- a
+  # missing/malformed SBOM or a bad PURL degrades to empty/skip.
   module SbomReader
     extend self
+
+    Result = Data.define(:dependencies, :unassessable)
 
     # PURL type -> still_active ecosystem (also the deps.dev `system`, lowercased).
     ECOSYSTEMS = {
@@ -30,51 +34,70 @@ module StillActive
       "nuget" => :nuget,
     }.freeze
 
-    def read(path)
-      read_string(File.read(path))
+    # PURL types that are not package dependencies: CI actions and opaque
+    # binaries. Excluded from both lists (not "unassessed deps").
+    NOISE_TYPES = ["github", "generic"].freeze
+
+    def read(path) = parse(path).dependencies
+    def read_string(body) = parse_string(body).dependencies
+
+    def parse(path)
+      parse_string(File.read(path))
     rescue SystemCallError, IOError
-      [] # missing/unreadable file -> no deps, never raise
+      Result.new(dependencies: [], unassessable: [])
     end
 
-    def read_string(body)
+    def parse_string(body)
       doc = JSON.parse(body)
       components = doc.is_a?(Hash) ? doc["components"] : nil
-      return [] unless components.is_a?(Array)
+      return Result.new(dependencies: [], unassessable: []) unless components.is_a?(Array)
 
-      components.filter_map { |component| component_to_dep(component) }.uniq
+      deps = []
+      unassessable = []
+      components.each do |component|
+        kind, entry = classify(component)
+        deps << entry if kind == :dependency
+        unassessable << entry if kind == :unassessable
+      end
+      Result.new(dependencies: deps.uniq, unassessable: unassessable.uniq)
     rescue JSON::ParserError
-      []
+      Result.new(dependencies: [], unassessable: [])
     end
 
     private
 
-    def component_to_dep(component)
-      return unless component.is_a?(Hash) && component["type"] == "library"
+    # [:dependency, {...}] | [:unassessable, {...}] | nil (non-package noise).
+    def classify(component)
+      return nil unless component.is_a?(Hash) && component["type"] == "library"
 
+      name = component["name"]
       purl = component["purl"]
-      return unless purl.is_a?(String) && !purl.empty?
+      return [:unassessable, { ecosystem: nil, name: name, reason: :no_purl }] unless purl.is_a?(String) && !purl.empty?
 
-      parse_purl(purl)
+      classify_purl(purl, name)
     end
 
-    # Parse via the official package-url gem (spec-compliant: percent-decoding,
-    # qualifier/subpath stripping, namespace handling). A malformed PURL on one
-    # component is skipped, not fatal -- a best-effort breadth input must never
-    # crash the read.
-    def parse_purl(purl)
+    def classify_purl(purl, name)
       parsed = PackageURL.parse(purl)
-      ecosystem = ECOSYSTEMS[parsed.type&.downcase]
-      return if ecosystem.nil? || parsed.name.to_s.empty? || parsed.version.to_s.empty?
+      type = parsed.type&.downcase
+      ecosystem = ECOSYSTEMS[type]
 
-      { ecosystem: ecosystem, name: build_name(ecosystem, parsed.namespace, parsed.name), version: parsed.version }
+      if ecosystem
+        return [:unassessable, { ecosystem: type, name: name, reason: :no_version }] if parsed.version.to_s.empty?
+
+        [:dependency, { ecosystem: ecosystem, name: build_name(ecosystem, parsed.namespace, parsed.name), version: parsed.version }]
+      elsif NOISE_TYPES.include?(type)
+        nil # CI actions / opaque binaries: not a package dependency
+      else
+        [:unassessable, { ecosystem: type, name: name, reason: :unsupported_ecosystem }]
+      end
     rescue PackageURL::InvalidPackageURL
-      nil # one malformed PURL must not kill the read; a real bug still surfaces
+      [:unassessable, { ecosystem: nil, name: name, reason: :malformed_purl }]
     end
 
-    # Reconstruct the lookup name from the PURL's namespace + name. The namespace
-    # carries the npm scope (`@scope/name`), the maven group (`group:artifact`),
-    # and the Go module path prefix (`github.com/owner/name`); pypi/cargo/gem/
-    # nuget have no namespace and use the bare name.
+    # Reconstruct the lookup name from the PURL's namespace + name: npm
+    # `@scope/name`, maven `group:artifact`, Go module path `github.com/owner/name`;
+    # pypi/cargo/gem/nuget have no namespace and use the bare name.
     def build_name(ecosystem, namespace, name)
       return name if namespace.to_s.empty?
 

--- a/lib/still_active/sbom_reader.rb
+++ b/lib/still_active/sbom_reader.rb
@@ -68,7 +68,7 @@ module StillActive
 
     # [:dependency, {...}] | [:unassessable, {...}] | nil (non-package noise).
     def classify(component)
-      return nil unless component.is_a?(Hash) && component["type"] == "library"
+      return unless component.is_a?(Hash) && component["type"] == "library"
 
       name = component["name"]
       purl = component["purl"]

--- a/spec/fixtures/sbom/sample.cdx.json
+++ b/spec/fixtures/sbom/sample.cdx.json
@@ -13,6 +13,7 @@
     { "type": "application", "name": "my-app", "version": "1.0.0" },
     { "type": "library", "name": "checkout", "version": "v4", "purl": "pkg:github/actions/checkout@v4#restore" },
     { "type": "library", "name": "node", "version": "24.0.0", "purl": "pkg:generic/node@24.0.0" },
+    { "type": "library", "name": "Alamofire", "version": "5.9.0", "purl": "pkg:cocoapods/Alamofire@5.9.0" },
     { "type": "library", "name": "nopurl", "version": "1.0.0" }
   ]
 }

--- a/spec/still_active/sbom_reader_spec.rb
+++ b/spec/still_active/sbom_reader_spec.rb
@@ -50,6 +50,28 @@ RSpec.describe(StillActive::SbomReader) do
     expect { expect(described_class.read_string("not json")).to(eq([])) }.not_to(raise_error)
   end
 
+  describe(".parse — surfacing unassessable components (never silently drop a real dep)") do
+    subject(:result) { described_class.parse(fixture) }
+
+    it("exposes the same assessable dependencies as .read") do
+      expect(result.dependencies).to(eq(described_class.read(fixture)))
+    end
+
+    it("surfaces a real dependency in an unsupported ecosystem rather than dropping it") do
+      cocoapods = result.unassessable.find { |u| u[:name] == "Alamofire" }
+      expect(cocoapods).to(include(reason: :unsupported_ecosystem, ecosystem: "cocoapods"))
+    end
+
+    it("surfaces a library component that has no PURL (potential git/path/local dep)") do
+      expect(result.unassessable.find { |u| u[:name] == "nopurl" }).to(include(reason: :no_purl))
+    end
+
+    it("does NOT surface genuine non-package noise (GitHub Actions, generic binaries) as unassessable") do
+      surfaced = result.unassessable.map { |u| u[:name] }
+      expect(surfaced).not_to(include("checkout", "node"))
+    end
+  end
+
   describe("edge cases") do
     def sbom(*components) = { "bomFormat" => "CycloneDX", "components" => components }.to_json
 


### PR DESCRIPTION
## What

`SbomReader.parse(path)` now returns `{dependencies, unassessable}` so a real dependency is **never silently dropped**. A maintenance audit that quietly omits git/path/local deps or unsupported ecosystems would report "all clear" while ignoring often the *riskiest* dependencies — below our bar.

## Surfaced as `unassessable` (with a reason), not dropped

- a library component with **no PURL** (`:no_purl`) — typically a git/path/local source;
- an **unsupported ecosystem** (`:unsupported_ecosystem`, e.g. swift/cocoapods/conda);
- a **no-version** or **malformed** PURL (`:no_version` / `:malformed_purl`).

So a `--sbom` audit on, say, a Swift project will report "N deps unassessed (unsupported ecosystem)" rather than a false "all clear."

## Still excluded (documented, not silent)

Genuine non-package noise — `pkg:github` (CI Actions), `pkg:generic` (opaque binaries), and `type:file/application` components — is excluded from both lists by design.

## Compat + safety

`read`/`read_string` keep the prior dependencies-only contract by delegating to `parse`. Never raises (missing file, malformed JSON, malformed PURL all degrade). Reviewed (back-compat + mutually-exclusive classification confirmed); 752 examples green, rubocop clean.

Grounded by the git/path empirical check (git deps *with a version tag* get ordinary registry PURLs → assessed, not dropped) and the uzomuzo head-to-head on the news-digest monorepo.
