### PR TITLE
feat: parameterize DepsDevClient for cross-ecosystem lookups

### DIFF
--- a/lib/still_active/deps_dev_client.rb
+++ b/lib/still_active/deps_dev_client.rb
@@ -8,10 +8,14 @@ module StillActive
 
     BASE_URI = URI("https://api.deps.dev/")
 
-    def version_info(gem_name:, version:)
+    # `system` is the deps.dev package system, lowercased: rubygems, npm, pypi,
+    # cargo, go, maven, nuget. It matches the ecosystem symbol SbomReader emits,
+    # so a cross-ecosystem caller threads it straight through. An unknown system
+    # 404s and degrades to nil (HttpHelper swallows 404), never raising.
+    def version_info(gem_name:, version:, system: :rubygems)
       return if gem_name.nil? || version.nil?
 
-      path = "/v3alpha/systems/rubygems/packages/#{encode(gem_name)}/versions/#{encode(version)}"
+      path = "/v3alpha/systems/#{encode(system)}/packages/#{encode(gem_name)}/versions/#{encode(version)}"
       body = HttpHelper.get_json(BASE_URI, path)
       return if body.nil?
 
@@ -19,6 +23,26 @@ module StillActive
         advisory_keys: body.dig("advisoryKeys")&.map { |a| a["id"] } || [],
         project_id: extract_project_id(body),
       }
+    end
+
+    # The package's most recent release date (ISO8601 string), or nil. This is
+    # the cross-ecosystem freshness signal: deps.dev's default version is the
+    # latest stable, and its publishedAt is more reliable than ecosyste.ms's
+    # latest_release_published_at, which can lag badly (mpmath: 2023 vs 2026).
+    # When no version is flagged default (all pre-release), fall back to the
+    # newest publishedAt so a still-active package isn't mis-read as dormant.
+    def latest_release_date(name:, system: :rubygems)
+      return if name.nil?
+
+      path = "/v3alpha/systems/#{encode(system)}/packages/#{encode(name)}"
+      body = HttpHelper.get_json(BASE_URI, path)
+      return if body.nil?
+
+      versions = body["versions"]
+      return unless versions.is_a?(Array) && !versions.empty?
+
+      default = versions.find { |v| v.is_a?(Hash) && v["isDefault"] }
+      (default || newest_version(versions))&.dig("publishedAt")
     end
 
     def project_scorecard(project_id:)
@@ -103,8 +127,18 @@ module StillActive
       segments
     end
 
+    # The version with the newest publishedAt, used only when no version is
+    # flagged default. Versions without a publishedAt are dropped; the rest
+    # compare lexicographically (deps.dev returns RFC3339 UTC, so string order
+    # is chronological), and a dated release always wins over an undated one.
+    def newest_version(versions)
+      versions
+        .select { |v| v.is_a?(Hash) && v["publishedAt"] }
+        .max_by { |v| v["publishedAt"].to_s }
+    end
+
     def encode(value)
-      URI.encode_www_form_component(value)
+      URI.encode_www_form_component(value.to_s)
     end
   end
 end

--- a/spec/still_active/deps_dev_client_spec.rb
+++ b/spec/still_active/deps_dev_client_spec.rb
@@ -21,6 +21,90 @@ RSpec.describe(StillActive::DepsDevClient) do
       expect(described_class.version_info(gem_name: "nokogiri", version: nil)).to(be_nil)
     end
 
+    it("queries the rubygems system by default") do
+      stub = stub_request(:get, %r{api\.deps\.dev/v3alpha/systems/rubygems/packages/nokogiri/versions/1\.19\.1})
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: "{}")
+
+      described_class.version_info(gem_name: "nokogiri", version: "1.19.1")
+      expect(stub).to(have_been_requested)
+    end
+
+    it("queries the given ecosystem's deps.dev system path") do
+      stub = stub_request(:get, %r{api\.deps\.dev/v3alpha/systems/npm/packages/express/versions/5\.2\.1})
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: "{}")
+
+      described_class.version_info(gem_name: "express", version: "5.2.1", system: :npm)
+      expect(stub).to(have_been_requested)
+    end
+
+    it("percent-encodes a scoped npm name so the path segment stays intact") do
+      # The scope slash must stay percent-encoded (%2F) so `core` isn't read as a
+      # separate path segment. WebMock/Addressable decodes %40 back to @.
+      stub = stub_request(:get, %r{api\.deps\.dev/v3alpha/systems/npm/packages/@babel%2Fcore/versions/7\.0\.0})
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: "{}")
+
+      described_class.version_info(gem_name: "@babel/core", version: "7.0.0", system: :npm)
+      expect(stub).to(have_been_requested)
+    end
+  end
+
+  describe(".latest_release_date") do
+    def package_body(versions)
+      { "versions" => versions }.to_json
+    end
+
+    it("returns the default version's publishedAt (the package's freshness signal)") do
+      stub_request(:get, %r{api\.deps\.dev/v3alpha/systems/pypi/packages/requests\z}).to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: package_body([
+          { "versionKey" => { "version" => "2.31.0" }, "isDefault" => false, "publishedAt" => "2023-05-22T15:12:42Z" },
+          { "versionKey" => { "version" => "2.32.5" }, "isDefault" => true, "publishedAt" => "2025-08-18T20:46:00Z" },
+        ]),
+      )
+
+      expect(described_class.latest_release_date(name: "requests", system: :pypi)).to(eq("2025-08-18T20:46:00Z"))
+    end
+
+    it("queries the rubygems system by default") do
+      stub = stub_request(:get, %r{api\.deps\.dev/v3alpha/systems/rubygems/packages/nokogiri\z})
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: package_body([]))
+
+      described_class.latest_release_date(name: "nokogiri")
+      expect(stub).to(have_been_requested)
+    end
+
+    it("falls back to the newest publishedAt when no version is flagged default") do
+      stub_request(:get, /api\.deps\.dev/).to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: package_body([
+          { "versionKey" => { "version" => "0.1.0" }, "isDefault" => false, "publishedAt" => "2024-01-01T00:00:00Z" },
+          { "versionKey" => { "version" => "0.2.0-rc1" }, "isDefault" => false, "publishedAt" => "2024-06-01T00:00:00Z" },
+        ]),
+      )
+
+      expect(described_class.latest_release_date(name: "all-pre", system: :cargo)).to(eq("2024-06-01T00:00:00Z"))
+    end
+
+    it("returns nil when name is nil") do
+      expect(described_class.latest_release_date(name: nil)).to(be_nil)
+    end
+
+    it("returns nil when the package is unknown (404 -> no body)") do
+      stub_request(:get, /api\.deps\.dev/).to_return(status: 404)
+
+      expect(described_class.latest_release_date(name: "does-not-exist", system: :npm)).to(be_nil)
+    end
+
+    it("returns nil when the package has no versions") do
+      stub_request(:get, /api\.deps\.dev/).to_return(
+        status: 200, headers: { "Content-Type" => "application/json" }, body: package_body([]),
+      )
+
+      expect(described_class.latest_release_date(name: "empty", system: :npm)).to(be_nil)
+    end
+
     it("returns nil on timeout") do
       stub_request(:get, /api\.deps\.dev/).to_timeout
 


### PR DESCRIPTION
## What

Parameterizes `DepsDevClient` for cross-ecosystem use, the foundation for the upcoming multi-language maintenance lens.

- `version_info(gem_name:, version:, system: :rubygems)` — new `system:` keyword threads the deps.dev package system (rubygems/npm/pypi/cargo/go/maven/nuget). It matches the ecosystem symbol `SbomReader` emits, so a cross-ecosystem caller passes it straight through. Existing rubygems callers are unchanged (default).
- `latest_release_date(name:, system:)` — the package's most recent release date, sourced from deps.dev's default-version `publishedAt`.

## Why deps.dev for the release date

The freshness signal (when did this package last ship) drives the lifecycle status. deps.dev's default version is the latest stable and its `publishedAt` is reliable; ecosyste.ms's `latest_release_published_at` can lag badly (mpmath read 2023 there vs 2026 on deps.dev), which would flip a maintained package to a false `legacy`. When no version is flagged default (all pre-release), it falls back to the newest `publishedAt` so a still-active package isn't mis-read as dormant.

## Safety

Both methods degrade to nil rather than raising: an unknown system 404s (HttpHelper swallows 404), a missing/empty `versions` array returns nil. No dependency can vanish from an audit through these. npm scoped names keep their slash percent-encoded (`%2F`) so the scope isn't split into a path segment.

761 examples green, rubocop clean.
