### PR TITLE
feat: cross-ecosystem maintenance lens (EcosystemLens)

### DIFF
--- a/lib/still_active.rb
+++ b/lib/still_active.rb
@@ -4,6 +4,7 @@ require_relative "still_active/version"
 require_relative "still_active/errors"
 require_relative "still_active/config"
 require_relative "still_active/sbom_reader"
+require_relative "still_active/ecosystem_lens"
 require_relative "still_active/cli"
 
 # Octokit depends on Faraday and emits a deprecation warning at load time

--- a/lib/still_active/deps_dev_client.rb
+++ b/lib/still_active/deps_dev_client.rb
@@ -25,13 +25,13 @@ module StillActive
       }
     end
 
-    # The package's most recent release date (ISO8601 string), or nil. This is
-    # the cross-ecosystem freshness signal: deps.dev's default version is the
-    # latest stable, and its publishedAt is more reliable than ecosyste.ms's
-    # latest_release_published_at, which can lag badly (mpmath: 2023 vs 2026).
-    # When no version is flagged default (all pre-release), fall back to the
-    # newest publishedAt so a still-active package isn't mis-read as dormant.
-    def latest_release_date(name:, system: :rubygems)
+    # The package's default version and its release date: { version:,
+    # published_at: }, or nil. deps.dev's default version is the latest stable;
+    # when none is flagged (all pre-release), the newest publishedAt stands in so
+    # a still-active package isn't mis-read as dormant. The version is exposed (not
+    # just the date) so a caller can recover the package's repo link from it when
+    # an exact locked version isn't indexed (yanked/normalization mismatch).
+    def default_version_info(name:, system: :rubygems)
       return if name.nil?
 
       path = "/v3alpha/systems/#{encode(system)}/packages/#{encode(name)}"
@@ -41,8 +41,18 @@ module StillActive
       versions = body["versions"]
       return unless versions.is_a?(Array) && !versions.empty?
 
-      default = versions.find { |v| v.is_a?(Hash) && v["isDefault"] }
-      (default || newest_version(versions))&.dig("publishedAt")
+      entry = versions.find { |v| v.is_a?(Hash) && v["isDefault"] } || newest_version(versions)
+      return if entry.nil?
+
+      { version: entry.dig("versionKey", "version"), published_at: entry["publishedAt"] }
+    end
+
+    # The package's most recent release date (ISO8601 string), or nil. This is
+    # the cross-ecosystem freshness signal, and deps.dev's publishedAt is more
+    # reliable than ecosyste.ms's latest_release_published_at, which can lag badly
+    # (mpmath: 2023 vs 2026).
+    def latest_release_date(name:, system: :rubygems)
+      default_version_info(name: name, system: system)&.dig(:published_at)
     end
 
     def project_scorecard(project_id:)

--- a/lib/still_active/ecosystem_lens.rb
+++ b/lib/still_active/ecosystem_lens.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require_relative "deps_dev_client"
+require_relative "ecosystems_client"
+require_relative "github_client"
+require_relative "../helpers/vulnerability_helper"
+
+module StillActive
+  # The cross-ecosystem maintenance lens. Given one SBOM-derived dependency
+  # ({ecosystem, name, version}), it assembles the same maintenance signals the
+  # native Ruby path produces -- latest release date, archived, advisories,
+  # scorecard -- into a gem_data hash StatusHelper.gem_status can read directly.
+  # The breadth counterpart to the depth Bundler path gives Ruby.
+  #
+  # Security: the SBOM supplies only ecosystem/name/version. The repository is
+  # discovered from deps.dev (a public source still_active opts into), never from
+  # a lockfile-derived URL, so a hostile SBOM can't redirect a lookup. Anything
+  # unresolvable (a private package deps.dev doesn't index) degrades to nil
+  # signals -> :unknown, never a fabricated "ok".
+  module EcosystemLens
+    extend self
+
+    def assess(ecosystem:, name:, version:)
+      info = DepsDevClient.version_info(gem_name: name, version: version, system: ecosystem)
+      default = DepsDevClient.default_version_info(name: name, system: ecosystem)
+      # Recover the repo from the default version when the exact locked version
+      # isn't indexed (yanked/normalization mismatch): otherwise its project link
+      # vanishes and a still-fresh package date would read a false :ok with
+      # archived/scorecard silently dropped. The native Bundler path resolves the
+      # repo independently of deps.dev's per-version record; this gives the lens
+      # the same resilience.
+      project_id = info&.dig(:project_id) || project_id_from(name, ecosystem, default)
+      vulnerabilities = vulnerabilities_for(info)
+      scorecard = DepsDevClient.project_scorecard(project_id: project_id)
+      repo = repo_signals(project_id)
+
+      {
+        ecosystem: ecosystem,
+        name: name,
+        version_used: version,
+        latest_version_release_date: default&.dig(:published_at),
+        repository_url: project_id && "https://#{project_id}",
+        last_commit_date: repo[:last_commit_date],
+        archived: repo[:archived],
+        scorecard_score: scorecard&.dig(:score),
+        scorecard_maintained: scorecard&.dig(:maintained),
+        vulnerability_count: vulnerabilities.length,
+        vulnerabilities: vulnerabilities,
+      }
+    end
+
+    private
+
+    def vulnerabilities_for(info)
+      advisory_keys = info&.dig(:advisory_keys) || []
+      # The keys ARE the evidence the locked version is vulnerable; the detail
+      # fetch only enriches CVSS/title. A failed enrichment must not drop the
+      # count to zero and read a known-vulnerable dep as clean, so a key whose
+      # detail can't be loaded still contributes a minimal advisory.
+      deps_dev = advisory_keys.map { DepsDevClient.advisory_detail(advisory_id: _1) || { id: _1, source: "deps.dev" } }
+      # No ruby-advisory-db here: that database is Ruby-only and the native
+      # Bundler path already merges it. Cross-ecosystem advisories come from
+      # deps.dev/OSV, which covers every system the lens serves.
+      VulnerabilityHelper.merge_advisories(deps_dev: deps_dev, ruby_advisory_db: [])
+    end
+
+    # The repo project_id from the package's default version, used only when the
+    # locked version's deps.dev record is missing or carries no link.
+    def project_id_from(name, ecosystem, default)
+      version = default&.dig(:version)
+      return if version.nil?
+
+      DepsDevClient.version_info(gem_name: name, version: version, system: ecosystem)&.dig(:project_id)
+    end
+
+    # archived + last-commit for a flat github.com/owner/repo project, or {} for
+    # anything else. deps.dev indexes github.com and gitlab.com only, but gitlab
+    # subgroups nest arbitrarily and ecosyste.ms's repo crawler is GitHub-centric,
+    # so a gitlab (or nested, or unresolved) project keeps archived unknown rather
+    # than risk a bogus owner/name lookup.
+    def repo_signals(project_id)
+      host, owner, name, *rest = project_id.to_s.split("/")
+      return {} unless host == "github.com" && owner && name && rest.empty?
+
+      repo_provider.repo_signals(owner: owner, name: name) || {}
+    end
+
+    # Mirrors Workflow#provider_for(:github): the live GitHub API when a token is
+    # configured (freshest), else ecosyste.ms (5000 anonymous req/hr vs GitHub's
+    # 60), so an untokened cross-ecosystem run still resolves a large SBOM.
+    def repo_provider
+      StillActive.config.github_oauth_token ? GithubClient : EcosystemsClient
+    end
+  end
+end

--- a/spec/still_active/ecosystem_lens_spec.rb
+++ b/spec/still_active/ecosystem_lens_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+RSpec.describe(StillActive::EcosystemLens) do
+  # Stub the deps.dev version endpoint (advisory keys + SOURCE_REPO link).
+  def stub_version(advisory_keys: [], source_repo: nil)
+    links = source_repo ? [{ "label" => "SOURCE_REPO", "url" => source_repo }] : []
+    body = { "advisoryKeys" => advisory_keys.map { { "id" => _1 } }, "links" => links }
+    stub_request(:get, %r{api\.deps\.dev/v3alpha/systems/[^/]+/packages/.+/versions/.+})
+      .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: body.to_json)
+  end
+
+  # Stub the deps.dev package endpoint (the latest-release-date source). The
+  # regex excludes the version sub-path so it never shadows stub_version.
+  def stub_package(default_published_at:)
+    versions = [{ "versionKey" => { "version" => "9.9.9" }, "isDefault" => true, "publishedAt" => default_published_at }]
+    stub_request(:get, %r{api\.deps\.dev/v3alpha/systems/[^/]+/packages/[^/]+\z})
+      .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: { "versions" => versions }.to_json)
+  end
+
+  def stub_project_scorecard(score: 7.0, maintained: 8)
+    body = { "scorecard" => { "overallScore" => score, "date" => "2026-01-01", "checks" => [{ "name" => "Maintained", "score" => maintained }] } }
+    stub_request(:get, %r{api\.deps\.dev/v3alpha/projects/})
+      .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: body.to_json)
+  end
+
+  def stub_advisory(id:, cvss: 9.8)
+    body = { "advisoryKey" => { "id" => id }, "title" => "boom", "aliases" => [], "cvss3Score" => cvss }
+    stub_request(:get, %r{api\.deps\.dev/v3alpha/advisories/})
+      .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: body.to_json)
+  end
+
+  def stub_ecosystems_repo(archived:, pushed_at: "2026-01-01T00:00:00Z")
+    body = { "archived" => archived, "pushed_at" => pushed_at }
+    stub_request(:get, %r{repos\.ecosyste\.ms/api/v1/hosts/GitHub/repositories/})
+      .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: body.to_json)
+  end
+
+  describe(".assess") do
+    it("assembles a gem_data hash an actively-maintained npm package reads as :ok") do
+      stub_version(source_repo: "https://github.com/expressjs/express")
+      stub_package(default_published_at: "2026-06-01T00:00:00Z")
+      stub_project_scorecard(score: 6.5, maintained: 9)
+      stub_ecosystems_repo(archived: false)
+
+      result = described_class.assess(ecosystem: :npm, name: "express", version: "5.2.1")
+
+      expect(result).to(include(
+        ecosystem: :npm,
+        name: "express",
+        version_used: "5.2.1",
+        latest_version_release_date: "2026-06-01T00:00:00Z",
+        repository_url: "https://github.com/expressjs/express",
+        archived: false,
+        scorecard_score: 6.5,
+        scorecard_maintained: 9,
+        vulnerability_count: 0,
+      ))
+      expect(StillActive::StatusHelper.gem_status(result)).to(eq(:ok))
+    end
+
+    it("reads a clean, long-dormant pypi package as :legacy") do
+      stub_version(source_repo: "https://github.com/owner/sleepy")
+      stub_package(default_published_at: "2018-01-01T00:00:00Z")
+      stub_project_scorecard
+      stub_ecosystems_repo(archived: false)
+
+      result = described_class.assess(ecosystem: :pypi, name: "sleepy", version: "1.0.0")
+
+      expect(StillActive::StatusHelper.gem_status(result)).to(eq(:legacy))
+    end
+
+    it("surfaces a vulnerability at the locked version and counts it") do
+      stub_version(advisory_keys: ["GHSA-xxxx"], source_repo: "https://github.com/owner/leaky")
+      stub_package(default_published_at: "2026-06-01T00:00:00Z")
+      stub_project_scorecard
+      stub_advisory(id: "GHSA-xxxx")
+      stub_ecosystems_repo(archived: false)
+
+      result = described_class.assess(ecosystem: :cargo, name: "leaky", version: "0.1.0")
+
+      expect(result[:vulnerability_count]).to(eq(1))
+      expect(result[:vulnerabilities].first).to(include(id: "GHSA-xxxx"))
+      expect(StillActive::StatusHelper.gem_status(result)).to(eq(:vulnerable))
+    end
+
+    it("reads an archived repo that still publishes recent releases as :stale, not dead") do
+      stub_version(source_repo: "https://github.com/owner/moved")
+      stub_package(default_published_at: "2026-06-01T00:00:00Z")
+      stub_project_scorecard
+      stub_ecosystems_repo(archived: true)
+
+      result = described_class.assess(ecosystem: :npm, name: "moved", version: "2.0.0")
+
+      expect(result[:archived]).to(be(true))
+      expect(StillActive::StatusHelper.gem_status(result)).to(eq(:stale))
+    end
+
+    it("degrades a private/unresolvable package to all-nil signals -> :unknown") do
+      # deps.dev 404s for a private package; ecosyste.ms is never reached because
+      # there is no deps.dev-derived project to look up.
+      stub_request(:get, /api\.deps\.dev/).to_return(status: 404)
+
+      result = described_class.assess(ecosystem: :npm, name: "@acme/private", version: "1.0.0")
+
+      expect(result).to(include(
+        latest_version_release_date: nil,
+        archived: nil,
+        repository_url: nil,
+        vulnerability_count: 0,
+      ))
+      expect(StillActive::StatusHelper.gem_status(result)).to(eq(:unknown))
+    end
+
+    it("does not look up repo signals for a non-github deps.dev project (gitlab archived unknown)") do
+      stub_version(source_repo: "https://gitlab.com/group/proj")
+      stub_package(default_published_at: "2026-06-01T00:00:00Z")
+      stub_project_scorecard
+      eco = stub_ecosystems_repo(archived: true)
+
+      result = described_class.assess(ecosystem: :pypi, name: "proj", version: "1.0.0")
+
+      expect(eco).not_to(have_been_requested)
+      expect(result[:archived]).to(be_nil)
+      expect(result[:repository_url]).to(eq("https://gitlab.com/group/proj"))
+    end
+
+    it("recovers archived from the package's default version when the locked version isn't indexed") do
+      # Finding A: a yanked/normalization-mismatched locked version 404s on the
+      # version endpoint, so its project link is gone. Without a fallback the repo
+      # (and thus archived) vanishes and a fresh package date reads a false :ok.
+      # The default version is still indexed, so its link recovers the repo.
+      stub_request(:get, %r{api\.deps\.dev/v3alpha/systems/[^/]+/packages/[^/]+/versions/1\.0\.0})
+        .to_return(status: 404)
+      stub_package(default_published_at: "2026-06-01T00:00:00Z") # default version is "9.9.9"
+      stub_request(:get, %r{api\.deps\.dev/v3alpha/systems/[^/]+/packages/[^/]+/versions/9\.9\.9})
+        .to_return(status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "links" => [{ "label" => "SOURCE_REPO", "url" => "https://github.com/owner/archived" }] }.to_json)
+      stub_project_scorecard
+      stub_ecosystems_repo(archived: true)
+
+      result = described_class.assess(ecosystem: :npm, name: "mismatch", version: "1.0.0")
+
+      expect(result[:archived]).to(be(true))
+      expect(result[:repository_url]).to(eq("https://github.com/owner/archived"))
+      expect(StillActive::StatusHelper.gem_status(result)).not_to(eq(:ok))
+    end
+
+    it("still counts a known advisory key whose detail fetch fails (no silent under-report)") do
+      # Finding B: version_info proves the package is vulnerable (two advisory
+      # keys), but the advisory detail endpoint is down. The count must reflect
+      # the keys, not the enriched details, or a known-vulnerable dep reads clean.
+      stub_version(advisory_keys: ["GHSA-aaaa", "GHSA-bbbb"], source_repo: "https://github.com/owner/leaky")
+      stub_package(default_published_at: "2026-06-01T00:00:00Z")
+      stub_project_scorecard
+      stub_request(:get, %r{api\.deps\.dev/v3alpha/advisories/}).to_return(status: 503)
+      stub_ecosystems_repo(archived: false)
+
+      result = described_class.assess(ecosystem: :npm, name: "leaky", version: "0.1.0")
+
+      expect(result[:vulnerability_count]).to(eq(2))
+      expect(result[:vulnerabilities].map { _1[:id] }).to(contain_exactly("GHSA-aaaa", "GHSA-bbbb"))
+      expect(StillActive::StatusHelper.gem_status(result)).to(eq(:vulnerable))
+    end
+
+    it("does not split a nested gitlab project path into a bogus owner/name repo lookup") do
+      stub_version(source_repo: "https://gitlab.com/group/subgroup/proj")
+      stub_package(default_published_at: "2026-06-01T00:00:00Z")
+      stub_project_scorecard
+      eco = stub_ecosystems_repo(archived: true)
+
+      result = described_class.assess(ecosystem: :pypi, name: "proj", version: "1.0.0")
+
+      expect(eco).not_to(have_been_requested)
+      expect(result[:archived]).to(be_nil)
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `EcosystemLens`, the cross-ecosystem maintenance lens. Given one SBOM-derived dependency (`{ecosystem, name, version}`), `assess` assembles the same maintenance signals the native Ruby path produces into a `gem_data`-shaped hash that `StatusHelper.gem_status` reads directly:

- **latest release date** — deps.dev default-version `publishedAt` (the freshness signal that drives the lifecycle verdict).
- **advisories** — deps.dev/OSV at the locked version (per-version, so a pinned vulnerable version is flagged even when the repo is otherwise healthy).
- **scorecard** — OpenSSF overall + Maintained sub-check (optional enrichment).
- **archived / last-commit** — GitHub repo signals, via ecosyste.ms (tokenless) or the GitHub API (when a token is set), mirroring the Ruby path's provider precedence.

This is the breadth counterpart to the depth the Bundler path gives Ruby. The same lifecycle model (`ok / legacy / stale / archived / vulnerable / dead / unknown`) now travels across npm/pypi/cargo/go/maven/nuget.

## Security: the SBOM is untrusted input

The SBOM supplies only ecosystem/name/version. The repository is discovered from **deps.dev** (a public source still_active opts into), never from a lockfile-derived URL, so a hostile SBOM can't redirect a lookup at a host of its choosing. A private/unresolvable package (one deps.dev doesn't index) degrades to nil signals and reads as `:unknown` — never a fabricated `:ok`.

## Scope

Archived enrichment is github.com-only (flat `owner/repo`) this PR: deps.dev indexes github.com and gitlab.com, but gitlab subgroups nest arbitrarily and ecosyste.ms's repo crawler is GitHub-centric, so a gitlab/nested/unresolved project keeps `archived` unknown rather than risk a bogus owner/name lookup. The release-recency signal (the primary driver) works for every ecosystem regardless.

No ruby-advisory-db here: it's Ruby-only and the native Bundler path already merges it; cross-ecosystem advisories come from deps.dev/OSV.

## False-reassurance hardening (silent-failure review)

A silent-failure pass flagged that partial lookup failures could produce a confident `:ok` that's indistinguishable from a genuine one. Two were lens-specific and are fixed here, with regression tests:

- **Locked-version not indexed → repo (and `archived`) vanished.** A yanked or normalization-mismatched version 404s on deps.dev's version endpoint, dropping its project link, so a still-fresh package date read a false `:ok`. The lens now recovers the repo from the package's **default version** (`DepsDevClient.default_version_info` exposes it), mirroring the native Bundler path's repo resolution that doesn't hinge on a single per-version record.
- **A known advisory key dropped to count 0 when its detail fetch failed.** The advisory *keys* are the evidence of vulnerability; enrichment only adds CVSS/title. A key whose detail can't be loaded now still contributes a minimal advisory, so a known-vulnerable dep can't read clean on a transient advisory-endpoint blip.

Two further notes from that review are **documented limitations, not fixed here:**

- A nil release date falling back to a recent commit date can mask a release drought. This is **pre-existing and tool-wide** (the native path falls back to commit date identically when RubyGems lookup fails); fixing it means redesigning the release-vs-commit confidence model across the whole tool, out of scope for this PR.
- An archived **gitlab**-hosted package reads at its release-recency level rather than `:archived`, because archived enrichment is github-only here. Narrow (gitlab + archived + recent releases) and needs GitlabClient wiring in the lens — a tracked follow-up.
- A confirmed advisory whose severity couldn't be fetched (key present, detail endpoint down) counts as vulnerable in the report but, under the **severity-threshold** gate variant (`--fail-if-vulnerable=high`), `severity_at_or_above?` reads unknown-severity as below-threshold and the gate clears. This is a pre-existing gate semantic (the native path hits it for any no-CVSS advisory) and is **unreachable from the lens until `--sbom` is wired**; the plain `--fail-if-vulnerable` boolean already fires correctly. I'll fix it (unknown-severity-on-a-confirmed-vuln should not silently clear a gate) in the `--sbom` PR, with the native path in scope and its own test, rather than change gate behaviour inside this lens PR.

## Changelog

Deliberately none yet: this and #91 are internal building blocks with no user-facing surface. The user-facing `--sbom` flag (next PR) gets one comprehensive `[Unreleased]` entry covering the whole cross-ecosystem feature.

770 examples green (9 new), rubocop clean. Every external lookup degrades to nil/{} rather than raising, so no dependency can vanish from an audit.
