### PR TITLE
fix: reset config in ecosystem_lens_spec (red test(head) on main)

### DIFF
--- a/spec/still_active/ecosystem_lens_spec.rb
+++ b/spec/still_active/ecosystem_lens_spec.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe(StillActive::EcosystemLens) do
+  # Reset the shared config singleton: repo_provider reads github_oauth_token to
+  # choose GithubClient vs EcosystemsClient, and a prior spec (e.g. workflow_spec)
+  # leaves a test token on the singleton. Without this, run order decides whether
+  # the lens hits the (stubbed) ecosyste.ms path or the live GitHub API. Matches
+  # the convention in config_spec/forgejo_client_spec.
+  before { StillActive.reset }
+
   # Stub the deps.dev version endpoint (advisory keys + SOURCE_REPO link).
   def stub_version(advisory_keys: [], source_repo: nil)
     links = source_repo ? [{ "label" => "SOURCE_REPO", "url" => source_repo }] : []


### PR DESCRIPTION
## What

Fixes a red `test (head)` leg on main: `ecosystem_lens_spec` was order-dependent.

`EcosystemLens#repo_provider` reads `config.github_oauth_token` to choose `GithubClient` vs the tokenless `EcosystemsClient`. The config singleton isn't reset between specs, and `workflow_spec` leaves `"ghp_test_token"` on it. On a run order where `workflow_spec` precedes `ecosystem_lens_spec`, the lens took the live GitHub path and hit `api.github.com` (no cassette → `VCR::UnhandledHTTPRequestError`) instead of the stubbed ecosyste.ms path. The 3.3/3.4/4.0 legs passed by seed luck; Ruby head's seed exposed it.

## Fix

`before { StillActive.reset }` in `ecosystem_lens_spec`, matching the convention already used by `config_spec` / `forgejo_client_spec`. Reproduced the failure locally (`rspec workflow_spec ecosystem_lens_spec --order defined`), confirmed green after the fix, and ran the full suite in defined order + seeds 777/12345 (770 examples, all green). Test-only; no runtime change.
