### PR TITLE
feat: render poison-pill receipts in terminal + markdown (PR-C)

### DIFF
--- a/docs/superpowers/specs/2026-07-01-poison-pill-rendering-design.md
+++ b/docs/superpowers/specs/2026-07-01-poison-pill-rendering-design.md
@@ -1,0 +1,114 @@
+# Poison-pill receipt rendering (PR-C) — design
+
+Status: designed 2026-07-01. Follows PR-B (signal shipped in JSON: `constraints:
+[{dependency, requirement, dep_latest, majors_behind, kind}]` + `poison:` boolean
+on `gem_data`, native + cross-ecosystem). This PR surfaces that data in the
+human-facing terminal and markdown outputs.
+
+## Goal
+
+Make a poison gem's receipt visible where a human reads output. The value is the
+actionable finding ("this dead gem blocks your upgrades"), so rendering shows the
+*worst offenders + how many*, not an enumeration of every cap.
+
+## Decisions (settled)
+
+- **Annotation only, not a lifecycle status.** Poison is a different axis from the
+  maintenance lifecycle (`:dead`…`:ok` = "is it maintained?"; poison = "does this
+  dormant dep block *my* upgrades?"). A gem can be `:legacy` *and* poison.
+  `StatusHelper.gem_status` / `project_status` are **unchanged**. `--fail-if-poison`
+  (a future PR) gates on the `poison:` boolean directly.
+- **Only `poison == true` gems render.** Pure exact-pin gems (`constraints` present,
+  `poison: false`) keep their data in JSON but are not rendered here — keeps the
+  headline crisp. Exact-pin caps still appear *inside* a poison gem's receipt when
+  that gem mixes ceilings and pins.
+- **Top-3 + total, both surfaces.** Listing all caps adds length, not decision
+  value: the action is "remove the one dead gem," not "fix N caps." The full list
+  stays in JSON. Terminal and markdown use the same selection; markdown formats each
+  shown cap slightly richer.
+- **Deterministic order:** `majors_behind` desc, then `dependency` name asc (stable
+  for the baseline diff).
+- **Native path only.** `run_sbom` is JSON-only (no TerminalHelper/MarkdownHelper
+  path exists for `--sbom`), so cross-ecosystem poison is already fully surfaced in
+  the `--sbom` JSON. Nothing to add there.
+
+## Components
+
+### 1. Selection helper — `ConstraintHelper.top_findings(constraints, limit: 3)`
+
+Lives next to `poison_findings` / `POISON_KINDS` (same owner, no new file). Pure.
+
+```
+top_findings(constraints, limit: 3) # =>
+  { shown: [<=limit constraint hashes, worst-first], total: constraints.length }
+```
+
+Order: `sort_by { [-majors_behind, dependency] }`, take `limit`. `total` is the full
+count so a renderer can print "— N total" / "+K more". Both renderers call this so
+the selection can't drift (the "computed two ways" trap the codebase avoids).
+
+### 2. Terminal — `TerminalHelper`
+
+A yellow `↳` sub-line per poison gem. Yellow (not the dim used for
+alternatives/transitive hints) because it's an actionable finding; the gem's row is
+already red (poison requires `:critical`/`:archived`), so poison is never on a green
+row and the yellow sub-line explains the red without diluting red (reserved for
+vulns/yanked/archived).
+
+- Single cap: `  ↳ poison: caps activemodel < 5.0 (4 majors behind, latest 8.x)`
+- Multi cap: `  ↳ poison: caps chalk (4 behind), through2 (3), vinyl (3) +11 more`
+- Transitive: `  ↳ poison (via rails): caps …` — and the generic
+  `dependency_path_line` is **suppressed** for this gem (the poison line subsumes it).
+
+Wiring in `render`: the current single `extra` (`direct == false ? path :
+alternatives`) becomes an ordered list. For a poison gem, emit the poison line first;
+skip the generic transitive line; still emit the alternatives line if a direct poison
+gem has alternatives (two sub-lines, different actions — acceptable and rare). For a
+non-poison gem, behavior is unchanged.
+
+Summary line: append `· N poison-pills` (yellow) when `N > 0`, where N counts
+`poison == true` gems. Placed after the vulnerabilities part.
+
+New private methods: `poison_line(data)`, `poison_receipt(constraints)` (shared
+phrasing built from `top_findings`), and a `poison_count(result)` for the summary.
+
+### 3. Markdown — `MarkdownHelper.poison_section(result)`
+
+Consistent with `alternatives_section` / `transitive_section`. Selects
+`poison == true` gems; `""` when none. Wired in `cli.rb#render_markdown` next to the
+other sections (`puts poison_section unless empty`).
+
+```
+**Poison-pill findings** (dormant deps capping your tree below its latest major):
+- `gulp-util` caps `chalk` `^1.0.0` (4 majors behind, latest 5.x), `through2` `^2.0.0` (3), `vinyl` `^0.5.0` (3) — 14 total
+- `protected_attributes` caps `activemodel` `< 5.0` (4 behind, latest 8.x)
+```
+
+Transitive gems get `via \`rails\`` after the gem name. Names/requirements go through
+`MarkdownEscape` (code spans), matching the existing sections.
+
+## What "latest 8.x" means
+
+`dep_latest` (e.g. `8.0.1`) abbreviated to its major + `.x` (`8.x`) — the cap is a
+major-level gap, so the major is the honest granularity. Shown only in the single-cap
+terminal case and per-cap in markdown; multi-cap terminal drops it for space (the
+`(N behind)` carries the gap).
+
+## Testing (pure, no network)
+
+- `ConstraintHelper.top_findings`: worst-first order, tie-break by name, `limit`,
+  `total`, empty input.
+- `TerminalHelper`: poison sub-line present for a poison gem (ANSI-stripped substring
+  checks, per existing spec style); single vs multi-cap phrasing; transitive fold +
+  suppression of the generic transitive line; summary `N poison-pills`; a non-poison
+  dormant gem gets no poison line.
+- `MarkdownHelper.poison_section`: bullet content, top-3 + total, transitive "via",
+  escaping, `""` when no poison gems.
+- `cli.rb#render_markdown`: section emitted when present (or cover via helper spec +
+  a thin integration check).
+
+## Out of scope (later)
+
+`--fail-if-poison` gate; SARIF poison result; lifecycle `:poison` status;
+cross-ecosystem terminal/markdown (blocked on `--sbom` having no human renderer at
+all — a separate, larger piece).

--- a/lib/helpers/constraint_helper.rb
+++ b/lib/helpers/constraint_helper.rb
@@ -94,6 +94,15 @@ module StillActive
       end
     end
 
+    # Select the worst `limit` findings for a display receipt, plus the full count
+    # so a renderer can say "+N more" / "N total". Worst-first by majors_behind,
+    # ties broken by dependency name so the output is stable and diffable. Shared
+    # by the terminal and markdown renderers so the selection can't drift.
+    def top_findings(findings, limit: 3)
+      ranked = findings.sort_by { |f| [-f[:majors_behind], f[:dependency].to_s] }
+      { shown: ranked.first(limit), total: findings.length }
+    end
+
     private
 
     # Split one OR-branch into its AND clauses: comma-separated (Ruby/pip) or

--- a/lib/helpers/markdown_helper.rb
+++ b/lib/helpers/markdown_helper.rb
@@ -3,6 +3,7 @@
 require_relative "markdown_escape"
 require_relative "vulnerability_helper"
 require_relative "activity_helper"
+require_relative "constraint_helper"
 
 module StillActive
   module MarkdownHelper
@@ -112,7 +113,53 @@ module StillActive
       lines.join("\n")
     end
 
+    # A dormant dep that caps your tree below its latest major (the poison-pill
+    # signal). Consistent with the other finding sections: worst caps + total, the
+    # direct parent named for a transitive pill. The full cap list is in the JSON.
+    def poison_section(result)
+      # Require constraints present, not just the poison flag, so an unexpected
+      # empty set can't emit a dangling "- `gem` caps" bullet (symmetric with the
+      # terminal's poison_line guard).
+      flagged = result.select { |_name, data| data[:poison] && !Array(data[:constraints]).empty? }
+      return "" if flagged.empty?
+
+      lines = ["", "**Poison-pill findings** (dormant deps capping your tree below its latest major):"]
+      flagged.each do |name, data|
+        lines << "- #{poison_gem_ref(name, data)} caps #{poison_caps(data[:constraints])}"
+      end
+      lines.join("\n")
+    end
+
     private
+
+    def poison_gem_ref(name, data)
+      ref = MarkdownEscape.code_span(name)
+      path = data[:dependency_path]
+      # Transitive pill: name the direct parent the user can actually act on (#60).
+      return ref unless data[:direct] == false && Array(path).length >= 2
+
+      "#{ref} via #{MarkdownEscape.code_span(path.first)}"
+    end
+
+    # The worst 3 caps; the first carries the full receipt (requirement + latest
+    # major), the rest just the gap, and "— N total" when there are more.
+    def poison_caps(constraints)
+      top = ConstraintHelper.top_findings(Array(constraints), limit: 3)
+      parts = top[:shown].each_with_index.map do |finding, i|
+        dep = MarkdownEscape.code_span(finding[:dependency])
+        req = MarkdownEscape.code_span(finding[:requirement])
+        behind = finding[:majors_behind]
+        i.zero? ? "#{dep} #{req} (#{behind} major#{"s" unless behind == 1} behind, latest #{poison_major(finding[:dep_latest])})" : "#{dep} #{req} (#{behind})"
+      end
+      joined = parts.join(", ")
+      top[:total] > 1 ? "#{joined} — #{top[:total]} total" : joined
+    end
+
+    # "8.0.1" -> "8.x": the cap is a major-level gap.
+    def poison_major(version)
+      major = version.to_s[/\d+/]
+      major ? "#{major}.x" : version
+    end
 
     def transitive_flagged?(data)
       [:archived, :critical].include?(ActivityHelper.activity_level(data)) || data[:vulnerability_count].to_i.positive?

--- a/lib/helpers/terminal_helper.rb
+++ b/lib/helpers/terminal_helper.rb
@@ -2,6 +2,7 @@
 
 require_relative "activity_helper"
 require_relative "ansi_helper"
+require_relative "constraint_helper"
 require_relative "summary_helper"
 require_relative "libyear_helper"
 require_relative "version_helper"
@@ -23,11 +24,7 @@ module StillActive
       lines << separator_line(widths)
       names.each_with_index do |name, i|
         lines << row_line(rows[i], widths)
-        data = result[name]
-        # Transitive gems can't be swapped directly, so point at the direct
-        # parent instead of suggesting alternatives for them (#60).
-        extra = data[:direct] == false ? dependency_path_line(data) : alternatives_line(data)
-        lines << extra if extra
+        lines.concat(sub_lines(result[name]))
       end
       lines << ""
       lines << summary_line(result)
@@ -134,6 +131,60 @@ module StillActive
         .join
     end
 
+    # The ↳ sub-lines under a gem row. A poison gem gets the poison receipt (which
+    # names the direct parent itself when transitive, so the generic transitive
+    # line is redundant and dropped); a direct poison gem may still get its
+    # alternatives line. A non-poison gem keeps the prior behaviour: transitive
+    # gems point at the parent (#60), direct ones offer alternatives.
+    def sub_lines(data)
+      if data[:poison]
+        [poison_line(data), (data[:direct] == false ? nil : alternatives_line(data))].compact
+      else
+        [data[:direct] == false ? dependency_path_line(data) : alternatives_line(data)].compact
+      end
+    end
+
+    # "  ↳ poison: caps <receipt>", yellow because it is an actionable finding
+    # (the row is already red -- poison requires a dormant gem). Transitive gems
+    # name the direct parent that pulls the pill in, the actionable target.
+    def poison_line(data)
+      constraints = data[:constraints]
+      return if constraints.nil? || constraints.empty?
+
+      path = data[:dependency_path]
+      via = data[:direct] == false && path && path.length >= 2 ? " (via #{path.first})" : ""
+      AnsiHelper.yellow("  ↳ poison#{via}: #{poison_receipt(constraints)}")
+    end
+
+    # Single cap: the full receipt (requirement + latest major), since there's
+    # room. Many caps: the worst 3 by majors-behind + "+N more", a glanceable
+    # summary; the complete list stays in the JSON output.
+    def poison_receipt(constraints)
+      top = ConstraintHelper.top_findings(constraints, limit: 3)
+      return single_cap_receipt(top[:shown].first) if top[:total] == 1
+
+      parts = top[:shown].each_with_index.map do |finding, i|
+        count = finding[:majors_behind]
+        i.zero? ? "#{finding[:dependency]} (#{count} behind)" : "#{finding[:dependency]} (#{count})"
+      end
+      remaining = top[:total] - top[:shown].length
+      receipt = "caps #{parts.join(", ")}"
+      remaining.positive? ? "#{receipt} +#{remaining} more" : receipt
+    end
+
+    def single_cap_receipt(finding)
+      behind = finding[:majors_behind]
+      "caps #{finding[:dependency]} #{finding[:requirement]} " \
+        "(#{behind} major#{"s" unless behind == 1} behind, latest #{major_x(finding[:dep_latest])})"
+    end
+
+    # "8.0.1" -> "8.x": the cap is a major-level gap, so the major is the honest
+    # granularity to name as the current latest.
+    def major_x(version)
+      major = version.to_s[/\d+/]
+      major ? "#{major}.x" : version
+    end
+
     def alternatives_line(data)
       level = ActivityHelper.activity_level(data)
       return unless [:archived, :critical].include?(level)
@@ -194,6 +245,8 @@ module StillActive
       activity << ", #{archived} archived" if archived > 0
       parts << activity
       parts << "#{summary[:vulnerabilities]} vulnerabilities"
+      poison = result.each_value.count { |data| data[:poison] }
+      parts << AnsiHelper.yellow("#{poison} poison-#{poison == 1 ? "pill" : "pills"}") if poison > 0
       total_libyear = LibyearHelper.total_libyear(result)
       parts << "#{total_libyear.round(1)} libyears behind" if total_libyear > 0
       parts.join(" · ")

--- a/lib/still_active/cli.rb
+++ b/lib/still_active/cli.rb
@@ -338,6 +338,8 @@ module StillActive
 
         puts MarkdownHelper.markdown_table_body_line(gem_name: name, data: gem_data)
       end
+      poison = MarkdownHelper.poison_section(result)
+      puts poison unless poison.empty?
       alternatives = MarkdownHelper.alternatives_section(result)
       puts alternatives unless alternatives.empty?
       transitive = MarkdownHelper.transitive_section(result)

--- a/spec/still_active/cli_spec.rb
+++ b/spec/still_active/cli_spec.rb
@@ -691,6 +691,26 @@ RSpec.describe(StillActive::CLI) do
     end
   end
 
+  describe("--markdown poison-pill") do
+    let(:workflow_result) do
+      {
+        "protected_attributes" => gem_data(last_commit_date: ancient_date).merge(
+          poison: true,
+          constraints: [{ dependency: "activemodel", requirement: "< 5.0", dep_latest: "8.0.1", majors_behind: 4, kind: :ceiling }],
+        ),
+      }
+    end
+
+    it("appends a Poison-pill findings section to markdown output") do
+      lines = []
+      allow($stdout).to(receive(:puts)) { |arg| lines << arg }
+      cli.run(["--gems=protected_attributes", "--markdown"])
+      output = lines.join("\n")
+      expect(output).to(include("**Poison-pill findings**"))
+      expect(output).to(include("`protected_attributes` caps `activemodel` `< 5.0` (4 majors behind, latest 8.x)"))
+    end
+  end
+
   describe("--fail-if-warning") do
     context("when a gem has warning activity") do
       let(:workflow_result) { { "aging_gem" => gem_data(last_commit_date: old_date) } }

--- a/spec/still_active/constraint_helper_spec.rb
+++ b/spec/still_active/constraint_helper_spec.rb
@@ -142,6 +142,39 @@ RSpec.describe(StillActive::ConstraintHelper) do
     end
   end
 
+  describe(".top_findings") do
+    def finding(dep, behind)
+      { dependency: dep, requirement: "< x", dep_latest: "9.0.0", majors_behind: behind, kind: :ceiling }
+    end
+
+    it("returns the worst `limit` findings (majors_behind desc) plus the full total") do
+      findings = [finding("a", 1), finding("b", 4), finding("c", 2), finding("d", 3)]
+
+      result = described_class.top_findings(findings, limit: 3)
+
+      expect(result[:total]).to(eq(4))
+      expect(result[:shown].map { |f| f[:dependency] }).to(eq(["b", "d", "c"])) # 4, 3, 2
+    end
+
+    it("breaks majors_behind ties by dependency name ascending, for a stable/diffable order") do
+      findings = [finding("vinyl", 3), finding("array-differ", 3), finding("through2", 3)]
+
+      result = described_class.top_findings(findings, limit: 3)
+
+      expect(result[:shown].map { |f| f[:dependency] }).to(eq(["array-differ", "through2", "vinyl"]))
+    end
+
+    it("returns all findings when there are fewer than the limit") do
+      findings = [finding("a", 2), finding("b", 1)]
+      result = described_class.top_findings(findings, limit: 3)
+      expect(result).to(eq(shown: [finding("a", 2), finding("b", 1)], total: 2))
+    end
+
+    it("handles an empty list") do
+      expect(described_class.top_findings([], limit: 3)).to(eq(shown: [], total: 0))
+    end
+  end
+
   describe(".poison_ceiling?") do
     it("is true only for a below-latest ceiling or exact pin") do
       expect(described_class.poison_ceiling?(requirement: "~> 4.2", dep_latest: "8.0.0")).to(be(true))

--- a/spec/still_active/markdown_helper_spec.rb
+++ b/spec/still_active/markdown_helper_spec.rb
@@ -332,6 +332,55 @@ RSpec.describe(StillActive::MarkdownHelper) do
     end
   end
 
+  describe(".poison_section") do
+    def poison_gem(constraints, extra = {})
+      { source_type: :rubygems, poison: true, constraints: constraints }.merge(extra)
+    end
+
+    it("lists a poison gem's worst caps with requirement and latest major") do
+      result = {
+        "protected_attributes" => poison_gem([
+          { dependency: "activemodel", requirement: "< 5.0", dep_latest: "8.0.1", majors_behind: 4, kind: :ceiling },
+        ]),
+      }
+      out = described_class.poison_section(result)
+      expect(out).to(include("**Poison-pill findings**"))
+      expect(out).to(include("`protected_attributes` caps `activemodel` `< 5.0` (4 majors behind, latest 8.x)"))
+    end
+
+    it("shows the worst 3 caps + total for a many-cap gem, worst-first with name tie-break") do
+      caps = [
+        { dependency: "chalk", requirement: "^1", dep_latest: "5.0.0", majors_behind: 4, kind: :ceiling },
+        { dependency: "through2", requirement: "^2", dep_latest: "5.0.0", majors_behind: 3, kind: :ceiling },
+        { dependency: "vinyl", requirement: "^0.5", dep_latest: "3.0.0", majors_behind: 3, kind: :ceiling },
+        { dependency: "dateformat", requirement: "^2", dep_latest: "5.0.0", majors_behind: 3, kind: :ceiling },
+      ]
+      out = described_class.poison_section({ "gulp-util" => poison_gem(caps) })
+      expect(out).to(include("`chalk` `^1` (4 majors behind, latest 5.x), `dateformat` `^2` (3), `through2` `^2` (3) — 4 total"))
+    end
+
+    it("names the direct parent for a transitive poison gem") do
+      result = {
+        "terrapin" => poison_gem(
+          [{ dependency: "climate_control", requirement: "< 1.0", dep_latest: "1.2.0", majors_behind: 1, kind: :ceiling }],
+          { direct: false, dependency_path: ["paperclip", "terrapin"] },
+        ),
+      }
+      expect(described_class.poison_section(result))
+        .to(include("`terrapin` via `paperclip` caps `climate_control` `< 1.0` (1 major behind, latest 1.x)"))
+    end
+
+    it("returns empty string when no gem is poison") do
+      result = { "kaminari" => { source_type: :rubygems, poison: false } }
+      expect(described_class.poison_section(result)).to(eq(""))
+    end
+
+    it("skips a poison gem with no constraints rather than emitting a dangling bullet") do
+      result = { "odd" => { source_type: :rubygems, poison: true, constraints: [] } }
+      expect(described_class.poison_section(result)).to(eq(""))
+    end
+  end
+
   describe(".ruby_line") do
     it("shows latest Ruby with success emoji") do
       info = { version: "3.4.0", latest_version: "3.4.0", libyear: nil, eol: false, eol_date: nil }

--- a/spec/still_active/terminal_helper_spec.rb
+++ b/spec/still_active/terminal_helper_spec.rb
@@ -269,5 +269,65 @@ RSpec.describe(StillActive::TerminalHelper) do
         expect(out).not_to(include("--alternatives"))
       end
     end
+
+    context("with a poison-pill sub-line") do
+      def poison_gem(constraints, extra = {})
+        {
+          version_used: "1.1.4",
+          latest_version: "1.1.4",
+          vulnerability_count: 0,
+          scorecard_score: nil,
+          poison: true,
+          constraints: constraints,
+        }.merge(extra)
+      end
+
+      it("prints a rich single-cap receipt with the requirement and latest major") do
+        result = {
+          "protected_attributes" => poison_gem([
+            { dependency: "activemodel", requirement: "< 5.0", dep_latest: "8.0.1", majors_behind: 4, kind: :ceiling },
+          ]),
+        }
+        expect(described_class.render(result))
+          .to(include("poison: caps activemodel < 5.0 (4 majors behind, latest 8.x)"))
+      end
+
+      it("prints a compact top-3 receipt with +N more for a many-cap gem, worst-first with name tie-break") do
+        caps = [
+          { dependency: "chalk", requirement: "^1", dep_latest: "5.0.0", majors_behind: 4, kind: :ceiling },
+          { dependency: "through2", requirement: "^2", dep_latest: "5.0.0", majors_behind: 3, kind: :ceiling },
+          { dependency: "vinyl", requirement: "^0.5", dep_latest: "3.0.0", majors_behind: 3, kind: :ceiling },
+          { dependency: "dateformat", requirement: "^2", dep_latest: "5.0.0", majors_behind: 3, kind: :ceiling },
+          { dependency: "beeper", requirement: "^1", dep_latest: "3.0.0", majors_behind: 2, kind: :ceiling },
+        ]
+        expect(described_class.render({ "gulp-util" => poison_gem(caps) }))
+          .to(include("poison: caps chalk (4 behind), dateformat (3), through2 (3) +2 more"))
+      end
+
+      it("folds the parent into a transitive poison line and suppresses the generic transitive line") do
+        result = {
+          "terrapin" => poison_gem(
+            [{ dependency: "climate_control", requirement: "< 1.0", dep_latest: "1.2.0", majors_behind: 1, kind: :ceiling }],
+            { direct: false, dependency_path: ["paperclip", "terrapin"] },
+          ),
+        }
+        out = described_class.render(result)
+        expect(out).to(include("poison (via paperclip): caps climate_control < 1.0 (1 major behind, latest 1.x)"))
+        expect(out).not_to(include("transitive, pulled in by paperclip"))
+      end
+
+      it("counts poison-pills in the summary line") do
+        result = {
+          "a" => poison_gem([{ dependency: "x", requirement: "< 5", dep_latest: "8.0.0", majors_behind: 3, kind: :ceiling }]),
+          "b" => poison_gem([{ dependency: "y", requirement: "< 5", dep_latest: "8.0.0", majors_behind: 3, kind: :ceiling }]),
+        }
+        expect(described_class.render(result)).to(include("2 poison-pills"))
+      end
+
+      it("prints no poison line for a non-poison gem") do
+        result = { "kaminari" => { version_used: "1", latest_version: "1", vulnerability_count: 0, scorecard_score: nil, poison: false } }
+        expect(described_class.render(result)).not_to(include("poison:"))
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

Surfaces the poison-pill signal (shipped in JSON by the prior PR) in the human-facing **terminal** and **markdown** outputs. Until now a dev reading default output couldn't see *why* a gem was flagged; this renders the receipt.

**Annotation only** — the maintenance lifecycle status (`:dead`…`:ok`) is a separate axis and stays unchanged; poison is a compatibility signal that renders *alongside* it. A future `--fail-if-poison` gates on the `poison:` boolean directly.

## How

- **`ConstraintHelper.top_findings`** — shared worst-N selection (`majors_behind` desc, name-asc tie-break) + total, so the two renderers can't drift.
- **Terminal** — a yellow `↳ poison:` sub-line under the (already red) gem row:
  - single cap: full receipt — `caps activemodel < 5.0 (4 majors behind, latest 8.x)`
  - many caps: worst 3 + `+N more` — `caps chalk (4 behind), through2 (3), vinyl (3) +11 more`
  - transitive pill names its direct parent `(via rails)` and drops the now-redundant generic transitive line
  - summary line gains `· N poison-pills`
- **Markdown** — a `Poison-pill findings` section next to alternatives/transitive; worst 3 + `— N total`; `via \`parent\`` for a transitive pill.
- Only `poison == true` gems render; the full cap list stays in JSON. **Native path only** — `--sbom` is JSON-only, so cross-ecosystem poison is already fully surfaced in that JSON.

## Dogfooded (real output)

```
paperclip             → 6.1.0   archived  2/10   0   -
  ↳ poison: caps terrapin ~> 0.6.0 (1 major behind, latest 1.x)
protected_attributes  → 1.1.4   critical  -      0   -
  ↳ poison: caps activemodel < 5.0, >= 4.0.1 (4 majors behind, latest 8.x)
…
4 gems: … · 0 vulnerabilities · 4 poison-pills
```
Looking at the real output is what caught a "1 majors behind" grammar bug (now pluralized) — tests alone wouldn't have.

## Tests

867 examples, rubocop clean. Pure rendering from `gem_data`, no network. TDD throughout; both review agents clean (one defensive markdown guard added from review).

Design doc: `docs/superpowers/specs/2026-07-01-poison-pill-rendering-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
