### PR TITLE
feat: --fail-if-poison gate (enforce the poison-pill signal in CI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Usage: still_active [options]
         --fail-if-vulnerable[=SEVERITY]
                                      Exit 1 if any gem has vulnerabilities (optionally at or above SEVERITY)
         --fail-if-outdated=LIBYEARS  Exit 1 if any gem exceeds LIBYEARS behind latest
+        --fail-if-poison             Exit 1 if any dormant gem caps a dependency below its latest major (poison-pill)
         --ignore=GEM,GEM2,...        Exclude gems from pass/fail checks (still shown in output)
         --critical-warning-emoji=EMOJI
         --futurist-emoji=EMOJI
@@ -227,7 +228,7 @@ Each dependency carries the same `activity_level` and lifecycle `status` as the 
 
 The SBOM is **untrusted input**: only ecosystem/name/version are read from it, the repository is resolved from deps.dev (never a URL the SBOM supplies, so a hostile SBOM can't redirect a lookup), and anything deps.dev doesn't index degrades to `unknown` rather than a fabricated `ok`. Packages it can't assess (unsupported ecosystems, a component with no version or PURL, or one whose lookup failed against a rate-limited/flaky deps.dev) are surfaced in an `unassessable` list plus a stderr count, never silently dropped, so an audit can't read "all clear" while ignoring what it skipped; a present-but-unreadable SBOM errors rather than reporting a clean empty audit. OS packages land in `unassessable` too: the differentiated play is **maintenance**, not vulnerability scanning, so compose Trivy/Grype for CVEs.
 
-The activity (`--fail-if-critical`/`--fail-if-warning`) and vulnerability (`--fail-if-vulnerable`) gates apply to SBOM dependencies. The Ruby-shaped policy features do not travel to the SBOM path yet: `.still_active.yml` suppressions and `--ignore` key on the gem name (SBOM results key on `ecosystem/name@version`), and `--fail-if-outdated` needs a libyear the cross-ecosystem lens doesn't compute.
+The activity (`--fail-if-critical`/`--fail-if-warning`), vulnerability (`--fail-if-vulnerable`), and poison-pill (`--fail-if-poison`) gates apply to SBOM dependencies. The Ruby-shaped policy features do not travel to the SBOM path yet: `.still_active.yml` suppressions and `--ignore` key on the gem name (SBOM results key on `ecosystem/name@version`), and `--fail-if-outdated` needs a libyear the cross-ecosystem lens doesn't compute.
 
 ### SARIF output (GitHub Code Scanning)
 
@@ -371,6 +372,7 @@ still_active --fail-if-warning --fail-if-vulnerable --ignore=legacy_gem --json
 fail_if_critical: true
 fail_if_vulnerable: high       # true, or a minimum severity: low|medium|high|critical
 fail_if_outdated: 3            # libyears
+fail_if_poison: true           # fail on a dormant gem that caps a dep below its latest major
 unreleased_commits: true
 output: json                   # terminal | markdown | json
 direct_only: true              # audit only declared deps, not the full transitive graph (--direct-only)
@@ -388,7 +390,7 @@ ignore:
 
   # Accept staleness on a vendored gem, but still fail if it gets a CVE
   - gem: legacy_thing
-    signal: activity            # activity | vulnerability | libyear
+    signal: activity            # activity | vulnerability | libyear | poison
     reason: "vendored, intentionally frozen"
 
   # A bare gem name keeps the old whole-gem behaviour (mutes every signal)
@@ -397,7 +399,7 @@ ignore:
 
 Design:
 
-- **Granularity.** Key by `advisory:` (one CVE) and/or `signal:` (`activity` / `vulnerability` / `libyear`), not the whole gem. A vulnerability suppression **must** name an advisory id, so a newly disclosed CVE on the same gem is never pre-silenced. `--ignore=GEM` (and a bare gem-name entry) still mute everything, by design.
+- **Granularity.** Key by `advisory:` (one CVE) and/or `signal:` (`activity` / `vulnerability` / `libyear` / `poison`), not the whole gem. A vulnerability suppression **must** name an advisory id, so a newly disclosed CVE on the same gem is never pre-silenced. `--ignore=GEM` (and a bare gem-name entry) still mute everything, by design.
 - **Precedence.** CLI flag > env var > config file > default. A CLI flag always wins; `--ignore` unions with the file's suppressions rather than replacing them. Secrets (tokens) and invocation-specific paths (`--gemfile`, `--gems`, `--baseline`, output paths) are intentionally **not** read from the file, so a committed config never carries a credential.
 - **Expiry.** An `expires:` date makes accepted risk visible: once it passes, the entry stops applying and the finding fails the gate again (Trivy-style), so a suppression can't rot silently. `reason:` is optional but recommended. A suppression naming a gem that isn't in your dependency graph (a typo, or a gem you've since removed) is also surfaced as a warning, so dead entries don't accumulate.
 - **bundler-audit, suggested not absorbed.** still_active never silently inherits another tool's ignore list: auto-importing `.bundler-audit.yml` would suppress vulnerabilities you only accepted in bundler-audit's context, with no reason or expiry here. Instead, when `--fail-if-vulnerable` is on and an un-imported `.bundler-audit.yml` is present, it prints a one-line hint suggesting the `import:` line, leaving the opt-in to you.

--- a/lib/still_active/cli.rb
+++ b/lib/still_active/cli.rb
@@ -352,7 +352,7 @@ module StillActive
 
     def check_exit_status(result)
       config = StillActive.config
-      return unless config.fail_if_critical || config.fail_if_warning || config.fail_if_vulnerable || config.fail_if_outdated
+      return unless config.fail_if_critical || config.fail_if_warning || config.fail_if_vulnerable || config.fail_if_outdated || config.fail_if_poison
 
       warn_unknown_severity_gate(result, config)
       exit(1) if result.any? { |name, data| gate_failed?(name, data, config) }
@@ -391,7 +391,15 @@ module StillActive
       suppressions = config.suppressions
       failed_activity?(name, data, config, suppressions) ||
         failed_vulnerability?(name, data, config, suppressions) ||
-        failed_outdated?(name, data, config, suppressions)
+        failed_outdated?(name, data, config, suppressions) ||
+        failed_poison?(name, data, config, suppressions)
+    end
+
+    def failed_poison?(name, data, config, suppressions)
+      return false unless config.fail_if_poison
+      return false if suppressions.suppressed?(gem: name, signal: :poison)
+
+      data[:poison] == true
     end
 
     def failed_activity?(name, data, config, suppressions)

--- a/lib/still_active/config.rb
+++ b/lib/still_active/config.rb
@@ -17,6 +17,7 @@ module StillActive
       :cyclonedx_path,
       :cyclonedx_version,
       :fail_if_critical,
+      :fail_if_poison,
       :fail_if_warning,
       :futurist_emoji,
       :gems,
@@ -38,6 +39,7 @@ module StillActive
       @unreleased_commits = false
       @direct_only = false
       @fail_if_critical = false
+      @fail_if_poison = false
       @fail_if_outdated = nil
       @fail_if_vulnerable = nil
       @fail_if_warning = false

--- a/lib/still_active/config_file.rb
+++ b/lib/still_active/config_file.rb
@@ -48,6 +48,7 @@ module StillActive
         case key
         when "fail_if_critical" then set_boolean(config, :fail_if_critical=, value, key, warnings)
         when "fail_if_warning" then set_boolean(config, :fail_if_warning=, value, key, warnings)
+        when "fail_if_poison" then set_boolean(config, :fail_if_poison=, value, key, warnings)
         when "alternatives" then set_boolean(config, :alternatives=, value, key, warnings)
         when "unreleased_commits" then set_boolean(config, :unreleased_commits=, value, key, warnings)
         when "direct_only" then set_boolean(config, :direct_only=, value, key, warnings)

--- a/lib/still_active/options.rb
+++ b/lib/still_active/options.rb
@@ -162,6 +162,9 @@ module StillActive
       opts.on("--fail-if-outdated=LIBYEARS", Float, "Exit 1 if any gem exceeds LIBYEARS behind latest") do |value|
         StillActive.config { |config| config.fail_if_outdated = value }
       end
+      opts.on("--fail-if-poison", "Exit 1 if any dormant gem caps a dependency below its latest major (poison-pill)") do
+        StillActive.config { |config| config.fail_if_poison = true }
+      end
     end
 
     def add_emoji_options(opts)

--- a/lib/still_active/suppressions.rb
+++ b/lib/still_active/suppressions.rb
@@ -5,8 +5,9 @@ require "date"
 module StillActive
   # Granular, auditable suppression of individual findings, loaded from the
   # `ignore:` block of a committed .still_active.yml. Each entry silences one
-  # signal (activity / libyear) or one advisory for one gem, optionally until an
-  # expiry date, replacing the all-or-nothing whole-gem --ignore. A bare gem
+  # signal (activity / vulnerability / libyear / poison) or one advisory for one
+  # gem, optionally until an expiry date, replacing the all-or-nothing whole-gem
+  # --ignore. A bare gem
   # name (or a gem-only mapping) keeps the old whole-gem behaviour so --ignore
   # can union into the same list.
   #
@@ -15,7 +16,7 @@ module StillActive
   # name an explicit advisory id, so a newly disclosed CVE on the same gem is
   # never pre-silenced.
   class Suppressions
-    GATEABLE_SIGNALS = [:activity, :vulnerability, :libyear].freeze
+    GATEABLE_SIGNALS = [:activity, :vulnerability, :libyear, :poison].freeze
 
     Entry = Struct.new(:gem, :advisory, :signal, :reason, :expires, keyword_init: true) do
       def whole_gem?
@@ -75,14 +76,14 @@ module StillActive
           return false
         end
         if signal && !GATEABLE_SIGNALS.include?(signal)
-          warnings << "ignoring suppression for #{label}: unknown signal #{signal.inspect} (expected activity, vulnerability, or libyear)"
+          warnings << "ignoring suppression for #{label}: unknown signal #{signal.inspect} (expected activity, vulnerability, libyear, or poison)"
           return false
         end
         if signal == :vulnerability && advisory.nil?
           warnings << "ignoring vulnerability suppression for #{label}: must name an advisory id so newly disclosed advisories still surface"
           return false
         end
-        if [:activity, :libyear].include?(signal) && gem.nil?
+        if [:activity, :libyear, :poison].include?(signal) && gem.nil?
           warnings << "ignoring #{signal} suppression: must name a gem"
           return false
         end

--- a/spec/still_active/cli_spec.rb
+++ b/spec/still_active/cli_spec.rb
@@ -711,6 +711,48 @@ RSpec.describe(StillActive::CLI) do
     end
   end
 
+  describe("--fail-if-poison") do
+    def poison_gem
+      gem_data(last_commit_date: ancient_date).merge(
+        poison: true,
+        constraints: [{ dependency: "activemodel", requirement: "< 5.0", dep_latest: "8.0.1", majors_behind: 4, kind: :ceiling }],
+      )
+    end
+
+    it("exits 1 when a gem is a poison-pill") do
+      StillActive.config.fail_if_poison = true
+      expect { cli.send(:check_exit_status, { "protected_attributes" => poison_gem }) }
+        .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(1)) })
+    end
+
+    it("does not exit when no gem is a poison-pill") do
+      StillActive.config.fail_if_poison = true
+      expect { cli.send(:check_exit_status, { "rails" => gem_data(last_commit_date: recent_date) }) }
+        .not_to(raise_error)
+    end
+
+    it("does not exit when the flag is off, even with a poison gem") do
+      expect { cli.send(:check_exit_status, { "protected_attributes" => poison_gem }) }
+        .not_to(raise_error)
+    end
+
+    it("does not exit when the poison gem is --ignore'd") do
+      StillActive.config.fail_if_poison = true
+      StillActive.config.ignored_gems = ["protected_attributes"]
+      expect { cli.send(:check_exit_status, { "protected_attributes" => poison_gem }) }
+        .not_to(raise_error)
+    end
+
+    it("does not exit when the gem's poison signal is suppressed in .still_active.yml") do
+      StillActive.config.fail_if_poison = true
+      StillActive.config.suppressions = StillActive::Suppressions.from(
+        [{ "gem" => "protected_attributes", "signal" => "poison", "reason" => "vendored, accepted" }],
+      )
+      expect { cli.send(:check_exit_status, { "protected_attributes" => poison_gem }) }
+        .not_to(raise_error)
+    end
+  end
+
   describe("--fail-if-warning") do
     context("when a gem has warning activity") do
       let(:workflow_result) { { "aging_gem" => gem_data(last_commit_date: old_date) } }

--- a/spec/still_active/config_file_spec.rb
+++ b/spec/still_active/config_file_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe(StillActive::ConfigFile) do
       data = {
         "fail_if_critical" => true,
         "fail_if_warning" => true,
+        "fail_if_poison" => true,
         "fail_if_vulnerable" => "high",
         "fail_if_outdated" => 2.5,
         "alternatives" => true,
@@ -58,6 +59,7 @@ RSpec.describe(StillActive::ConfigFile) do
 
       expect(config.fail_if_critical).to(be(true))
       expect(config.fail_if_warning).to(be(true))
+      expect(config.fail_if_poison).to(be(true))
       expect(config.fail_if_vulnerable).to(eq("high"))
       expect(config.fail_if_outdated).to(eq(2.5))
       expect(config.alternatives).to(be(true))

--- a/spec/still_active/suppressions_spec.rb
+++ b/spec/still_active/suppressions_spec.rb
@@ -99,6 +99,18 @@ RSpec.describe(StillActive::Suppressions) do
       expect(s.warnings).to(be_empty)
       expect(s.suppressed?(gem: "g", signal: :activity)).to(be(true))
     end
+
+    it("accepts a poison signal suppression for a named gem") do
+      s = build([{ "gem" => "protected_attributes", "signal" => "poison", "reason" => "vendored" }])
+      expect(s.warnings).to(be_empty)
+      expect(s.suppressed?(gem: "protected_attributes", signal: :poison)).to(be(true))
+      expect(s.suppressed?(gem: "other", signal: :poison)).to(be(false))
+    end
+
+    it("rejects a poison suppression that names no gem (must target a specific gem)") do
+      s = build([{ "signal" => "poison" }])
+      expect(s.warnings.join).to(match(/gem/i))
+    end
   end
 
   describe("#stale_gem_warnings (presence-based rot)") do


### PR DESCRIPTION
## What

Adds `--fail-if-poison` — the enforcement gate for the poison-pill signal. Until now the signal was informational (rendered in terminal/markdown, shipped in JSON); this lets a team fail the build on a dormant gem that caps a dependency below its latest major.

Mirrors the existing `--fail-if-critical` boolean pattern.

## How

- **Flag + config:** `--fail-if-poison`, and `fail_if_poison: true` in `.still_active.yml`.
- **Suppressible:** `:poison` joins the gateable suppression signals, so a team can accept a *known* pill per-gem with a reason/expiry rather than `--ignore`-ing it from every gate:
  ```yaml
  - gem: legacy_thing
    signal: poison
    reason: "vendored, migration scheduled Q3"
    expires: 2026-10-01
  ```
- **Gate:** `failed_poison?` mirrors the other gates — off unless enabled, respects `--ignore` and granular suppression, then fails on `data[:poison] == true`. Independent of the other gates (enabling it can't mask activity/vuln/outdated).
- **Both paths:** `run_sbom` already calls `check_exit_status` and the lens sets `poison` on assessed deps, so **cross-ecosystem pills are enforced too**.

## Dogfooded (exit codes are the deliverable)

| invocation | exit |
|---|---|
| `--gems=protected_attributes --fail-if-poison` | **1** |
| `--gems=rails --fail-if-poison` | 0 |
| `--gems=protected_attributes` (no gate) | 0 |
| `--sbom <npm/cargo pills> --fail-if-poison` | **1** (cross-ecosystem) |

## Tests

874 examples, rubocop clean. TDD throughout: gate exits (pill/clean/flag-off/ignore/suppressed), config-file key, `:poison` suppression accept + must-name-a-gem reject. Code-review clean (fixed a stale suppressions docstring).

README updated: help block, SBOM-applicability note, `.still_active.yml` example, signal list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
