### PR TITLE
feat: flag vulnerabilities with no fixed version available

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **How do you know if your Ruby dependencies are still maintained?**
 
-`bundle outdated` tells you version drift. `bundler-audit` catches known CVEs. Neither tells you whether anyone is still working on the thing. `still_active` checks maintenance activity, version freshness, security scores, vulnerabilities, libyear drift, and archived repos for every gem in your dependency graph — direct and transitive by default (`--direct-only` to narrow), with granular, committed suppression via `.still_active.yml`.
+`bundle outdated` tells you version drift. `bundler-audit` catches known CVEs. Neither tells you whether anyone is still working on the thing. `still_active` checks maintenance activity, version freshness, security scores, vulnerabilities (flagging those with **no fixed version available** — you can't upgrade out of them), libyear drift, and archived repos for every gem in your dependency graph — direct and transitive by default (`--direct-only` to narrow), with granular, committed suppression via `.still_active.yml`.
 
 Findings ship as **terminal / markdown / JSON / SARIF / CycloneDX** — SARIF lands in your GitHub Security tab and as inline PR annotations on `Gemfile.lock`; CycloneDX feeds Trivy / Dependency-Track / Snyk. PR mode (`--baseline=FILE`) reports only what got worse since main, so reviewers see one line ("`vcr` newly archived") instead of an absolute snapshot of every dep.
 

--- a/lib/helpers/markdown_helper.rb
+++ b/lib/helpers/markdown_helper.rb
@@ -208,7 +208,8 @@ module StillActive
       severity = VulnerabilityHelper.highest_severity(vulnerabilities)
       ids = vulnerabilities.flat_map { |v| [v[:id], *v[:aliases]] }.compact.uniq.first(3)
 
-      parts = [severity ? "#{count} (#{severity})" : count.to_s]
+      notes = [severity, ("no fix" if VulnerabilityHelper.no_fix_available?(vulnerabilities))].compact
+      parts = [notes.empty? ? count.to_s : "#{count} (#{notes.join(", ")})"]
       parts << MarkdownEscape.cell(ids.join(", ")) unless ids.empty?
       parts.join(" ")
     end

--- a/lib/helpers/ruby_advisory_db.rb
+++ b/lib/helpers/ruby_advisory_db.rb
@@ -13,6 +13,9 @@ module StillActive
     extend self
 
     STALE_AFTER_SECONDS = 30 * 24 * 60 * 60 # 30 days
+    # Requirement operators whose safe versions are OLDER than the flaw, i.e. not a
+    # forward fix a consumer can upgrade to. Anything else ("> X" etc.) is.
+    OLDER_THAN_FLAW_OPERATORS = ["<", "<="].freeze
 
     # bundler-audit's Database#check_gem expects an object responding to
     # #name and #version (a Gem::Version).
@@ -66,11 +69,31 @@ module StillActive
         cvss3_score: details[:cvss_v3],
         cvss3_vector: nil,
         cvss2_score: details[:cvss_v2],
+        # No safe version a consumer can upgrade TO: the correlation bundler-audit
+        # + `bundle outdated` can't produce alone. A factual read of the DB.
+        no_fix_available: no_forward_fix?(advisory),
         source: "ruby-advisory-db",
       }
     end
 
     private
+
+    # True when the advisory records no version the consumer can move forward to.
+    # Mirrors bundler-audit's own `!patched? && !unaffected?` rather than only the
+    # patched half: a clean release shipped AFTER a backdoored/yanked version is
+    # recorded in unaffected_versions as a "> X" range, not in patched_versions
+    # (the CVE-2019-15224 bootstrap-sass pattern). Be conservative -- only a purely
+    # older-than-the-flaw safe range ("< X") counts as no-forward-fix -- so we never
+    # claim "no fix" while a later safe release exists.
+    def no_forward_fix?(advisory)
+      return false unless advisory.patched_versions.empty?
+
+      advisory.unaffected_versions.all? { |requirement| older_than_flaw_only?(requirement) }
+    end
+
+    def older_than_flaw_only?(requirement)
+      requirement.requirements.all? { |operator, _| OLDER_THAN_FLAW_OPERATORS.include?(operator) }
+    end
 
     # nil for versions Gem::Version can't parse (e.g. a git sha); such a "version"
     # has nothing to match in the advisory DB, so the caller returns [].

--- a/lib/helpers/sarif_helper.rb
+++ b/lib/helpers/sarif_helper.rb
@@ -190,11 +190,14 @@ module StillActive
       aliases = Array(vuln[:aliases]).first(3).join(", ")
       alias_suffix = aliases.empty? ? "" : " [#{aliases}]"
       title = vuln[:title] ? ": #{vuln[:title]}" : ""
+      # ruby-advisory-db records no safe version: upgrading can't clear it, which
+      # is the actionable distinction from an ordinary (patchable) advisory.
+      no_fix = vuln[:no_fix_available] ? " (no fixed version available)" : ""
 
       base = result(
         "SA003",
         name,
-        "#{name} #{version}: #{advisory_id}#{title}#{alias_suffix}#{transitive_suffix(data)}.",
+        "#{name} #{version}: #{advisory_id}#{title}#{alias_suffix}#{no_fix}#{transitive_suffix(data)}.",
         location,
         level: level,
         fp_extra: advisory_id,

--- a/lib/helpers/terminal_helper.rb
+++ b/lib/helpers/terminal_helper.rb
@@ -102,7 +102,8 @@ module StillActive
       return AnsiHelper.green("0") if count.zero?
 
       severity = VulnerabilityHelper.highest_severity(data[:vulnerabilities])
-      label = severity ? "#{count} (#{severity})" : count.to_s
+      notes = [severity, ("no fix" if VulnerabilityHelper.no_fix_available?(data[:vulnerabilities]))].compact
+      label = notes.empty? ? count.to_s : "#{count} (#{notes.join(", ")})"
       AnsiHelper.red(label)
     end
 

--- a/lib/helpers/vulnerability_helper.rb
+++ b/lib/helpers/vulnerability_helper.rb
@@ -22,6 +22,13 @@ module StillActive
       (vulnerability[:cvss3_score] || vulnerability[:cvss2_score]).nil?
     end
 
+    # True when at least one advisory has no fixed version available -- the gem
+    # can't be upgraded out of the vulnerability. Only ruby-advisory-db sets this
+    # today; a deps.dev-only advisory leaves it nil (unknown), which reads false.
+    def no_fix_available?(vulnerabilities)
+      Array(vulnerabilities).any? { |vulnerability| vulnerability[:no_fix_available] }
+    end
+
     def severity_at_or_above?(vulnerabilities, threshold)
       return false if vulnerabilities.nil? || vulnerabilities.empty?
 
@@ -69,6 +76,11 @@ module StillActive
       into[:title] ||= from[:title]
       into[:url] ||= from[:url]
       into[:aliases] = (identifiers(into) | identifiers(from)).reject { |id| id == into[:id] }.sort
+      # ruby-advisory-db is the sole authority for fix availability; its
+      # determination wins whenever it has one (deps.dev leaves the key absent
+      # today, but this fails safe if that ever changes: a radb "no fix" can't be
+      # overridden by a stale/absent deps.dev value on a security-adjacent field).
+      into[:no_fix_available] = from[:no_fix_available] unless from[:no_fix_available].nil?
       into[:source] = "merged"
     end
 

--- a/spec/still_active/markdown_helper_spec.rb
+++ b/spec/still_active/markdown_helper_spec.rb
@@ -222,6 +222,31 @@ RSpec.describe(StillActive::MarkdownHelper) do
         expect(line).to(include("GHSA-abc"))
       end
     end
+
+    context("when an advisory has no fixed version") do
+      let(:data) do
+        {
+          last_activity_warning_emoji: "",
+          up_to_date_emoji: "✅",
+          version_used: "1.0.0",
+          latest_version: "1.0.0",
+          version_used_release_date: Time.now,
+          latest_version_release_date: Time.now,
+          latest_pre_release_version: nil,
+          latest_pre_release_version_release_date: nil,
+          repository_url: nil,
+          ruby_gems_url: nil,
+          last_commit_date: nil,
+          scorecard_score: nil,
+          vulnerability_count: 1,
+          vulnerabilities: [{ id: "CVE-1", aliases: [], cvss3_score: 7.5, no_fix_available: true }],
+        }
+      end
+
+      it("marks 'no fix' alongside the severity") do
+        expect(line).to(include("1 (high, no fix)"))
+      end
+    end
   end
 
   describe(".markdown_table_body_line with hostile metadata") do

--- a/spec/still_active/ruby_advisory_db_spec.rb
+++ b/spec/still_active/ruby_advisory_db_spec.rb
@@ -6,7 +6,7 @@ require "bundler/audit/database"
 RSpec.describe(StillActive::RubyAdvisoryDb) do
   # A stand-in for a bundler-audit Advisory: the CVSS scores live in #to_h,
   # while ids are exposed as methods (matches bundler-audit 0.9.3).
-  def fake_advisory(ghsa_id:, cve_id:, id:, identifiers:, to_h:)
+  def fake_advisory(ghsa_id:, cve_id:, id:, identifiers:, to_h:, patched_versions: [Gem::Requirement.new(">= 1.0")], unaffected_versions: [])
     instance_double(
       Bundler::Audit::Advisory,
       ghsa_id: ghsa_id,
@@ -14,6 +14,8 @@ RSpec.describe(StillActive::RubyAdvisoryDb) do
       id: id,
       identifiers: identifiers,
       to_h: to_h,
+      patched_versions: patched_versions,
+      unaffected_versions: unaffected_versions,
     )
   end
 
@@ -60,6 +62,38 @@ RSpec.describe(StillActive::RubyAdvisoryDb) do
 
     it("tags the source as ruby-advisory-db") do
       expect(vulnerability[:source]).to(eq("ruby-advisory-db"))
+    end
+
+    def unpatched(unaffected: [])
+      fake_advisory(
+        ghsa_id: "GHSA-x",
+        cve_id: "CVE-x",
+        id: "CVE-x",
+        identifiers: ["CVE-x"],
+        to_h: {},
+        patched_versions: [],
+        unaffected_versions: unaffected,
+      )
+    end
+
+    it("marks no_fix_available when the advisory declares no patched or forward-safe version") do
+      expect(described_class.to_vulnerability(unpatched)[:no_fix_available]).to(be(true))
+    end
+
+    it("marks no_fix_available when the only safe versions are older than the flaw (< X)") do
+      advisory = unpatched(unaffected: [Gem::Requirement.new("< 1.0.6")])
+      expect(described_class.to_vulnerability(advisory)[:no_fix_available]).to(be(true))
+    end
+
+    it("does NOT mark no_fix when a later clean release exists in unaffected_versions (backdoor/yank pattern)") do
+      # CVE-2019-15224 shape: version X was backdoored, "> X" is a clean forward fix
+      # recorded in unaffected_versions rather than patched_versions.
+      advisory = unpatched(unaffected: [Gem::Requirement.new("< 1.18.0"), Gem::Requirement.new("> 1.18.0")])
+      expect(described_class.to_vulnerability(advisory)[:no_fix_available]).to(be(false))
+    end
+
+    it("marks no_fix_available false when a patched version exists") do
+      expect(vulnerability[:no_fix_available]).to(be(false))
     end
 
     it("falls back to the CVE id when there is no GHSA id") do

--- a/spec/still_active/sarif_helper_spec.rb
+++ b/spec/still_active/sarif_helper_spec.rb
@@ -303,6 +303,19 @@ RSpec.describe(StillActive::SarifHelper) do
       expect(sa003.size).to(eq(2))
     end
 
+    it("notes when an advisory has no fixed version available") do
+      report = {
+        "stuck" => {
+          version_used: "1.0.0",
+          vulnerabilities: [
+            { id: "CVE-2026-9", title: "RCE", cvss3_score: 9.0, no_fix_available: true },
+          ],
+        },
+      }
+      msg = render(result: report).dig("runs", 0, "results").find { |r| r["ruleId"] == "SA003" }.dig("message", "text")
+      expect(msg).to(include("no fixed version available"))
+    end
+
     it("maps CVSS to level (>= 7 -> error, 4-6.9 -> warning)") do
       sa003 = results.select { |r| r["ruleId"] == "SA003" }
       by_message = sa003.to_h { |r| [r["message"]["text"][/CVE-\d{4}-\d+/], r["level"]] }

--- a/spec/still_active/terminal_helper_spec.rb
+++ b/spec/still_active/terminal_helper_spec.rb
@@ -270,6 +270,21 @@ RSpec.describe(StillActive::TerminalHelper) do
       end
     end
 
+    context("with an unpatchable vulnerability") do
+      it("marks 'no fix' in the vulns column when an advisory has no fixed version") do
+        result = {
+          "leftpad" => {
+            version_used: "1.0.0",
+            latest_version: "1.0.0",
+            scorecard_score: nil,
+            vulnerability_count: 1,
+            vulnerabilities: [{ id: "CVE-1", cvss3_score: 7.5, no_fix_available: true }],
+          },
+        }
+        expect(described_class.render(result)).to(include("1 (high, no fix)"))
+      end
+    end
+
     context("with a poison-pill sub-line") do
       def poison_gem(constraints, extra = {})
         {

--- a/spec/still_active/vulnerability_helper_spec.rb
+++ b/spec/still_active/vulnerability_helper_spec.rb
@@ -91,6 +91,22 @@ RSpec.describe(StillActive::VulnerabilityHelper) do
     end
   end
 
+  describe(".no_fix_available?") do
+    it("is true when any advisory has no fixed version") do
+      vulns = [{ id: "A", no_fix_available: false }, { id: "B", no_fix_available: true }]
+      expect(described_class.no_fix_available?(vulns)).to(be(true))
+    end
+
+    it("is false when every advisory has a fix (or unknown)") do
+      expect(described_class.no_fix_available?([{ id: "A", no_fix_available: false }, { id: "B" }])).to(be(false))
+    end
+
+    it("is false for nil or empty") do
+      expect(described_class.no_fix_available?(nil)).to(be(false))
+      expect(described_class.no_fix_available?([])).to(be(false))
+    end
+  end
+
   describe(".merge_advisories") do
     it("returns an empty array when both sources are empty") do
       expect(described_class.merge_advisories(deps_dev: [], ruby_advisory_db: [])).to(eq([]))
@@ -124,6 +140,22 @@ RSpec.describe(StillActive::VulnerabilityHelper) do
       expect(merged[:title]).to(eq("from deps.dev")) # deps.dev preferred
       expect(merged[:cvss3_score]).to(eq(7.5))       # deps.dev preferred
       expect(merged[:aliases]).to(contain_exactly("CVE-1", "OSVDB-9")) # unioned
+    end
+
+    it("carries no_fix_available from ruby-advisory-db onto a merged advisory (deps.dev doesn't know it)") do
+      deps_dev = [{ id: "GHSA-aaa", aliases: [], source: "deps.dev" }]
+      radb = [{ id: "GHSA-aaa", aliases: [], no_fix_available: true, source: "ruby-advisory-db" }]
+      merged = described_class.merge_advisories(deps_dev: deps_dev, ruby_advisory_db: radb).first
+      expect(merged[:no_fix_available]).to(be(true))
+    end
+
+    it("lets ruby-advisory-db's no_fix determination win over a deps.dev value (radb is the sole authority)") do
+      # Guards the security-adjacent field against a future deps.dev that carries
+      # a (stale/wrong) no_fix value: the authoritative radb 'true' must survive.
+      deps_dev = [{ id: "GHSA-aaa", aliases: [], no_fix_available: false, source: "deps.dev" }]
+      radb = [{ id: "GHSA-aaa", aliases: [], no_fix_available: true, source: "ruby-advisory-db" }]
+      merged = described_class.merge_advisories(deps_dev: deps_dev, ruby_advisory_db: radb).first
+      expect(merged[:no_fix_available]).to(be(true))
     end
 
     it("merges when a deps.dev id matches a ruby-advisory-db alias") do


### PR DESCRIPTION
## What

Flags vulnerabilities you **can't upgrade out of**. `bundler-audit` says a gem is vulnerable; `bundle outdated` says you're current; neither tells you the reason you're stuck is that **no fixed version exists**. This surfaces that correlation — the "no fix" case where removal or a fork is the only path.

## How

- **`ruby_advisory_db`:** `no_fix_available` mirrors bundler-audit's own authoritative `!patched? && !unaffected?`, not just the patched half. Critical subtlety: a clean release shipped *after* a backdoored/yanked version is recorded in `unaffected_versions` as a `> X` range, **not** `patched_versions` (the CVE-2019-15224 bootstrap-sass pattern). So only a purely older-than-the-flaw safe range (`< X`) counts as no-forward-fix — we never claim "no fix" while a later safe release exists.
- **`vulnerability_helper`:** a `no_fix_available?` predicate; the merge lets ruby-advisory-db (the *sole authority* for this field) win, so a future deps.dev value can't override a radb "no fix" on a security-adjacent field (fail-safe).
- **All human surfaces + JSON:** terminal/markdown vulns column (`1 (high, no fix)`), SARIF SA003 message (`no fixed version available`). **Purely additive** — never alters the vuln count or severity.

## Dogfooded

```
active-support   -   -   -   1 (no fix)   -      # malicious typosquat, CVE-2018-3779, no patch
SARIF: CVE-2018-3779: Malicious ruby gem ... (no fixed version available).
```

## Review (this is security-adjacent, so two passes)

- **code-review** caught a real over-flag: `patched_versions.empty?` alone wrongly claims "no fix" for the backdoor-yank pattern (a `> X` unaffected range = a forward fix). **Fixed** to mirror bundler-audit's full semantics + a regression test.
- **silent-failure-hunter** flagged the merge trusting deps.dev over the authoritative radb (latent false-reassurance). **Fixed** to let radb win + a pinning test.

## Tests

893 examples, rubocop clean. PoC-validated against the real 1043-advisory ruby-advisory-db (101 unpatched; the backdoor cases correctly excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
