### PR TITLE
fix: don't assess a private-registry SBOM package against public data

### DIFF
--- a/lib/still_active/cli.rb
+++ b/lib/still_active/cli.rb
@@ -193,7 +193,8 @@ module StillActive
 
       noun = unassessable.size == 1 ? "dependency" : "dependencies"
       $stderr.puts("warning: #{unassessable.size} #{noun} could not be assessed " \
-        "(unsupported ecosystem, missing version, no package URL, or a lookup failure); see \"unassessable\" in the JSON output")
+        "(a private/alternative registry, unsupported ecosystem, missing version, no package URL, or a lookup failure); " \
+        "see \"unassessable\" in the JSON output")
     end
 
     # Dates live in the result as real Time objects (the activity/libyear math

--- a/lib/still_active/sbom_reader.rb
+++ b/lib/still_active/sbom_reader.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "uri"
 require "package_url"
 
 module StillActive
@@ -77,6 +78,25 @@ module StillActive
       classify_purl(purl, name)
     end
 
+    # Public registry hosts per ecosystem. A purl `repository_url` qualifier means
+    # a non-default (private/alternative) registry per the purl spec, EXCEPT when a
+    # generator redundantly names the public one -- so we still assess those.
+    PUBLIC_REGISTRY_HOSTS = [
+      "rubygems.org",
+      "registry.npmjs.org",
+      "npmjs.org",
+      "registry.yarnpkg.com",
+      "pypi.org",
+      "files.pythonhosted.org",
+      "crates.io",
+      "static.crates.io",
+      "index.crates.io",
+      "repo1.maven.org",
+      "repo.maven.apache.org",
+      "api.nuget.org",
+      "proxy.golang.org",
+    ].freeze
+
     def classify_purl(purl, name)
       parsed = PackageURL.parse(purl)
       type = parsed.type&.downcase
@@ -85,7 +105,21 @@ module StillActive
       if ecosystem
         return [:unassessable, { ecosystem: type, name: name, reason: :no_version }] if parsed.version.to_s.empty?
 
-        [:dependency, { ecosystem: ecosystem, name: build_name(ecosystem, parsed.namespace, parsed.name), version: parsed.version }]
+        full_name = build_name(ecosystem, parsed.namespace, parsed.name)
+        repository_url = parsed.qualifiers&.dig("repository_url")
+        # A private/alternative registry: never look the name up on the public
+        # registry (a same-named public package's data is not this one's -- the #43
+        # dependency-confusion guard, cross-ecosystem). We never dial the URL; its
+        # presence alone is the signal. Limit: this can only fire when the SBOM
+        # carries repository_url; a generator that omits it (Syft often can't
+        # determine the source registry) leaves a private package indistinguishable
+        # from a public one, so it is still assessed by name. Best-effort, not a
+        # guarantee that every private package is caught.
+        if repository_url && !public_registry?(repository_url)
+          return [:unassessable, { ecosystem: ecosystem, name: full_name, version: parsed.version, reason: :private_registry, repository_url: repository_url }]
+        end
+
+        [:dependency, { ecosystem: ecosystem, name: full_name, version: parsed.version }]
       elsif NOISE_TYPES.include?(type)
         nil # CI actions / opaque binaries: not a package dependency
       else
@@ -93,6 +127,20 @@ module StillActive
       end
     rescue PackageURL::InvalidPackageURL
       [:unassessable, { ecosystem: nil, name: name, reason: :malformed_purl }]
+    end
+
+    # Whether a repository_url points at a known public registry. We only read the
+    # host; we never connect to it (a lockfile/SBOM-derived URL is untrusted). An
+    # unparseable or non-public host reads as private, failing safe.
+    def public_registry?(repository_url)
+      host = registry_host(repository_url)
+      !host.nil? && PUBLIC_REGISTRY_HOSTS.include?(host)
+    end
+
+    def registry_host(url)
+      URI.parse(url.include?("//") ? url : "//#{url}").host&.downcase
+    rescue URI::InvalidURIError
+      nil
     end
 
     # Reconstruct the lookup name from the PURL's namespace + name: npm

--- a/spec/still_active/sbom_reader_spec.rb
+++ b/spec/still_active/sbom_reader_spec.rb
@@ -75,11 +75,41 @@ RSpec.describe(StillActive::SbomReader) do
   describe("edge cases") do
     def sbom(*components) = { "bomFormat" => "CycloneDX", "components" => components }.to_json
 
-    it("ignores a private repository_url qualifier (untrusted lockfile-derived input) yet still extracts the package") do
-      # The lens must never call a registry URL taken from the SBOM; we key only
-      # on ecosystem/name/version and look those up on the trusted public APIs.
+    it("classifies a package from a non-public repository_url as private (never substitutes public-registry data)") do
+      # A repository_url qualifier means a non-default (private/alternative)
+      # registry per the purl spec. We still never dial the URL -- we use its
+      # presence to refuse a public-by-name lookup, which would report a
+      # same-named PUBLIC package's data as if it were this private one
+      # (dependency confusion; the #43 principle, cross-ecosystem).
       body = sbom({ "type" => "library", "purl" => "pkg:pypi/internalpkg@1.0.0?repository_url=https://pypi.internal.example.com" })
-      expect(described_class.read_string(body)).to(eq([{ ecosystem: :pypi, name: "internalpkg", version: "1.0.0" }]))
+      result = described_class.parse_string(body)
+      expect(result.dependencies).to(eq([]))
+      expect(result.unassessable).to(eq([{
+        ecosystem: :pypi,
+        name: "internalpkg",
+        version: "1.0.0",
+        reason: :private_registry,
+        repository_url: "https://pypi.internal.example.com",
+      }]))
+    end
+
+    it("classifies a GitHub Packages npm package as private") do
+      body = sbom({ "type" => "library", "purl" => "pkg:npm/%40acme/utils@2.0.0?repository_url=https://npm.pkg.github.com" })
+      result = described_class.parse_string(body)
+      expect(result.dependencies).to(eq([]))
+      expect(result.unassessable.first).to(include(ecosystem: :npm, name: "@acme/utils", reason: :private_registry))
+    end
+
+    it("treats a userinfo-spoofed repository_url as private (the dependency-confusion payload)") do
+      # `pypi.org@evil.com` parses with host evil.com, not pypi.org -- the guard
+      # must not be fooled into a public lookup.
+      body = sbom({ "type" => "library", "purl" => "pkg:pypi/internalpkg@1.0.0?repository_url=https://pypi.org@evil.com" })
+      expect(described_class.parse_string(body).unassessable.first).to(include(reason: :private_registry))
+    end
+
+    it("still assesses a package whose repository_url redundantly names the PUBLIC registry") do
+      body = sbom({ "type" => "library", "purl" => "pkg:pypi/requests@2.0.0?repository_url=https://pypi.org" })
+      expect(described_class.read_string(body)).to(eq([{ ecosystem: :pypi, name: "requests", version: "2.0.0" }]))
     end
 
     it("extracts a scoped (possibly private) npm package by its full @scope/name") do


### PR DESCRIPTION
## What

Closes a cross-ecosystem **dependency-confusion gap** on the `--sbom` path. A private package (npm/pypi/cargo from GitHub Packages, Artifactory, an internal registry) whose name collides with a public one was looked up on public deps.dev/ecosyste.ms by bare name — so still_active reported the **public** same-named package's maintenance/vuln data as if it were your private dep (a clean bill of health that isn't yours).

The native Bundler path already guards this (#43: an unqueryable private source reports blanks, never substitutes public data). The `--sbom` path didn't.

## How

Per the purl spec, a `repository_url` qualifier denotes a **non-default (private/alternative)** registry. Use its *presence* — **never dialing it** (the URL is untrusted SBOM input) — to classify the package `unassessable` (`reason: :private_registry`) so it never reaches the public-by-name lookup. A `PUBLIC_REGISTRY_HOSTS` allowlist keeps a redundantly-declared public URL assessable; anything else (including an unparseable or userinfo-spoofed host like `pypi.org@evil.com`) fails safe to private.

## The reversal

This reverses the deliberate #89 behaviour (ignore `repository_url`, assess publicly), which optimised for coverage but substituted a stranger's verdict for your private dep. **Failing safe to "unassessable (private registry)" is the right bias for a security tool.** Honest limit noted in-code: it only fires when the SBOM *includes* `repository_url` (Syft often omits it — a package with no qualifier is still assessed by name).

## Dogfooded

```
components: public lodash@4.17.21 + private lodash@1.0.0 (repository_url=npm.pkg.github.com)
→ assessed:      ["npm/lodash@4.17.21"]
→ unassessable:  npm/lodash@1.0.0  reason=private_registry  repo=npm.pkg.github.com
```
The private lodash no longer inherits public lodash's assessment.

## Review

Both agents (this is security-sensitive) hunted the false-public-assessment direction: **no slip** — every crafted host (userinfo spoof, subdomain, missing scheme, unparseable, whitespace) fails safe to private. Added a userinfo-spoof regression test + fixed a latent `require "uri"`.

## Tests

896 examples, rubocop clean. This is **Phase 1** (safety); Phase 2 (fetch a private package's *own manifest* with opted-in creds to compute compatibility ceilings, where public tools are blind) is a separate, credential-config decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
