### PR TITLE
feat: severity tiers for poison-pill findings (rank + gate by how bad)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Usage: still_active [options]
         --fail-if-vulnerable[=SEVERITY]
                                      Exit 1 if any gem has vulnerabilities (optionally at or above SEVERITY)
         --fail-if-outdated=LIBYEARS  Exit 1 if any gem exceeds LIBYEARS behind latest
-        --fail-if-poison             Exit 1 if any dormant gem caps a dependency below its latest major (poison-pill)
+        --fail-if-poison[=TIER]      Exit 1 on a poison-pill at or above TIER (note|warning|critical; default warning)
         --ignore=GEM,GEM2,...        Exclude gems from pass/fail checks (still shown in output)
         --critical-warning-emoji=EMOJI
         --futurist-emoji=EMOJI
@@ -372,7 +372,7 @@ still_active --fail-if-warning --fail-if-vulnerable --ignore=legacy_gem --json
 fail_if_critical: true
 fail_if_vulnerable: high       # true, or a minimum severity: low|medium|high|critical
 fail_if_outdated: 3            # libyears
-fail_if_poison: true           # fail on a dormant gem that caps a dep below its latest major
+fail_if_poison: warning        # true (=warning), or a tier: note|warning|critical (severity scales with majors-behind)
 unreleased_commits: true
 output: json                   # terminal | markdown | json
 direct_only: true              # audit only declared deps, not the full transitive graph (--direct-only)

--- a/lib/helpers/constraint_helper.rb
+++ b/lib/helpers/constraint_helper.rb
@@ -63,6 +63,39 @@ module StillActive
       { kind: kind, majors_behind: behind }
     end
 
+    # Severity tiers for a compatibility ceiling, worst-last (mirrors
+    # StatusHelper::SEVERITY -- an ordinal set compared by index, never a numeric
+    # composite). :note is FYI, :warning is review-and-plan, :critical is act-now.
+    SEVERITY = [:note, :warning, :critical].freeze
+
+    # Tier one ceiling finding. Magnitude-driven: the real-project dogfood showed
+    # Ruby findings are bimodal -- 1 major behind is trivial (a done gem pinning an
+    # old minor), 3+ is a genuine upgrade wall (e.g. capping actionmailer below
+    # Rails 6). Popularity was rejected as an input (it ranks the framework blocker
+    # below a utility) and a vulnerable-gem escalator was rejected (that is the
+    # vulnerability finding's job, not the cap's).
+    def constraint_severity(finding)
+      case finding[:majors_behind]
+      when 2 then :warning
+      when 3.. then :critical
+      else :note
+      end
+    end
+
+    # The worst tier across a gem's CEILING findings (exact-pins are a milder
+    # hazard, not poison, and don't carry a tier), or nil when there are none.
+    def worst_severity(findings)
+      tiers = findings.filter_map { constraint_severity(_1) if _1[:kind] == :ceiling }
+      tiers.max_by { SEVERITY.index(_1) }
+    end
+
+    # For the --fail-if-poison[=TIER] gate: is `severity` at or above `threshold`?
+    def severity_at_or_above?(severity, threshold)
+      return false if severity.nil?
+
+      SEVERITY.index(severity) >= SEVERITY.index(threshold)
+    end
+
     # The poison condition: a below-latest ceiling or exact pin. A permissive
     # constraint, or a cap at/above the dep's latest major, is not a pill.
     def poison_ceiling?(requirement:, dep_latest:)

--- a/lib/helpers/markdown_helper.rb
+++ b/lib/helpers/markdown_helper.rb
@@ -124,8 +124,17 @@ module StillActive
       return "" if flagged.empty?
 
       lines = ["", "**Poison-pill findings** (dormant deps capping your tree below its latest major):"]
-      flagged.each do |name, data|
-        lines << "- #{poison_gem_ref(name, data)} caps #{poison_caps(data[:constraints])}"
+      # Worst-first so the act-now findings lead, then by magnitude for a stable,
+      # triage-friendly order.
+      ranked = flagged.sort_by do |name, data|
+        [
+          -ConstraintHelper::SEVERITY.index(data[:poison_severity] || :note),
+          -Array(data[:constraints]).map { |c| c[:majors_behind].to_i }.max,
+          name.to_s,
+        ]
+      end
+      ranked.each do |name, data|
+        lines << "- **#{data[:poison_severity] || :note}** #{poison_gem_ref(name, data)} caps #{poison_caps(data[:constraints])}"
       end
       lines.join("\n")
     end

--- a/lib/helpers/sarif_helper.rb
+++ b/lib/helpers/sarif_helper.rb
@@ -139,7 +139,10 @@ module StillActive
       end
 
       if data[:poison] && !Array(data[:constraints]).empty?
-        out << mark_suppressed(result("SA008", name, poison_message(name, version, data), location), name, :poison)
+        # Level tracks the poison tier: critical -> error, warning -> warning,
+        # note -> note. The fingerprint stays (rule_id, gem_name) so a tier change
+        # as the capped dep ships majors doesn't re-alert.
+        out << mark_suppressed(result("SA008", name, poison_message(name, version, data), location, level: poison_level(data)), name, :poison)
       end
 
       out
@@ -151,6 +154,10 @@ module StillActive
     # precise version, not the "8.x" the terminal abbreviates to), plus "+N more"
     # and the transitive parent. Note result() fingerprints on (rule_id, gem_name)
     # only, so this volatile detail never re-alerts a finding the user triaged.
+    def poison_level(data)
+      { critical: "error", warning: "warning", note: "note" }.fetch(data[:poison_severity], "warning")
+    end
+
     def poison_message(name, version, data)
       top = ConstraintHelper.top_findings(Array(data[:constraints]), limit: 3)
       caps = top[:shown].map do |finding|

--- a/lib/helpers/terminal_helper.rb
+++ b/lib/helpers/terminal_helper.rb
@@ -145,16 +145,23 @@ module StillActive
       end
     end
 
-    # "  ↳ poison: caps <receipt>", yellow because it is an actionable finding
-    # (the row is already red -- poison requires a dormant gem). Transitive gems
-    # name the direct parent that pulls the pill in, the actionable target.
+    # "  ↳ poison: caps <receipt>", coloured by severity tier (see poison_colour).
+    # The row is already red (poison requires a dormant gem); the sub-line tier
+    # says how urgent the cap is. Transitive gems name the direct parent that pulls
+    # the pill in, the actionable target.
     def poison_line(data)
       constraints = data[:constraints]
       return if constraints.nil? || constraints.empty?
 
       path = data[:dependency_path]
       via = data[:direct] == false && path && path.length >= 2 ? " (via #{path.first})" : ""
-      AnsiHelper.yellow("  ↳ poison#{via}: #{poison_receipt(constraints)}")
+      # Colour carries the tier: red = act-now (3+ majors behind), yellow = plan,
+      # dim = a minor/FYI cap (1 behind). The row is already red (dormant gem).
+      AnsiHelper.public_send(poison_colour(data[:poison_severity]), "  ↳ poison#{via}: #{poison_receipt(constraints)}")
+    end
+
+    def poison_colour(severity)
+      { critical: :red, warning: :yellow, note: :dim }.fetch(severity, :yellow)
     end
 
     # Single cap: the full receipt (requirement + latest major), since there's
@@ -246,8 +253,13 @@ module StillActive
       activity << ", #{archived} archived" if archived > 0
       parts << activity
       parts << "#{summary[:vulnerabilities]} vulnerabilities"
-      poison = result.each_value.count { |data| data[:poison] }
-      parts << AnsiHelper.yellow("#{poison} poison-#{poison == 1 ? "pill" : "pills"}") if poison > 0
+      poison = result.each_value.select { |data| data[:poison] }
+      unless poison.empty?
+        by_tier = poison.group_by { |data| data[:poison_severity] || :note }
+        present = ConstraintHelper::SEVERITY.reverse.select { |t| by_tier[t] } # worst-first
+        breakdown = present.map { |t| "#{by_tier[t].size} #{t}" }.join(", ")
+        parts << AnsiHelper.public_send(poison_colour(present.first), "#{poison.size} poison-#{poison.size == 1 ? "pill" : "pills"} (#{breakdown})")
+      end
       total_libyear = LibyearHelper.total_libyear(result)
       parts << "#{total_libyear.round(1)} libyears behind" if total_libyear > 0
       parts.join(" · ")

--- a/lib/still_active/cli.rb
+++ b/lib/still_active/cli.rb
@@ -400,7 +400,10 @@ module StillActive
       return false unless config.fail_if_poison
       return false if suppressions.suppressed?(gem: name, signal: :poison)
 
-      data[:poison] == true
+      # Bare --fail-if-poison fails at :warning and above (a 1-behind :note is FYI,
+      # not a build breaker); --fail-if-poison=TIER sets an explicit threshold.
+      threshold = config.fail_if_poison == true ? :warning : config.fail_if_poison
+      ConstraintHelper.severity_at_or_above?(data[:poison_severity], threshold)
     end
 
     def failed_activity?(name, data, config, suppressions)

--- a/lib/still_active/config_file.rb
+++ b/lib/still_active/config_file.rb
@@ -2,6 +2,7 @@
 
 require "yaml"
 require_relative "suppressions"
+require_relative "../helpers/constraint_helper"
 require_relative "../helpers/vulnerability_helper"
 
 module StillActive
@@ -48,7 +49,7 @@ module StillActive
         case key
         when "fail_if_critical" then set_boolean(config, :fail_if_critical=, value, key, warnings)
         when "fail_if_warning" then set_boolean(config, :fail_if_warning=, value, key, warnings)
-        when "fail_if_poison" then set_boolean(config, :fail_if_poison=, value, key, warnings)
+        when "fail_if_poison" then apply_fail_if_poison(config, value, warnings)
         when "alternatives" then set_boolean(config, :alternatives=, value, key, warnings)
         when "unreleased_commits" then set_boolean(config, :unreleased_commits=, value, key, warnings)
         when "direct_only" then set_boolean(config, :direct_only=, value, key, warnings)
@@ -132,6 +133,18 @@ module StillActive
         config.parallelism = value
       else
         warnings << "#{FILENAME}: parallelism must be a positive integer (got #{value.inspect}), ignoring it"
+      end
+    end
+
+    # true/false, or a severity tier (note|warning|critical). Mirrors the CLI
+    # flag: bare `true` fails at :warning, a tier sets an explicit threshold.
+    def apply_fail_if_poison(config, value, warnings)
+      if value == true || value == false
+        config.fail_if_poison = value
+      elsif ConstraintHelper::SEVERITY.map(&:to_s).include?(value.to_s)
+        config.fail_if_poison = value.to_sym
+      else
+        warnings << "#{FILENAME}: fail_if_poison must be true/false or one of #{ConstraintHelper::SEVERITY.join(", ")} (got #{value.inspect}), ignoring it"
       end
     end
 

--- a/lib/still_active/ecosystem_lens.rb
+++ b/lib/still_active/ecosystem_lens.rb
@@ -97,6 +97,7 @@ module StillActive
 
       gem_data[:constraints] = findings
       gem_data[:poison] = findings.any? { |finding| finding[:kind] == :ceiling }
+      gem_data[:poison_severity] = ConstraintHelper.worst_severity(findings) if gem_data[:poison]
     end
 
     # A capped dep's current latest version in `ecosystem`, via deps.dev's default

--- a/lib/still_active/options.rb
+++ b/lib/still_active/options.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "optparse"
+require_relative "../helpers/constraint_helper"
 require_relative "../helpers/cyclonedx_helper"
 require_relative "../helpers/vulnerability_helper"
 
@@ -162,8 +163,15 @@ module StillActive
       opts.on("--fail-if-outdated=LIBYEARS", Float, "Exit 1 if any gem exceeds LIBYEARS behind latest") do |value|
         StillActive.config { |config| config.fail_if_outdated = value }
       end
-      opts.on("--fail-if-poison", "Exit 1 if any dormant gem caps a dependency below its latest major (poison-pill)") do
-        StillActive.config { |config| config.fail_if_poison = true }
+      opts.on("--fail-if-poison[=TIER]", "Exit 1 on a poison-pill at or above TIER (note|warning|critical; default warning)") do |value|
+        if value
+          valid = StillActive::ConstraintHelper::SEVERITY.map(&:to_s)
+          raise ArgumentError, "--fail-if-poison tier must be one of: #{valid.join(", ")} (got #{value})" unless valid.include?(value)
+
+          StillActive.config { |config| config.fail_if_poison = value.to_sym }
+        else
+          StillActive.config { |config| config.fail_if_poison = true }
+        end
       end
     end
 

--- a/lib/still_active/workflow.rb
+++ b/lib/still_active/workflow.rb
@@ -246,6 +246,7 @@ module StillActive
       # is a milder resolution hazard: still surfaced in constraints, but it may be
       # deliberate, so it doesn't earn the poison label on its own.
       gem_data[:poison] = constraints.any? { |constraint| constraint[:kind] == :ceiling }
+      gem_data[:poison_severity] = ConstraintHelper.worst_severity(constraints) if gem_data[:poison]
     end
 
     # The capped dep's current latest stable version, for the majors-behind math.

--- a/spec/still_active/cli_spec.rb
+++ b/spec/still_active/cli_spec.rb
@@ -712,16 +712,28 @@ RSpec.describe(StillActive::CLI) do
   end
 
   describe("--fail-if-poison") do
-    def poison_gem
+    def poison_gem(severity = :critical)
       gem_data(last_commit_date: ancient_date).merge(
         poison: true,
+        poison_severity: severity,
         constraints: [{ dependency: "activemodel", requirement: "< 5.0", dep_latest: "8.0.1", majors_behind: 4, kind: :ceiling }],
       )
     end
 
-    it("exits 1 when a gem is a poison-pill") do
+    it("exits 1 when a critical poison-pill meets the default (warning) threshold") do
       StillActive.config.fail_if_poison = true
-      expect { cli.send(:check_exit_status, { "protected_attributes" => poison_gem }) }
+      expect { cli.send(:check_exit_status, { "protected_attributes" => poison_gem(:critical) }) }
+        .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(1)) })
+    end
+
+    it("does NOT exit on a note-level poison-pill under the default (warning) threshold") do
+      StillActive.config.fail_if_poison = true
+      expect { cli.send(:check_exit_status, { "tty-reader" => poison_gem(:note) }) }.not_to(raise_error)
+    end
+
+    it("exits on a note-level pill when the threshold is lowered to note") do
+      StillActive.config.fail_if_poison = :note
+      expect { cli.send(:check_exit_status, { "tty-reader" => poison_gem(:note) }) }
         .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(1)) })
     end
 

--- a/spec/still_active/constraint_helper_spec.rb
+++ b/spec/still_active/constraint_helper_spec.rb
@@ -175,6 +175,35 @@ RSpec.describe(StillActive::ConstraintHelper) do
     end
   end
 
+  describe("severity") do
+    def ceiling(behind)
+      { dependency: "d", requirement: "< x", dep_latest: "9.0.0", majors_behind: behind, kind: :ceiling }
+    end
+
+    it("tiers a ceiling by magnitude: 1 behind = note, 2 = warning, 3+ = critical") do
+      expect(described_class.constraint_severity(ceiling(1))).to(eq(:note))
+      expect(described_class.constraint_severity(ceiling(2))).to(eq(:warning))
+      expect(described_class.constraint_severity(ceiling(3))).to(eq(:critical))
+      expect(described_class.constraint_severity(ceiling(5))).to(eq(:critical))
+    end
+
+    it("rolls a gem's ceilings up to its worst tier (exact-pins excluded)") do
+      findings = [ceiling(1), ceiling(3), { dependency: "e", kind: :exact_pin, majors_behind: 9 }]
+      expect(described_class.worst_severity(findings)).to(eq(:critical))
+    end
+
+    it("returns nil worst_severity when there are no ceilings") do
+      expect(described_class.worst_severity([{ kind: :exact_pin, majors_behind: 4 }])).to(be_nil)
+    end
+
+    it("compares severities by ordinal for the gate threshold") do
+      expect(described_class.severity_at_or_above?(:critical, :warning)).to(be(true))
+      expect(described_class.severity_at_or_above?(:note, :warning)).to(be(false))
+      expect(described_class.severity_at_or_above?(:warning, :warning)).to(be(true))
+      expect(described_class.severity_at_or_above?(nil, :note)).to(be(false))
+    end
+  end
+
   describe(".poison_ceiling?") do
     it("is true only for a below-latest ceiling or exact pin") do
       expect(described_class.poison_ceiling?(requirement: "~> 4.2", dep_latest: "8.0.0")).to(be(true))

--- a/spec/still_active/markdown_helper_spec.rb
+++ b/spec/still_active/markdown_helper_spec.rb
@@ -395,6 +395,17 @@ RSpec.describe(StillActive::MarkdownHelper) do
         .to(include("`terrapin` via `paperclip` caps `climate_control` `< 1.0` (1 major behind, latest 1.x)"))
     end
 
+    it("ranks poison findings worst-first with a tier label per bullet") do
+      result = {
+        "minor" => poison_gem([{ dependency: "a", requirement: "~> 2", dep_latest: "3.0.0", majors_behind: 1, kind: :ceiling }], { poison_severity: :note }),
+        "blocker" => poison_gem([{ dependency: "b", requirement: "< 6", dep_latest: "9.0.0", majors_behind: 3, kind: :ceiling }], { poison_severity: :critical }),
+      }
+      out = described_class.poison_section(result)
+      expect(out).to(include("**critical** `blocker`"))
+      expect(out).to(include("**note** `minor`"))
+      expect(out.index("blocker")).to(be < out.index("minor")) # worst-first
+    end
+
     it("returns empty string when no gem is poison") do
       result = { "kaminari" => { source_type: :rubygems, poison: false } }
       expect(described_class.poison_section(result)).to(eq(""))

--- a/spec/still_active/terminal_helper_spec.rb
+++ b/spec/still_active/terminal_helper_spec.rb
@@ -339,6 +339,15 @@ RSpec.describe(StillActive::TerminalHelper) do
         expect(described_class.render(result)).to(include("2 poison-pills"))
       end
 
+      it("colours the poison line by severity tier (red critical, dim note)") do
+        crit = poison_gem([{ dependency: "x", requirement: "< 5", dep_latest: "8.0.0", majors_behind: 4, kind: :ceiling }], { poison_severity: :critical })
+        note = poison_gem([{ dependency: "y", requirement: "~> 2", dep_latest: "3.0.0", majors_behind: 1, kind: :ceiling }], { poison_severity: :note })
+        out = described_class.render({ "crit" => crit, "note" => note })
+        expect(out).to(match(/\e\[31m  ↳ poison: caps x/))   # red = critical
+        expect(out).to(match(/\e\[2m  ↳ poison: caps y/))    # dim = note
+        expect(out).to(include("2 poison-pills (1 critical, 1 note)"))
+      end
+
       it("prints no poison line for a non-poison gem") do
         result = { "kaminari" => { version_used: "1", latest_version: "1", vulnerability_count: 0, scorecard_score: nil, poison: false } }
         expect(described_class.render(result)).not_to(include("poison:"))

--- a/spec/still_active/workflow_spec.rb
+++ b/spec/still_active/workflow_spec.rb
@@ -502,6 +502,7 @@ RSpec.describe(StillActive::Workflow) do
 
         data = result["protected_attributes"]
         expect(data[:poison]).to(be(true))
+        expect(data[:poison_severity]).to(eq(:critical)) # 4 majors behind
         expect(data[:constraints]).to(eq([
           { dependency: "activemodel", requirement: "< 5.0, >= 4.0.1", dep_latest: "8.0.1", majors_behind: 4, kind: :ceiling },
         ]))


### PR DESCRIPTION
## What

Adds a **severity model** to the poison-pill signal. Previously flat (`poison=true`) — a real project surfaced 11 pills ranging from "caps actionmailer below Rails 6" (an upgrade wall) to "caps rake 1 minor behind" (trivial), all rendered identically. You couldn't tell which to fix.

## How (data-backed)

- `ConstraintHelper::SEVERITY = [:note, :warning, :critical]` — ordinal, mirrors `StatusHelper::SEVERITY` (no opaque score).
- `constraint_severity` is **magnitude-driven**: 1 major behind → `note`, 2 → `warning`, 3+ → `critical`. The dogfood showed Ruby findings are **bimodal** (trivial vs real wall). **Popularity was rejected** as an input — `dependent_packages_count` ranks the framework blocker (actionmailer) *below* a utility (paperclip) and floats rake to #1 — and a vulnerable-gem escalator was rejected (that's the vuln finding's job, not the cap's).
- `attach_constraints` stores `gem_data[:poison_severity]` (worst ceiling tier).
- **Terminal:** poison line colored by tier (red/yellow/dim) + tiered summary `11 poison-pills (6 critical, 5 note)`. **Markdown:** ranked worst-first with a `**tier**` label. **SARIF:** SA008 level maps tier → error/warning/note.
- **`--fail-if-poison[=TIER]`** is now threshold-based; **bare defaults to `:warning`** — a note-only tree no longer fails CI, a critical still does. (Behavior change from "fail on any poison"; safe since #98 is unreleased.) Config-file `fail_if_poison` accepts `true` or a tier.

## Dogfood (real mastodon-2018, 11 pills)

```
↳ poison: caps actionmailer < 6, >= 3 (3 majors behind, latest 8.x)   ← red (critical)
↳ poison (via tty-prompt): caps wisper ~> 2.0.0 (1 major behind…)      ← dim  (note)
…
11 poison-pills (6 critical, 5 note)
```
The 6 Rails-upgrade blockers render red, the 5 minor caps dim — triage at a glance.

## Tests

905 examples, rubocop clean. Review + simplifier both clean (added a nil-fold + a shared-severity `filter_map`). Severity/ranking/color/gate-threshold all covered.

## Follow-up

Language-runtime ceiling reuses the same severity function (EOL-forced → critical, latest-not-yet-supported → note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
