### PR TITLE
feat: language-runtime ceiling signal (SA009), poison's sibling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Ruby 4.0.1 (latest)
 | **Yanked version detection** | -                 | -                      | -                 | **Yes**                  |
 | **Ruby version freshness**   | -                 | -                      | -                 | **Yes** (EOL + libyear)  |
 | GitLab support               | -                 | -                      | -                 | Yes                      |
-| CI quality gates             | -                 | Exit code              | -                 | Yes (4 flags)            |
+| CI quality gates             | -                 | Exit code              | -                 | Yes (6 flags)            |
 | Output formats               | Text              | Text                   | Text              | Terminal, JSON, Markdown, SARIF, CycloneDX |
 
 The bolded rows are the gap `still_active` fills: nobody else answers "is the maintainer still around?" The CVE column is worth a closer look: `bundler-audit` reads `ruby-advisory-db` and `still_active` reads `deps.dev`, which sometimes diverge. **If `bundler-audit` is installed alongside `still_active`, we read its `ruby-advisory-db` checkout too and merge the results** (deduplicated, each advisory tagged with its `source`) — so running both no longer means reconciling two different vuln counts by hand.
@@ -130,6 +130,8 @@ Usage: still_active [options]
                                      Exit 1 if any gem has vulnerabilities (optionally at or above SEVERITY)
         --fail-if-outdated=LIBYEARS  Exit 1 if any gem exceeds LIBYEARS behind latest
         --fail-if-poison[=TIER]      Exit 1 on a poison-pill at or above TIER (note|warning|critical; default warning)
+        --fail-if-ruby-ceiling[=TIER]
+                                     Exit 1 on a Ruby-runtime ceiling at or above TIER (note|warning|critical; default warning)
         --ignore=GEM,GEM2,...        Exclude gems from pass/fail checks (still shown in output)
         --critical-warning-emoji=EMOJI
         --futurist-emoji=EMOJI
@@ -373,6 +375,7 @@ fail_if_critical: true
 fail_if_vulnerable: high       # true, or a minimum severity: low|medium|high|critical
 fail_if_outdated: 3            # libyears
 fail_if_poison: warning        # true (=warning), or a tier: note|warning|critical (severity scales with majors-behind)
+fail_if_ruby_ceiling: warning  # true (=warning), or a tier: note|warning|critical (EOL-forcing cap is critical)
 unreleased_commits: true
 output: json                   # terminal | markdown | json
 direct_only: true              # audit only declared deps, not the full transitive graph (--direct-only)
@@ -390,7 +393,7 @@ ignore:
 
   # Accept staleness on a vendored gem, but still fail if it gets a CVE
   - gem: legacy_thing
-    signal: activity            # activity | vulnerability | libyear | poison
+    signal: activity            # activity | vulnerability | libyear | poison | ruby_ceiling
     reason: "vendored, intentionally frozen"
 
   # A bare gem name keeps the old whole-gem behaviour (mutes every signal)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Usage: still_active [options]
         --fail-if-outdated=LIBYEARS  Exit 1 if any gem exceeds LIBYEARS behind latest
         --fail-if-poison[=TIER]      Exit 1 on a poison-pill at or above TIER (note|warning|critical; default warning)
         --fail-if-ruby-ceiling[=TIER]
-                                     Exit 1 on a Ruby-runtime ceiling at or above TIER (note|warning|critical; default warning)
+                                     Exit 1 on a Ruby-runtime ceiling (default: EOL-forced only; =note also gates latest-not-yet)
         --ignore=GEM,GEM2,...        Exclude gems from pass/fail checks (still shown in output)
         --critical-warning-emoji=EMOJI
         --futurist-emoji=EMOJI
@@ -375,7 +375,7 @@ fail_if_critical: true
 fail_if_vulnerable: high       # true, or a minimum severity: low|medium|high|critical
 fail_if_outdated: 3            # libyears
 fail_if_poison: warning        # true (=warning), or a tier: note|warning|critical (severity scales with majors-behind)
-fail_if_ruby_ceiling: warning  # true (=warning), or a tier: note|warning|critical (EOL-forcing cap is critical)
+fail_if_ruby_ceiling: true     # true = EOL-forced ceilings only; :note also gates latest-not-yet (fluctuates with Ruby's release calendar)
 unreleased_commits: true
 output: json                   # terminal | markdown | json
 direct_only: true              # audit only declared deps, not the full transitive graph (--direct-only)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,6 +1,6 @@
 # still_active SARIF Rules
 
-Each finding `still_active --sarif` emits maps to one of the rules below. Rule IDs (`SA001`–`SA008`) are stable across versions; renames or removals are breaking changes.
+Each finding `still_active --sarif` emits maps to one of the rules below. Rule IDs (`SA001`–`SA009`) are stable across versions; renames or removals are breaking changes.
 
 When uploaded via `github/codeql-action/upload-sarif`, findings appear in the GitHub Code Scanning UI and as inline annotations on `Gemfile.lock` in pull requests.
 
@@ -128,8 +128,22 @@ When uploaded via `github/codeql-action/upload-sarif`, findings appear in the Gi
 
 ---
 
+## SA009 — Ruby Runtime Ceiling {#sa009}
+
+**Triggers when:** a resolved gem version's declared `ruby_version` caps the Ruby you can run: either below every still-supported release (an EOL-forcing cap) or below the latest stable (a latest-not-yet cap). The runtime support window comes from [endoflife.date](https://endoflife.date/ruby).
+
+**Why it matters:** this is the language-runtime sibling of the poison pill. Where a poison pill caps a dependency, this caps your interpreter. An EOL-forcing cap strands you on a Ruby that receives no security patches, a genuine upgrade blocker. A latest-not-yet cap is a lower-stakes heads-up: a compatibility ceiling to plan around before you invest, or a place to contribute Ruby-N support upstream. It is not gated on maintenance status, since the cap is a fact of the resolved version whether or not the gem is still shipping.
+
+**SARIF level:** `note` by default, raised to `error` per result for an EOL-forcing cap · **security-severity:** none (a maintenance/compatibility finding, not a vulnerability) · **CWE:** [CWE-1104](https://cwe.mitre.org/data/definitions/1104.html)
+
+**How to fix:** if a newer release of the gem lifts the cap, upgrade it (the finding says so when it does). Otherwise replace or fork the gem, or contribute Ruby-N support upstream.
+
+**When to suppress:** when the pinned version is deliberate and the runtime ceiling is accepted. Suppress the `ruby_ceiling` signal for the specific gem in `.still_active.yml`, ideally with an `expires:` date so the acceptance is revisited.
+
+---
+
 ## Stability
 
-- Rule IDs are stable. New rules (SA009+) are additive. Existing rule renames/removals would be breaking changes.
+- Rule IDs are stable. New rules (SA010+) are additive. Existing rule renames/removals would be breaking changes.
 - `partialFingerprints` hash `(rule_id, gem_name, advisory_id?)` — version is **not** included, so a `bundle update` that doesn't change which gems are flagged keeps the same alert IDs (no churn in the GitHub Security UI).
 - Rule thresholds (libyear ≥ 1.0, scorecard < 4.0, abandonment ≥ 2 years) are tracked in `lib/helpers/sarif_helper.rb`.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -136,7 +136,9 @@ When uploaded via `github/codeql-action/upload-sarif`, findings appear in the Gi
 
 **SARIF level:** `note` by default, raised to `error` per result for an EOL-forcing cap · **security-severity:** none (a maintenance/compatibility finding, not a vulnerability) · **CWE:** [CWE-1104](https://cwe.mitre.org/data/definitions/1104.html)
 
-**How to fix:** if a newer release of the gem lifts the cap, upgrade it (the finding says so when it does). Otherwise replace or fork the gem, or contribute Ruby-N support upstream.
+**How to fix:** if a newer release of the gem lifts the cap, upgrade it (the finding says so when it does, unless a poison-pill on the same gem blocks that upgrade). Otherwise replace or fork the gem, or contribute Ruby-N support upstream.
+
+**Reading the negative space:** a declared `ruby_version` cap is a maintainer being honest about tested compatibility, not a defect. Equally, **no SA009 findings does not mean "safe to bump Ruby"**: the signal only sees gems that *declare* a cap. The most common real upgrade blockers (native extensions that fail to compile, removed stdlib, deprecated C-API) declare nothing and are invisible here. A latest-not-yet cap is also suppressed for a grace period after a new Ruby ships, since "doesn't support it yet" three days in is about the release calendar, not the gem.
 
 **When to suppress:** when the pinned version is deliberate and the runtime ceiling is accepted. Suppress the `ruby_ceiling` signal for the specific gem in `.still_active.yml`, ideally with an `expires:` date so the acceptance is revisited.
 

--- a/docs/still_active.schema.json
+++ b/docs/still_active.schema.json
@@ -86,7 +86,38 @@
         "version_used_release_date": { "type": ["string", "null"], "format": "date-time" },
         "version_yanked": { "type": "boolean" },
         "license": { "type": ["string", "null"] },
-        "libyear": { "type": ["number", "null"] }
+        "libyear": { "type": ["number", "null"] },
+        "poison": { "type": "boolean" },
+        "poison_severity": { "type": "string", "enum": ["note", "warning", "critical"] },
+        "constraints": { "type": "array", "items": { "$ref": "#/$defs/constraint" } },
+        "ruby_ceiling": { "$ref": "#/$defs/ruby_ceiling" }
+      }
+    },
+    "constraint": {
+      "type": "object",
+      "required": ["dependency", "requirement", "dep_latest", "majors_behind", "kind"],
+      "additionalProperties": false,
+      "properties": {
+        "dependency": { "type": "string" },
+        "requirement": { "type": "string" },
+        "dep_latest": { "type": ["string", "null"] },
+        "majors_behind": { "type": "integer", "minimum": 0 },
+        "kind": { "type": "string", "enum": ["ceiling", "exact_pin", "permissive"] }
+      }
+    },
+    "ruby_ceiling": {
+      "type": "object",
+      "required": ["requirement", "eol_forced", "severity", "oldest_supported", "latest_stable"],
+      "additionalProperties": false,
+      "properties": {
+        "requirement": { "type": "string" },
+        "eol_forced": { "type": "boolean" },
+        "severity": { "type": "string", "enum": ["note", "warning", "critical"] },
+        "ceiling_version": { "type": ["string", "null"] },
+        "ceiling_eol_date": { "type": ["string", "null"], "format": "date-time" },
+        "oldest_supported": { "type": "string" },
+        "latest_stable": { "type": "string" },
+        "fixed_by_upgrade": { "type": "boolean" }
       }
     },
     "vulnerability": {

--- a/docs/still_active.schema.json
+++ b/docs/still_active.schema.json
@@ -117,7 +117,8 @@
         "ceiling_eol_date": { "type": ["string", "null"], "format": "date-time" },
         "oldest_supported": { "type": "string" },
         "latest_stable": { "type": "string" },
-        "fixed_by_upgrade": { "type": "boolean" }
+        "fixed_by_upgrade": { "type": "boolean" },
+        "upgrade_blocked": { "type": "boolean" }
       }
     },
     "vulnerability": {

--- a/lib/helpers/constraint_helper.rb
+++ b/lib/helpers/constraint_helper.rb
@@ -75,6 +75,11 @@ module StillActive
     # below a utility) and a vulnerable-gem escalator was rejected (that is the
     # vulnerability finding's job, not the cap's).
     def constraint_severity(finding)
+      # A runtime ceiling that strands you on an end-of-life Ruby is act-now: no
+      # patched runtime is reachable. This short-circuit lets the language-ceiling
+      # signal (which carries no majors_behind) reuse the same tierer as poison.
+      return :critical if finding[:eol_forced]
+
       case finding[:majors_behind]
       when 2 then :warning
       when 3.. then :critical

--- a/lib/helpers/markdown_helper.rb
+++ b/lib/helpers/markdown_helper.rb
@@ -139,7 +139,37 @@ module StillActive
       lines.join("\n")
     end
 
+    # The language-runtime ceiling: a resolved version whose `ruby_version` caps
+    # the runtime onto an EOL Ruby (critical) or below the latest stable (note).
+    # Ranked worst-first with a tier label, mirroring the poison section.
+    def ruby_ceiling_section(result)
+      flagged = result.select { |_name, data| data[:ruby_ceiling] }
+      return "" if flagged.empty?
+
+      lines = ["", "**Ruby ceiling findings** (a resolved version's `ruby_version` capping your Ruby runtime):"]
+      ranked = flagged.sort_by { |name, data| [-ConstraintHelper::SEVERITY.index(data[:ruby_ceiling][:severity] || :note), name.to_s] }
+      ranked.each do |name, data|
+        ceiling = data[:ruby_ceiling]
+        lines << "- **#{ceiling[:severity] || :note}** #{MarkdownEscape.code_span(name)} #{ruby_ceiling_receipt(ceiling, data)}"
+      end
+      lines.join("\n")
+    end
+
     private
+
+    def ruby_ceiling_receipt(ceiling, data)
+      req = MarkdownEscape.code_span(ceiling[:requirement])
+      base =
+        if ceiling[:eol_forced]
+          eol = ceiling[:ceiling_eol_date]
+          eol_part = eol ? " (EOL #{eol.strftime("%Y-%m-%d")})" : ""
+          "requires Ruby #{req}, stranding you on end-of-life Ruby #{ceiling[:ceiling_version]}#{eol_part}"
+        else
+          "requires Ruby #{req}, no Ruby #{ceiling[:latest_stable]} support yet"
+        end
+      fix = ceiling[:fixed_by_upgrade] && data[:latest_version] ? "; upgrade to #{data[:latest_version]} to lift it" : ""
+      "#{base}#{fix}"
+    end
 
     def poison_gem_ref(name, data)
       ref = MarkdownEscape.code_span(name)

--- a/lib/helpers/ruby_helper.rb
+++ b/lib/helpers/ruby_helper.rb
@@ -68,8 +68,26 @@ module StillActive
       {
         oldest_supported: supported.map { |cycle| cycle[:version] }.min,
         latest_stable: Gem::Version.new(latest),
+        latest_stable_fresh: latest_stable_fresh?(cycles.first),
         cycles: normalized,
       }
+    end
+
+    # How long a newly-released runtime gets before gems are held accountable for
+    # not yet declaring support for it. Below this, a latest-not-yet ceiling is
+    # about the release calendar, not the gem, so the note is suppressed.
+    LATEST_STABLE_GRACE_SECONDS = 90 * 24 * 60 * 60
+
+    def latest_stable_fresh?(latest_cycle)
+      released = parse_date(latest_cycle["releaseDate"])
+      return false if released.nil?
+
+      (Time.now - released) < LATEST_STABLE_GRACE_SECONDS
+    rescue ArgumentError
+      # A malformed (non-nil) releaseDate from the best-effort feed must degrade to
+      # "not fresh" (notes fire as normal), never raise: raising here would null the
+      # whole support window and silently disable EOL-forced criticals too.
+      false
     end
 
     private

--- a/lib/helpers/ruby_helper.rb
+++ b/lib/helpers/ruby_helper.rb
@@ -42,7 +42,48 @@ module StillActive
       }
     end
 
+    # The runtime facts a per-gem language ceiling is measured against: the
+    # oldest Ruby cycle still receiving security releases, the latest stable
+    # release, and the normalized cycle list (version + EOL flag/date) so a
+    # ceiling finding can name the exact Ruby a cap strands you on and how long
+    # it's been dead. Reuses the same endoflife.date feed as #ruby_freshness.
+    # Returns nil when the feed is unavailable or every known cycle is EOL (no
+    # supported floor to compare against).
+    def supported_ruby_range
+      cycles = fetch_cycles
+      return if cycles.nil? || cycles.empty?
+
+      # endoflife.date is best-effort third-party data. Guard the newest cycle's
+      # `latest` the same way normalize_cycle guards `cycle`: a malformed/preview
+      # value must degrade to "sit out" (nil), not raise. This method is fetched
+      # once outside the per-gem rescue, so an unguarded raise would abort the
+      # entire audit, contrary to the best-effort contract.
+      latest = cycles.first["latest"]
+      return unless latest && Gem::Version.correct?(latest)
+
+      normalized = cycles.filter_map { |cycle| normalize_cycle(cycle) }
+      supported = normalized.reject { |cycle| cycle[:eol] }
+      return if supported.empty?
+
+      {
+        oldest_supported: supported.map { |cycle| cycle[:version] }.min,
+        latest_stable: Gem::Version.new(latest),
+        cycles: normalized,
+      }
+    end
+
     private
+
+    def normalize_cycle(cycle)
+      version = cycle["cycle"]
+      return unless version && Gem::Version.correct?(version)
+
+      {
+        version: Gem::Version.new(version),
+        eol: eol_reached?(cycle["eol"]) == true,
+        eol_date: parse_eol(cycle["eol"]),
+      }
+    end
 
     def current_ruby_version
       lockfile_ruby_version || (RUBY_ENGINE == "ruby" ? RUBY_VERSION : nil)

--- a/lib/helpers/runtime_ceiling_helper.rb
+++ b/lib/helpers/runtime_ceiling_helper.rb
@@ -45,7 +45,11 @@ module StillActive
 
       if supported_allowed.empty?
         eol_forced_finding(req, requirement, support_window)
-      elsif !req.satisfied_by?(support_window[:latest_stable])
+      elsif !req.satisfied_by?(support_window[:latest_stable]) && !support_window[:latest_stable_fresh]
+        # Runs on a supported runtime but not the latest stable. Suppressed while
+        # the latest stable is still within its grace window (see supported_ruby_
+        # range): right after a runtime ships, "doesn't support it yet" indicts the
+        # release calendar, not the gem. After the window it is a real note.
         latest_not_yet_finding(requirement, support_window)
       end
     end

--- a/lib/helpers/runtime_ceiling_helper.rb
+++ b/lib/helpers/runtime_ceiling_helper.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require_relative "constraint_helper"
+
+module StillActive
+  # The language-runtime sibling of the poison-pill signal, kept deliberately
+  # generic: it reads a constraint a package declares on its RUNTIME (the version
+  # range it can run on) and, given that runtime's support window, answers how much
+  # the constraint holds you back. Ruby (`ruby_version`) is the first consumer, but
+  # nothing here is Ruby-specific: the same core serves any runtime with an
+  # end-of-life calendar (Python's `requires_python`, etc.). The runtime-specific
+  # parts -- where the constraint string comes from, and how the support window is
+  # built -- live in the calibration layer (RubyHelper.supported_ruby_range) and
+  # the workflow boundary, exactly as poison keeps ConstraintHelper generic and
+  # pushes ecosystem resolution to the lens.
+  #
+  # Two tiers, mirroring the severity model:
+  #   - EOL-forced (critical): the constraint admits no still-supported runtime,
+  #     stranding you on an end-of-life release with no security patches. A genuine
+  #     upgrade blocker (e.g. a gem's `ruby_version < 3.2` caps at the EOL Ruby 3.1).
+  #   - latest-not-yet (note): runs on a supported runtime but caps below the latest
+  #     stable. An FYI ceiling to plan around, or a place to contribute support for
+  #     the newest release before you invest.
+  #
+  # A bare floor (`>= 3.1`) or a requires-newer constraint (`>= 4.1`, `~> 5.0`) is
+  # NOT a ceiling: it raises the minimum, it doesn't cap you onto a dead release.
+  # The distinction is drawn against the live EOL cycles, not the operator alone.
+  module RuntimeCeilingHelper
+    extend self
+
+    # Gem::Requirement caps input via a regex; a registry-derived string could be
+    # pathological. Bound it up front like ConstraintHelper does.
+    MAX_REQUIREMENT_LENGTH = 256
+
+    # => { requirement:, eol_forced:, severity:, ... } or nil when there's no
+    # ceiling. `support_window` is a { oldest_supported:, latest_stable:, cycles: }
+    # hash of Gem::Versions plus normalized EOL cycles (see supported_ruby_range).
+    def analyze(requirement:, support_window:)
+      return if support_window.nil?
+
+      req = safe_requirement(requirement)
+      return if req.nil? || !capping?(req)
+
+      supported_allowed = support_window[:cycles].reject { |c| c[:eol] }.select { |c| req.satisfied_by?(c[:version]) }
+
+      if supported_allowed.empty?
+        eol_forced_finding(req, requirement, support_window)
+      elsif !req.satisfied_by?(support_window[:latest_stable])
+        latest_not_yet_finding(requirement, support_window)
+      end
+    end
+
+    private
+
+    # A ceiling exists only if the constraint has an upper bound. A pure lower
+    # bound (`>`, `>=`) can never strand you on an old release, so skip it before
+    # any cycle math (this is also what keeps `>= 4.1` requires-newer out). Exact
+    # pins (`=`) are excluded deliberately: pinning a runtime to an exact patch is
+    # pathological (unheard of in practice) and can't be matched against the
+    # major.minor EOL cycles anyway, so we don't fabricate support for it.
+    CAPPING_OPERATORS = ["<", "<=", "~>"].freeze
+
+    def capping?(req)
+      req.requirements.any? { |operator, _version| CAPPING_OPERATORS.include?(operator) }
+    end
+
+    def eol_forced_finding(req, requirement, support_window)
+      # No supported release is admitted. Only a genuine cap (admits some EOL
+      # release) is EOL-forced; a requires-newer floor admits nothing at or below
+      # the oldest supported and is not our concern.
+      allowed_eol = support_window[:cycles].select { |c| c[:eol] && req.satisfied_by?(c[:version]) }
+      return if allowed_eol.empty?
+
+      ceiling = allowed_eol.max_by { |c| c[:version] }
+      finding = {
+        requirement: requirement,
+        eol_forced: true,
+        ceiling_version: ceiling[:version].to_s,
+        ceiling_eol_date: ceiling[:eol_date],
+        oldest_supported: support_window[:oldest_supported].to_s,
+        latest_stable: support_window[:latest_stable].to_s,
+      }
+      finding.merge(severity: ConstraintHelper.constraint_severity(finding))
+    end
+
+    def latest_not_yet_finding(requirement, support_window)
+      finding = {
+        requirement: requirement,
+        eol_forced: false,
+        oldest_supported: support_window[:oldest_supported].to_s,
+        latest_stable: support_window[:latest_stable].to_s,
+      }
+      finding.merge(severity: ConstraintHelper.constraint_severity(finding))
+    end
+
+    # Registries render a floor+ceiling requirement as a single comma-joined string
+    # (e.g. ">= 2.5, < 3.2" -- common for `ruby_version`/`required_ruby_version`).
+    # Gem::Requirement.new can't parse that one-string form (it raises), so split
+    # into clauses and splat, preserving BOTH bounds. Reading only the string as-is
+    # would drop the `< 3.2` ceiling and silently miss the very case this exists to
+    # catch. Best-effort: a genuinely malformed clause degrades to nil (no finding),
+    # never a raised exception that could break the core audit.
+    def safe_requirement(requirement)
+      return if requirement.nil? || requirement.to_s.length > MAX_REQUIREMENT_LENGTH
+
+      clauses = requirement.to_s.split(",").map(&:strip).reject(&:empty?)
+      return if clauses.empty?
+
+      Gem::Requirement.new(*clauses)
+    rescue ArgumentError
+      # Covers Gem::Requirement::BadRequirementError (a subclass) plus any other
+      # malformed-input ArgumentError, so a pathological registry string degrades
+      # to "no ceiling" and never breaks the core audit.
+      nil
+    end
+  end
+end

--- a/lib/helpers/sarif_helper.rb
+++ b/lib/helpers/sarif_helper.rb
@@ -147,9 +147,14 @@ module StillActive
 
       if data[:ruby_ceiling]
         # Level tracks the ceiling tier: critical (EOL-forced) -> error, note
-        # (latest-not-yet) -> note. Fingerprint stays (rule_id, gem_name) so a
-        # shifting Ruby support window doesn't re-alert a triaged finding.
-        out << mark_suppressed(result("SA009", name, ruby_ceiling_message(name, version, data), location, level: ruby_ceiling_level(data)), name, :ruby_ceiling)
+        # (latest-not-yet) -> note. Fingerprint is (rule_id, gem_name, state) where
+        # state is the eol_forced boolean: cosmetic churn (which patch, which
+        # latest) doesn't re-alert, but a note -> EOL-forced escalation (a supported
+        # Ruby went EOL) mints a NEW alert so a past dismissal of the note can't
+        # silently mute the critical -- that transition is exactly the one a human
+        # must see.
+        state = data[:ruby_ceiling][:eol_forced] ? "eol_forced" : "latest_not_yet"
+        out << mark_suppressed(result("SA009", name, ruby_ceiling_message(name, version, data), location, level: ruby_ceiling_level(data), fp_extra: state), name, :ruby_ceiling)
       end
 
       out

--- a/lib/helpers/sarif_helper.rb
+++ b/lib/helpers/sarif_helper.rb
@@ -145,7 +145,32 @@ module StillActive
         out << mark_suppressed(result("SA008", name, poison_message(name, version, data), location, level: poison_level(data)), name, :poison)
       end
 
+      if data[:ruby_ceiling]
+        # Level tracks the ceiling tier: critical (EOL-forced) -> error, note
+        # (latest-not-yet) -> note. Fingerprint stays (rule_id, gem_name) so a
+        # shifting Ruby support window doesn't re-alert a triaged finding.
+        out << mark_suppressed(result("SA009", name, ruby_ceiling_message(name, version, data), location, level: ruby_ceiling_level(data)), name, :ruby_ceiling)
+      end
+
       out
+    end
+
+    def ruby_ceiling_level(data)
+      { critical: "error", warning: "warning", note: "note" }.fetch(data[:ruby_ceiling][:severity], "note")
+    end
+
+    def ruby_ceiling_message(name, version, data)
+      ceiling = data[:ruby_ceiling]
+      body =
+        if ceiling[:eol_forced]
+          eol = ceiling[:ceiling_eol_date]
+          eol_part = eol ? " (EOL #{format_date(eol)})" : ""
+          "stranding you on end-of-life Ruby #{ceiling[:ceiling_version]}#{eol_part}"
+        else
+          "no Ruby #{ceiling[:latest_stable]} support yet"
+        end
+      fix = ceiling[:fixed_by_upgrade] && data[:latest_version] ? "; upgrade to #{data[:latest_version]} to lift it" : ""
+      "#{name} #{version}: requires Ruby #{ceiling[:requirement]}, #{body}#{fix}#{transitive_suffix(data)}."
     end
 
     # The poison receipt for a Code Scanning alert: the worst 3 caps (shared

--- a/lib/helpers/terminal_helper.rb
+++ b/lib/helpers/terminal_helper.rb
@@ -138,11 +138,47 @@ module StillActive
     # alternatives line. A non-poison gem keeps the prior behaviour: transitive
     # gems point at the parent (#60), direct ones offer alternatives.
     def sub_lines(data)
-      if data[:poison]
-        [poison_line(data), (data[:direct] == false ? nil : alternatives_line(data))].compact
+      lines = if data[:poison]
+        [poison_line(data), (data[:direct] == false ? nil : alternatives_line(data))]
       else
-        [data[:direct] == false ? dependency_path_line(data) : alternatives_line(data)].compact
+        [data[:direct] == false ? dependency_path_line(data) : alternatives_line(data)]
       end
+      # A language-runtime ceiling is orthogonal to poison/alternatives (a gem can
+      # be maintained yet still cap your Ruby), so it always gets its own line.
+      lines << ruby_ceiling_line(data)
+      lines.compact
+    end
+
+    # "  ↳ ruby ceiling: <receipt>", coloured by tier (red = strands you on an EOL
+    # Ruby, dim = an FYI cap below the latest stable). Reuses poison_colour.
+    def ruby_ceiling_line(data)
+      ceiling = data[:ruby_ceiling]
+      return if ceiling.nil?
+
+      AnsiHelper.public_send(poison_colour(ceiling[:severity]), "  ↳ ruby ceiling: #{ruby_ceiling_receipt(ceiling, data)}")
+    end
+
+    def ruby_ceiling_receipt(ceiling, data)
+      base =
+        if ceiling[:eol_forced]
+          "requires Ruby #{ceiling[:requirement]}, stranding you on end-of-life Ruby #{ceiling[:ceiling_version]}#{eol_suffix(ceiling[:ceiling_eol_date])}"
+        else
+          "requires Ruby #{ceiling[:requirement]}, no Ruby #{ceiling[:latest_stable]} support yet"
+        end
+      "#{base}#{ruby_ceiling_fix_hint(ceiling, data)}"
+    end
+
+    def eol_suffix(eol_date)
+      eol_date ? " (EOL #{eol_date.strftime("%Y-%m-%d")})" : ""
+    end
+
+    # Name the actionable fix when a newer release of the gem lifts the cap; the
+    # gem's own name sits on the row directly above, so "upgrade to <latest>" reads
+    # unambiguously without repeating it.
+    def ruby_ceiling_fix_hint(ceiling, data)
+      return "" unless ceiling[:fixed_by_upgrade] && data[:latest_version]
+
+      "; upgrade to #{data[:latest_version]} to lift it"
     end
 
     # "  ↳ poison: caps <receipt>", coloured by severity tier (see poison_colour).
@@ -162,6 +198,18 @@ module StillActive
 
     def poison_colour(severity)
       { critical: :red, warning: :yellow, note: :dim }.fetch(severity, :yellow)
+    end
+
+    # A worst-first "N label (X critical, Y note)" summary fragment, coloured by
+    # the worst tier present, or nil when there are none. Shared by the poison and
+    # Ruby-ceiling counts (both roll a set of tiered findings up the same way).
+    def tier_summary_part(severities, label)
+      return if severities.empty?
+
+      by_tier = severities.group_by { |severity| severity || :note }
+      present = ConstraintHelper::SEVERITY.reverse.select { |tier| by_tier[tier] } # worst-first
+      breakdown = present.map { |tier| "#{by_tier[tier].size} #{tier}" }.join(", ")
+      AnsiHelper.public_send(poison_colour(present.first), "#{label} (#{breakdown})")
     end
 
     # Single cap: the full receipt (requirement + latest major), since there's
@@ -253,13 +301,12 @@ module StillActive
       activity << ", #{archived} archived" if archived > 0
       parts << activity
       parts << "#{summary[:vulnerabilities]} vulnerabilities"
-      poison = result.each_value.select { |data| data[:poison] }
-      unless poison.empty?
-        by_tier = poison.group_by { |data| data[:poison_severity] || :note }
-        present = ConstraintHelper::SEVERITY.reverse.select { |t| by_tier[t] } # worst-first
-        breakdown = present.map { |t| "#{by_tier[t].size} #{t}" }.join(", ")
-        parts << AnsiHelper.public_send(poison_colour(present.first), "#{poison.size} poison-#{poison.size == 1 ? "pill" : "pills"} (#{breakdown})")
-      end
+      poison_tiers = result.each_value.select { |data| data[:poison] }.map { |data| data[:poison_severity] }
+      poison_part = tier_summary_part(poison_tiers, "#{poison_tiers.size} poison-#{poison_tiers.size == 1 ? "pill" : "pills"}")
+      parts << poison_part if poison_part
+      ceilings = result.each_value.filter_map { |data| data[:ruby_ceiling] }
+      ceiling_part = tier_summary_part(ceilings.map { |ceiling| ceiling[:severity] }, "#{ceilings.size} Ruby ceiling#{"s" unless ceilings.size == 1}")
+      parts << ceiling_part if ceiling_part
       total_libyear = LibyearHelper.total_libyear(result)
       parts << "#{total_libyear.round(1)} libyears behind" if total_libyear > 0
       parts.join(" · ")

--- a/lib/helpers/version_helper.rb
+++ b/lib/helpers/version_helper.rb
@@ -44,6 +44,15 @@ module StillActive
       Time.parse(release_date) unless release_date.nil?
     end
 
+    # The version's declared Ruby requirement (the `ruby_version` field in the
+    # RubyGems versions payload, e.g. ">= 3.2", "< 3.2"), or nil when absent. This
+    # is the language-runtime ceiling's raw input; note it is `ruby_version`, not
+    # the gemspec's `required_ruby_version`.
+    def ruby_requirement(version_hash:)
+      requirement = version_hash&.dig("ruby_version")
+      requirement unless requirement.nil? || requirement.empty?
+    end
+
     # SPDX license identifier(s) from the RubyGems versions payload.
     # Comma-joined when a gem declares more than one. nil when unknown.
     def license(version_hash:)

--- a/lib/still_active/cli.rb
+++ b/lib/still_active/cli.rb
@@ -341,6 +341,8 @@ module StillActive
       end
       poison = MarkdownHelper.poison_section(result)
       puts poison unless poison.empty?
+      ruby_ceiling = MarkdownHelper.ruby_ceiling_section(result)
+      puts ruby_ceiling unless ruby_ceiling.empty?
       alternatives = MarkdownHelper.alternatives_section(result)
       puts alternatives unless alternatives.empty?
       transitive = MarkdownHelper.transitive_section(result)
@@ -353,7 +355,7 @@ module StillActive
 
     def check_exit_status(result)
       config = StillActive.config
-      return unless config.fail_if_critical || config.fail_if_warning || config.fail_if_vulnerable || config.fail_if_outdated || config.fail_if_poison
+      return unless config.fail_if_critical || config.fail_if_warning || config.fail_if_vulnerable || config.fail_if_outdated || config.fail_if_poison || config.fail_if_ruby_ceiling
 
       warn_unknown_severity_gate(result, config)
       exit(1) if result.any? { |name, data| gate_failed?(name, data, config) }
@@ -393,7 +395,8 @@ module StillActive
       failed_activity?(name, data, config, suppressions) ||
         failed_vulnerability?(name, data, config, suppressions) ||
         failed_outdated?(name, data, config, suppressions) ||
-        failed_poison?(name, data, config, suppressions)
+        failed_poison?(name, data, config, suppressions) ||
+        failed_ruby_ceiling?(name, data, config, suppressions)
     end
 
     def failed_poison?(name, data, config, suppressions)
@@ -404,6 +407,17 @@ module StillActive
       # not a build breaker); --fail-if-poison=TIER sets an explicit threshold.
       threshold = config.fail_if_poison == true ? :warning : config.fail_if_poison
       ConstraintHelper.severity_at_or_above?(data[:poison_severity], threshold)
+    end
+
+    def failed_ruby_ceiling?(name, data, config, suppressions)
+      return false unless config.fail_if_ruby_ceiling
+      return false if suppressions.suppressed?(gem: name, signal: :ruby_ceiling)
+
+      # Same threshold semantics as poison: bare flag fails at :warning+ (a
+      # latest-not-yet :note is an FYI/contribution lead, not a build breaker); an
+      # EOL-forcing ceiling is :critical and always trips the default.
+      threshold = config.fail_if_ruby_ceiling == true ? :warning : config.fail_if_ruby_ceiling
+      ConstraintHelper.severity_at_or_above?(data.dig(:ruby_ceiling, :severity), threshold)
     end
 
     def failed_activity?(name, data, config, suppressions)

--- a/lib/still_active/cli.rb
+++ b/lib/still_active/cli.rb
@@ -413,10 +413,12 @@ module StillActive
       return false unless config.fail_if_ruby_ceiling
       return false if suppressions.suppressed?(gem: name, signal: :ruby_ceiling)
 
-      # Same threshold semantics as poison: bare flag fails at :warning+ (a
-      # latest-not-yet :note is an FYI/contribution lead, not a build breaker); an
-      # EOL-forcing ceiling is :critical and always trips the default.
-      threshold = config.fail_if_ruby_ceiling == true ? :warning : config.fail_if_ruby_ceiling
+      # Ceiling findings are only ever :critical (EOL-forced) or :note
+      # (latest-not-yet) -- there is no :warning tier for this signal -- so the
+      # bare flag defaults to :critical (the genuine blocker: no supported Ruby is
+      # reachable). A latest-not-yet :note is an FYI/contribution lead that gates
+      # only when the user explicitly opts in with =note.
+      threshold = config.fail_if_ruby_ceiling == true ? :critical : config.fail_if_ruby_ceiling
       ConstraintHelper.severity_at_or_above?(data.dig(:ruby_ceiling, :severity), threshold)
     end
 

--- a/lib/still_active/config.rb
+++ b/lib/still_active/config.rb
@@ -18,6 +18,7 @@ module StillActive
       :cyclonedx_version,
       :fail_if_critical,
       :fail_if_poison,
+      :fail_if_ruby_ceiling,
       :fail_if_warning,
       :futurist_emoji,
       :gems,
@@ -40,6 +41,7 @@ module StillActive
       @direct_only = false
       @fail_if_critical = false
       @fail_if_poison = false
+      @fail_if_ruby_ceiling = false
       @fail_if_outdated = nil
       @fail_if_vulnerable = nil
       @fail_if_warning = false

--- a/lib/still_active/config_file.rb
+++ b/lib/still_active/config_file.rb
@@ -50,6 +50,7 @@ module StillActive
         when "fail_if_critical" then set_boolean(config, :fail_if_critical=, value, key, warnings)
         when "fail_if_warning" then set_boolean(config, :fail_if_warning=, value, key, warnings)
         when "fail_if_poison" then apply_fail_if_poison(config, value, warnings)
+        when "fail_if_ruby_ceiling" then apply_fail_if_ruby_ceiling(config, value, warnings)
         when "alternatives" then set_boolean(config, :alternatives=, value, key, warnings)
         when "unreleased_commits" then set_boolean(config, :unreleased_commits=, value, key, warnings)
         when "direct_only" then set_boolean(config, :direct_only=, value, key, warnings)
@@ -145,6 +146,18 @@ module StillActive
         config.fail_if_poison = value.to_sym
       else
         warnings << "#{FILENAME}: fail_if_poison must be true/false or one of #{ConstraintHelper::SEVERITY.join(", ")} (got #{value.inspect}), ignoring it"
+      end
+    end
+
+    # true/false, or a severity tier (note|warning|critical). Mirrors the CLI
+    # flag: bare `true` fails at :warning, a tier sets an explicit threshold.
+    def apply_fail_if_ruby_ceiling(config, value, warnings)
+      if value == true || value == false
+        config.fail_if_ruby_ceiling = value
+      elsif ConstraintHelper::SEVERITY.map(&:to_s).include?(value.to_s)
+        config.fail_if_ruby_ceiling = value.to_sym
+      else
+        warnings << "#{FILENAME}: fail_if_ruby_ceiling must be true/false or one of #{ConstraintHelper::SEVERITY.join(", ")} (got #{value.inspect}), ignoring it"
       end
     end
 

--- a/lib/still_active/options.rb
+++ b/lib/still_active/options.rb
@@ -173,11 +173,16 @@ module StillActive
           StillActive.config { |config| config.fail_if_poison = true }
         end
       end
-      opts.on("--fail-if-ruby-ceiling[=TIER]", "Exit 1 on a Ruby-runtime ceiling at or above TIER (note|warning|critical; default warning)") do |value|
+      opts.on("--fail-if-ruby-ceiling[=TIER]", "Exit 1 on a Ruby-runtime ceiling (default: EOL-forced only; =note also gates latest-not-yet)") do |value|
         if value
           valid = StillActive::ConstraintHelper::SEVERITY.map(&:to_s)
           raise ArgumentError, "--fail-if-ruby-ceiling tier must be one of: #{valid.join(", ")} (got #{value})" unless valid.include?(value)
 
+          # Ceiling findings are only ever :critical or :note, so =warning can't
+          # match anything the bare (=critical) default doesn't already catch.
+          if value == "warning"
+            $stderr.puts("warning: --fail-if-ruby-ceiling=warning has no effect (runtime ceilings are only critical or note); behaves as =critical")
+          end
           StillActive.config { |config| config.fail_if_ruby_ceiling = value.to_sym }
         else
           StillActive.config { |config| config.fail_if_ruby_ceiling = true }

--- a/lib/still_active/options.rb
+++ b/lib/still_active/options.rb
@@ -173,6 +173,16 @@ module StillActive
           StillActive.config { |config| config.fail_if_poison = true }
         end
       end
+      opts.on("--fail-if-ruby-ceiling[=TIER]", "Exit 1 on a Ruby-runtime ceiling at or above TIER (note|warning|critical; default warning)") do |value|
+        if value
+          valid = StillActive::ConstraintHelper::SEVERITY.map(&:to_s)
+          raise ArgumentError, "--fail-if-ruby-ceiling tier must be one of: #{valid.join(", ")} (got #{value})" unless valid.include?(value)
+
+          StillActive.config { |config| config.fail_if_ruby_ceiling = value.to_sym }
+        else
+          StillActive.config { |config| config.fail_if_ruby_ceiling = true }
+        end
+      end
     end
 
     def add_emoji_options(opts)

--- a/lib/still_active/sarif/rules.rb
+++ b/lib/still_active/sarif/rules.rb
@@ -2,7 +2,7 @@
 
 module StillActive
   module Sarif
-    # Catalog of SARIF rules emitted by still_active. Rule IDs (SA001-SA008)
+    # Catalog of SARIF rules emitted by still_active. Rule IDs (SA001-SA009)
     # are stable across versions; renames or removals are breaking changes.
     #
     # Each rule maps a still_active finding into a SARIF result. Security
@@ -114,6 +114,16 @@ module StillActive
           level: "warning",
           security_severity: nil, # maintenance/resolvability, not a CVE (as SA002/SA004/SA005)
           tags: ["maintenance", "supply-chain", "external/cwe/cwe-1104"],
+        },
+        {
+          id: "SA009",
+          name: "RubyRuntimeCeiling",
+          short: "Resolved gem version caps the Ruby runtime",
+          full: "A resolved gem version's declared `ruby_version` caps the Ruby you can run: either below every still-supported release (stranding you on an end-of-life Ruby with no security patches) or below the latest stable (a compatibility ceiling to plan around). The default level is note; an EOL-forcing cap is raised to error per result.",
+          help_text: "If a newer release of the gem lifts the cap, upgrade it. Otherwise replace or fork the gem, or contribute Ruby-N support upstream.",
+          level: "note",
+          security_severity: nil, # maintenance/compatibility, not a CVE (as SA002/SA004/SA005/SA008)
+          tags: ["maintenance", "runtime", "external/cwe/cwe-1104"],
         },
       ].freeze
 

--- a/lib/still_active/suppressions.rb
+++ b/lib/still_active/suppressions.rb
@@ -16,7 +16,7 @@ module StillActive
   # name an explicit advisory id, so a newly disclosed CVE on the same gem is
   # never pre-silenced.
   class Suppressions
-    GATEABLE_SIGNALS = [:activity, :vulnerability, :libyear, :poison].freeze
+    GATEABLE_SIGNALS = [:activity, :vulnerability, :libyear, :poison, :ruby_ceiling].freeze
 
     Entry = Struct.new(:gem, :advisory, :signal, :reason, :expires, keyword_init: true) do
       def whole_gem?

--- a/lib/still_active/workflow.rb
+++ b/lib/still_active/workflow.rb
@@ -15,6 +15,7 @@ require_relative "../helpers/http_helper"
 require_relative "../helpers/libyear_helper"
 require_relative "../helpers/ruby_advisory_db"
 require_relative "../helpers/ruby_helper"
+require_relative "../helpers/runtime_ceiling_helper"
 require_relative "../helpers/version_helper"
 require_relative "../helpers/vulnerability_helper"
 require "async"
@@ -33,6 +34,19 @@ module StillActive
         # read-only Database is shared across fibers rather than reloaded per gem.
         advisory_db = RubyAdvisoryDb.load
         catalog = StillActive.config.alternatives ? CatalogIndex.load : nil
+        # The Ruby support window (oldest-supported / latest-stable / EOL cycles)
+        # is a per-run constant, so fetch it once here rather than per gem. nil when
+        # the endoflife feed is unavailable -> the language-ceiling signal quietly
+        # sits out, exactly like a missing advisory_db. This runs OUTSIDE the
+        # per-gem rescue, so a defensive rescue keeps a best-effort enrichment from
+        # ever aborting the whole audit (the "never crash the core" contract).
+        ruby_range =
+          begin
+            RubyHelper.supported_ruby_range
+          rescue StandardError => e
+            $stderr.puts("warning: Ruby support window lookup failed: #{e.class} (#{e.message}); skipping language-ceiling checks")
+            nil
+          end
         # Resolve the GitHub token once here, single-fibered, before the fan-out:
         # provider_for reads it per gem across fibers and gh_cli_token shells out,
         # so resolving eagerly keeps that off the concurrent path and guarantees
@@ -62,6 +76,7 @@ module StillActive
               advisory_db: advisory_db,
               catalog: catalog,
               constraint_cache: constraint_cache,
+              ruby_range: ruby_range,
             )
           rescue Octokit::TooManyRequests
             $stderr.print("\r\e[K") if on_progress
@@ -89,7 +104,7 @@ module StillActive
 
     private
 
-    def gem_info(gem_name:, result_object:, gem_version: nil, source_type: :rubygems, source_uri: nil, direct: true, dependency_path: nil, advisory_db: nil, catalog: nil, constraint_cache: {})
+    def gem_info(gem_name:, result_object:, gem_version: nil, source_type: :rubygems, source_uri: nil, direct: true, dependency_path: nil, advisory_db: nil, catalog: nil, constraint_cache: {}, ruby_range: nil)
       result_object[gem_name] = { source_type: source_type, direct: direct }
       result_object[gem_name][:dependency_path] = dependency_path if dependency_path
       result_object[gem_name][:version_used] = gem_version if gem_version
@@ -104,6 +119,7 @@ module StillActive
           result_object: result_object,
           source_uri: source_uri,
           advisory_db: advisory_db,
+          ruby_range: ruby_range,
         )
       end
 
@@ -116,7 +132,7 @@ module StillActive
       end
     end
 
-    def gem_info_rubygems(gem_name:, gem_version:, result_object:, source_uri:, advisory_db: nil)
+    def gem_info_rubygems(gem_name:, gem_version:, result_object:, source_uri:, advisory_db: nil, ruby_range: nil)
       vs = versions(gem_name: gem_name, source_uri: source_uri)
       repo_info = repository_info(gem_name: gem_name, versions: vs, source_uri: source_uri)
       signals = repo_signals(
@@ -159,8 +175,8 @@ module StillActive
         )
       end
 
+      version_used = gem_version ? VersionHelper.find_version(versions: vs, version_string: gem_version) : nil
       if gem_version
-        version_used = VersionHelper.find_version(versions: vs, version_string: gem_version)
         result_object[gem_name].merge!({
           up_to_date: VersionHelper.up_to_date(
             version_used: version_used,
@@ -177,6 +193,47 @@ module StillActive
           ),
         })
       end
+
+      attach_ruby_ceiling(
+        gem_data: result_object[gem_name],
+        used_version_hash: version_used,
+        latest_version_hash: last_release,
+        ruby_range: ruby_range,
+      )
+    end
+
+    # Language-runtime ceiling: the sibling of poison. A gem's resolved version
+    # declares a `ruby_version` that caps the runtime -- either onto an end-of-life
+    # Ruby (critical: no patched runtime is reachable) or below the latest stable
+    # (note: a compatibility ceiling to plan around / a place to contribute Ruby-N
+    # support). Unlike poison this is NOT gated on dormancy: a cap is a fact of the
+    # resolved version whether or not the gem is maintained. Best-effort: a nil
+    # range (endoflife feed down) or absent ruby_version yields no finding.
+    def attach_ruby_ceiling(gem_data:, used_version_hash:, latest_version_hash:, ruby_range:)
+      return if ruby_range.nil?
+
+      used_req = VersionHelper.ruby_requirement(version_hash: used_version_hash)
+      latest_req = VersionHelper.ruby_requirement(version_hash: latest_version_hash)
+      # Analyze the version actually in the tree. Fall back to latest ONLY when
+      # there's no pinned version (a latest-only audit), never when the pinned
+      # version merely declares no ruby_version: an absent cap runs on any Ruby, so
+      # projecting a newer release's cap back onto it would mint a false ceiling.
+      requirement = used_version_hash ? used_req : latest_req
+      finding = RuntimeCeilingHelper.analyze(requirement: requirement, support_window: ruby_range)
+      return if finding.nil?
+
+      finding[:fixed_by_upgrade] = ruby_ceiling_lifted_by_upgrade?(used_req: used_req, latest_req: latest_req, ruby_range: ruby_range)
+      gem_data[:ruby_ceiling] = finding
+    end
+
+    # Does bumping the gem to its latest lift the ceiling? True only when the cap
+    # is on the resolved (older) version and the latest version declares no ceiling
+    # of its own -- the actionable "upgrade the gem" case (e.g. CFPropertyList
+    # 3.0.9's `< 3.2` cap, gone by 4.0.0). False when already on latest.
+    def ruby_ceiling_lifted_by_upgrade?(used_req:, latest_req:, ruby_range:)
+      return false if used_req.nil? || used_req == latest_req
+
+      RuntimeCeilingHelper.analyze(requirement: latest_req, support_window: ruby_range).nil?
     end
 
     def gem_info_non_rubygems(gem_name:, gem_version:, result_object:, source_uri: nil, advisory_db: nil)

--- a/lib/still_active/workflow.rb
+++ b/lib/still_active/workflow.rb
@@ -90,6 +90,10 @@ module StillActive
           end
         end
         barrier.wait
+        # Whole-tree correlation, once every gem's signals are in: a ceiling's
+        # "upgrade to lift it" must not contradict a poison finding that caps the
+        # same gem below that upgrade.
+        reconcile_ceiling_with_poison(result_object)
         # Gems are inserted as their async tasks finish, so the natural order is
         # nondeterministic completion order. Sort by name once here so every
         # consumer (JSON, SARIF, the baseline diff) gets a stable, diffable order.
@@ -103,6 +107,26 @@ module StillActive
     end
 
     private
+
+    # A ceiling that says "upgrade <gem> to lift it" is wrong if the same tree
+    # poisons <gem> below that upgrade (a dormant dep caps it). Correlate the two
+    # signals so the report never advises an upgrade its own poison finding says is
+    # impossible: clear fixed_by_upgrade and mark the block. All data is already in
+    # the assembled result, so this is one whole-tree pass, no extra fetches.
+    def reconcile_ceiling_with_poison(result_object)
+      capped = result_object.each_value
+        .flat_map { |data| Array(data[:constraints]) }
+        .select { |constraint| constraint[:majors_behind].to_i.positive? }
+        .map { |constraint| constraint[:dependency] }
+        .uniq
+      result_object.each do |name, data|
+        ceiling = data[:ruby_ceiling]
+        next unless ceiling && ceiling[:fixed_by_upgrade] && capped.include?(name)
+
+        ceiling[:fixed_by_upgrade] = false
+        ceiling[:upgrade_blocked] = true
+      end
+    end
 
     def gem_info(gem_name:, result_object:, gem_version: nil, source_type: :rubygems, source_uri: nil, direct: true, dependency_path: nil, advisory_db: nil, catalog: nil, constraint_cache: {}, ruby_range: nil)
       result_object[gem_name] = { source_type: source_type, direct: direct }

--- a/lib/still_active/workflow.rb
+++ b/lib/still_active/workflow.rb
@@ -196,10 +196,29 @@ module StillActive
 
       attach_ruby_ceiling(
         gem_data: result_object[gem_name],
-        used_version_hash: version_used,
-        latest_version_hash: last_release,
+        used_ruby_requirement: canonical_ruby_requirement(vs, version_used),
+        latest_ruby_requirement: canonical_ruby_requirement(vs, last_release),
+        pinned: !version_used.nil?,
         ruby_range: ruby_range,
       )
+    end
+
+    # The ruby_version to judge a language ceiling against, read from the canonical
+    # `ruby` (source) platform entry of a version rather than whichever variant the
+    # registry happens to list first. Native gems ship a permissive `ruby` platform
+    # plus precompiled per-platform variants that cap ruby_version to the ABIs they
+    # were built for; the source platform is the gem's true Ruby support (it can be
+    # compiled on a newer Ruby), so a precompiled variant's tighter cap must not be
+    # read as the gem's ceiling. (Flagging that a project's LOCKED precompiled
+    # variant lacks a newer-Ruby build is a distinct, narrower signal, and needs the
+    # locked platform, which isn't threaded here yet.)
+    def canonical_ruby_requirement(versions, version_hash)
+      number = version_hash && version_hash["number"]
+      return if number.nil?
+
+      entries = versions.select { |version| version["number"] == number }
+      chosen = entries.find { |version| version["platform"] == "ruby" || version["platform"].nil? } || entries.first
+      VersionHelper.ruby_requirement(version_hash: chosen)
     end
 
     # Language-runtime ceiling: the sibling of poison. A gem's resolved version
@@ -209,20 +228,18 @@ module StillActive
     # support). Unlike poison this is NOT gated on dormancy: a cap is a fact of the
     # resolved version whether or not the gem is maintained. Best-effort: a nil
     # range (endoflife feed down) or absent ruby_version yields no finding.
-    def attach_ruby_ceiling(gem_data:, used_version_hash:, latest_version_hash:, ruby_range:)
+    def attach_ruby_ceiling(gem_data:, used_ruby_requirement:, latest_ruby_requirement:, pinned:, ruby_range:)
       return if ruby_range.nil?
 
-      used_req = VersionHelper.ruby_requirement(version_hash: used_version_hash)
-      latest_req = VersionHelper.ruby_requirement(version_hash: latest_version_hash)
       # Analyze the version actually in the tree. Fall back to latest ONLY when
       # there's no pinned version (a latest-only audit), never when the pinned
       # version merely declares no ruby_version: an absent cap runs on any Ruby, so
       # projecting a newer release's cap back onto it would mint a false ceiling.
-      requirement = used_version_hash ? used_req : latest_req
+      requirement = pinned ? used_ruby_requirement : latest_ruby_requirement
       finding = RuntimeCeilingHelper.analyze(requirement: requirement, support_window: ruby_range)
       return if finding.nil?
 
-      finding[:fixed_by_upgrade] = ruby_ceiling_lifted_by_upgrade?(used_req: used_req, latest_req: latest_req, ruby_range: ruby_range)
+      finding[:fixed_by_upgrade] = ruby_ceiling_lifted_by_upgrade?(used_req: used_ruby_requirement, latest_req: latest_ruby_requirement, ruby_range: ruby_range)
       gem_data[:ruby_ceiling] = finding
     end
 

--- a/spec/still_active/cli_spec.rb
+++ b/spec/still_active/cli_spec.rb
@@ -797,13 +797,16 @@ RSpec.describe(StillActive::CLI) do
       )
     end
 
-    it("exits 1 when an EOL-forcing (critical) ceiling meets the default (warning) threshold") do
+    # Ceiling findings only ever carry :critical (EOL-forced) or :note
+    # (latest-not-yet) -- there is no :warning tier -- so the bare gate defaults to
+    # :critical (the real blocker), not the :warning poison uses.
+    it("exits 1 when an EOL-forcing (critical) ceiling meets the default (critical) threshold") do
       StillActive.config.fail_if_ruby_ceiling = true
       expect { cli.send(:check_exit_status, { "cfpropertylist" => ceiling_gem(:critical) }) }
         .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(1)) })
     end
 
-    it("does NOT exit on a note-level ceiling under the default (warning) threshold") do
+    it("does NOT exit on a note-level ceiling under the default (critical) threshold") do
       StillActive.config.fail_if_ruby_ceiling = true
       expect { cli.send(:check_exit_status, { "somegem" => ceiling_gem(:note) }) }.not_to(raise_error)
     end

--- a/spec/still_active/cli_spec.rb
+++ b/spec/still_active/cli_spec.rb
@@ -261,6 +261,31 @@ RSpec.describe(StillActive::CLI) do
           alternatives: ["foo"],
           vulnerabilities: [{ id: "CVE-2024-1", url: "https://example/x", title: "t", aliases: ["GHSA-x"], cvss3_score: 7.5, cvss3_vector: "AV:N", cvss2_score: nil, source: "merged" }],
         },
+        # A poison-pill gem and a language-ceiling gem, so the published schema is
+        # actually validated against those compatibility-signal shapes.
+        "protected_attributes" => {
+          source_type: :rubygems,
+          direct: true,
+          poison: true,
+          poison_severity: :critical,
+          constraints: [{ dependency: "activemodel", requirement: "< 5.0", dep_latest: "8.0.1", majors_behind: 4, kind: :ceiling }],
+        },
+        "cfpropertylist" => {
+          source_type: :rubygems,
+          direct: true,
+          version_used: "3.0.9",
+          latest_version: "4.0.0",
+          ruby_ceiling: {
+            requirement: "< 3.2",
+            eol_forced: true,
+            severity: :critical,
+            ceiling_version: "3.1",
+            ceiling_eol_date: Time.new(2025, 3, 31, 0, 0, 0, "+00:00"),
+            oldest_supported: "3.3",
+            latest_stable: "4.0.5",
+            fixed_by_upgrade: true,
+          },
+        },
       }
       allow(StillActive::Workflow).to(receive_messages(
         call: rich,
@@ -275,7 +300,7 @@ RSpec.describe(StillActive::CLI) do
 
       errors = JSONSchemer.schema(Pathname.new(schema_path)).validate(payload).to_a
       expect(errors).to(be_empty, errors.map { |e| "#{e["data_pointer"]}: #{e["type"]} (#{e["data"].inspect})" }.join("\n"))
-      expect(payload["summary"]).to(include("total_gems" => 2, "direct" => 1, "transitive" => 1, "vulnerable_gems" => 1, "ruby_eol" => false))
+      expect(payload["summary"]).to(include("total_gems" => 4, "direct" => 3, "transitive" => 1, "vulnerable_gems" => 1, "ruby_eol" => false))
     end
 
     it("omits ruby key when ruby info is nil") do
@@ -762,6 +787,43 @@ RSpec.describe(StillActive::CLI) do
       )
       expect { cli.send(:check_exit_status, { "protected_attributes" => poison_gem }) }
         .not_to(raise_error)
+    end
+  end
+
+  describe("--fail-if-ruby-ceiling") do
+    def ceiling_gem(severity = :critical)
+      gem_data(last_commit_date: recent_date).merge(
+        ruby_ceiling: { requirement: "< 3.2", eol_forced: severity == :critical, severity: severity },
+      )
+    end
+
+    it("exits 1 when an EOL-forcing (critical) ceiling meets the default (warning) threshold") do
+      StillActive.config.fail_if_ruby_ceiling = true
+      expect { cli.send(:check_exit_status, { "cfpropertylist" => ceiling_gem(:critical) }) }
+        .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(1)) })
+    end
+
+    it("does NOT exit on a note-level ceiling under the default (warning) threshold") do
+      StillActive.config.fail_if_ruby_ceiling = true
+      expect { cli.send(:check_exit_status, { "somegem" => ceiling_gem(:note) }) }.not_to(raise_error)
+    end
+
+    it("exits on a note-level ceiling when the threshold is lowered to note") do
+      StillActive.config.fail_if_ruby_ceiling = :note
+      expect { cli.send(:check_exit_status, { "somegem" => ceiling_gem(:note) }) }
+        .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(1)) })
+    end
+
+    it("does not exit when the flag is off, even with a ceiling gem") do
+      expect { cli.send(:check_exit_status, { "cfpropertylist" => ceiling_gem }) }.not_to(raise_error)
+    end
+
+    it("does not exit when the gem's ruby_ceiling signal is suppressed in .still_active.yml") do
+      StillActive.config.fail_if_ruby_ceiling = true
+      StillActive.config.suppressions = StillActive::Suppressions.from(
+        [{ "gem" => "cfpropertylist", "signal" => "ruby_ceiling", "reason" => "pinned on purpose" }],
+      )
+      expect { cli.send(:check_exit_status, { "cfpropertylist" => ceiling_gem }) }.not_to(raise_error)
     end
   end
 

--- a/spec/still_active/config_file_spec.rb
+++ b/spec/still_active/config_file_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe(StillActive::ConfigFile) do
         "fail_if_critical" => true,
         "fail_if_warning" => true,
         "fail_if_poison" => true,
+        "fail_if_ruby_ceiling" => "note",
         "fail_if_vulnerable" => "high",
         "fail_if_outdated" => 2.5,
         "alternatives" => true,
@@ -60,6 +61,7 @@ RSpec.describe(StillActive::ConfigFile) do
       expect(config.fail_if_critical).to(be(true))
       expect(config.fail_if_warning).to(be(true))
       expect(config.fail_if_poison).to(be(true))
+      expect(config.fail_if_ruby_ceiling).to(eq(:note))
       expect(config.fail_if_vulnerable).to(eq("high"))
       expect(config.fail_if_outdated).to(eq(2.5))
       expect(config.alternatives).to(be(true))

--- a/spec/still_active/constraint_helper_spec.rb
+++ b/spec/still_active/constraint_helper_spec.rb
@@ -180,6 +180,16 @@ RSpec.describe(StillActive::ConstraintHelper) do
       { dependency: "d", requirement: "< x", dep_latest: "9.0.0", majors_behind: behind, kind: :ceiling }
     end
 
+    it("short-circuits an EOL-forced runtime ceiling to critical, regardless of magnitude") do
+      # The language-runtime ceiling reuses this tierer. A cap that strands you on
+      # an end-of-life Ruby is act-now no matter that it carries no majors_behind.
+      expect(described_class.constraint_severity({ eol_forced: true })).to(eq(:critical))
+    end
+
+    it("tiers a magnitude-less finding (e.g. latest-not-yet runtime ceiling) as a note") do
+      expect(described_class.constraint_severity({ eol_forced: false })).to(eq(:note))
+    end
+
     it("tiers a ceiling by magnitude: 1 behind = note, 2 = warning, 3+ = critical") do
       expect(described_class.constraint_severity(ceiling(1))).to(eq(:note))
       expect(described_class.constraint_severity(ceiling(2))).to(eq(:warning))

--- a/spec/still_active/markdown_helper_spec.rb
+++ b/spec/still_active/markdown_helper_spec.rb
@@ -417,6 +417,62 @@ RSpec.describe(StillActive::MarkdownHelper) do
     end
   end
 
+  describe(".ruby_ceiling_section") do
+    def ceiling_gem(ceiling, extra = {})
+      { source_type: :rubygems, latest_version: "4.0.0", ruby_ceiling: ceiling }.merge(extra)
+    end
+
+    it("lists an EOL-forcing ceiling with the stranded Ruby, its EOL date, and the upgrade fix") do
+      result = {
+        "cfpropertylist" => ceiling_gem({
+          requirement: "< 3.2",
+          eol_forced: true,
+          severity: :critical,
+          ceiling_version: "3.1",
+          ceiling_eol_date: Time.new(2025, 3, 31),
+          oldest_supported: "3.3",
+          latest_stable: "4.0.5",
+          fixed_by_upgrade: true,
+        }),
+      }
+      out = described_class.ruby_ceiling_section(result)
+      expect(out).to(include("**Ruby ceiling findings**"))
+      expect(out).to(include("**critical** `cfpropertylist` requires Ruby `< 3.2`, stranding you on end-of-life Ruby 3.1 (EOL 2025-03-31); upgrade to 4.0.0 to lift it"))
+    end
+
+    it("lists a latest-not-yet ceiling as a note without an upgrade fix") do
+      result = {
+        "somegem" => ceiling_gem(
+          {
+            requirement: "~> 3.3",
+            eol_forced: false,
+            severity: :note,
+            oldest_supported: "3.3",
+            latest_stable: "4.0.5",
+            fixed_by_upgrade: false,
+          },
+          { latest_version: "1.0.0" },
+        ),
+      }
+      out = described_class.ruby_ceiling_section(result)
+      expect(out).to(include("**note** `somegem` requires Ruby `~> 3.3`, no Ruby 4.0.5 support yet"))
+      expect(out).not_to(include("upgrade to"))
+    end
+
+    it("ranks ceilings worst-first (critical before note)") do
+      result = {
+        "minor" => ceiling_gem({ requirement: "~> 3.3", eol_forced: false, severity: :note, oldest_supported: "3.3", latest_stable: "4.0.5", fixed_by_upgrade: false }, { latest_version: "1.0.0" }),
+        "blocker" => ceiling_gem({ requirement: "< 3.2", eol_forced: true, severity: :critical, ceiling_version: "3.1", ceiling_eol_date: nil, oldest_supported: "3.3", latest_stable: "4.0.5", fixed_by_upgrade: false }),
+      }
+      out = described_class.ruby_ceiling_section(result)
+      expect(out.index("blocker")).to(be < out.index("minor"))
+    end
+
+    it("returns empty string when no gem has a ceiling") do
+      expect(described_class.ruby_ceiling_section({ "rails" => { source_type: :rubygems } })).to(eq(""))
+    end
+  end
+
   describe(".ruby_line") do
     it("shows latest Ruby with success emoji") do
       info = { version: "3.4.0", latest_version: "3.4.0", libyear: nil, eol: false, eol_date: nil }

--- a/spec/still_active/options_spec.rb
+++ b/spec/still_active/options_spec.rb
@@ -136,6 +136,21 @@ RSpec.describe(StillActive::Options) do
       expect(StillActive.config.fail_if_outdated).to(eq(3.0))
     end
 
+    it("sets fail-if-ruby-ceiling to true when bare") do
+      described_class.new.parse!(["--fail-if-ruby-ceiling", "--gems=rails"])
+      expect(StillActive.config.fail_if_ruby_ceiling).to(be(true))
+    end
+
+    it("sets fail-if-ruby-ceiling to a tier symbol when given one") do
+      described_class.new.parse!(["--fail-if-ruby-ceiling=note", "--gems=rails"])
+      expect(StillActive.config.fail_if_ruby_ceiling).to(eq(:note))
+    end
+
+    it("raises when the fail-if-ruby-ceiling tier is invalid") do
+      expect { described_class.new.parse!(["--fail-if-ruby-ceiling=banana", "--gems=rails"]) }
+        .to(raise_error(ArgumentError, /tier must be one of/))
+    end
+
     it("sets ignored gems from comma-separated list") do
       described_class.new.parse!(["--ignore=nokogiri,puma", "--gems=rails"])
       expect(StillActive.config.ignored_gems).to(eq(["nokogiri", "puma"]))

--- a/spec/still_active/options_spec.rb
+++ b/spec/still_active/options_spec.rb
@@ -151,6 +151,12 @@ RSpec.describe(StillActive::Options) do
         .to(raise_error(ArgumentError, /tier must be one of/))
     end
 
+    it("warns that fail-if-ruby-ceiling=warning is a no-op tier but still accepts it") do
+      expect { described_class.new.parse!(["--fail-if-ruby-ceiling=warning", "--gems=rails"]) }
+        .to(output(/no effect.*behaves as =critical/).to_stderr)
+      expect(StillActive.config.fail_if_ruby_ceiling).to(eq(:warning))
+    end
+
     it("sets ignored gems from comma-separated list") do
       described_class.new.parse!(["--ignore=nokogiri,puma", "--gems=rails"])
       expect(StillActive.config.ignored_gems).to(eq(["nokogiri", "puma"]))

--- a/spec/still_active/ruby_helper_spec.rb
+++ b/spec/still_active/ruby_helper_spec.rb
@@ -148,4 +148,45 @@ RSpec.describe(StillActive::RubyHelper) do
       end
     end
   end
+
+  describe(".supported_ruby_range") do
+    # eol_reached? compares each cycle's eol date against the real clock, so with
+    # the fixture (3.4/3.3 future EOL, 3.2/3.1 past) the supported set is 3.3+ and
+    # the newest release is 3.4.2. These runtime facts feed the per-gem ceiling.
+    it("reports the oldest still-supported cycle and the latest stable release") do
+      range = described_class.supported_ruby_range
+      expect(range[:oldest_supported]).to(eq(Gem::Version.new("3.3")))
+      expect(range[:latest_stable]).to(eq(Gem::Version.new("3.4.2")))
+    end
+
+    it("exposes normalized cycles (version, eol flag, eol date) for ceiling enrichment") do
+      cycles = described_class.supported_ruby_range[:cycles]
+      eol_31 = cycles.find { |c| c[:version] == Gem::Version.new("3.1") }
+      expect(eol_31[:eol]).to(be(true))
+      expect(eol_31[:eol_date]).to(eq(Time.parse("2025-03-31")))
+      live_34 = cycles.find { |c| c[:version] == Gem::Version.new("3.4") }
+      expect(live_34[:eol]).to(be(false))
+    end
+
+    it("returns nil when the endoflife API is unavailable") do
+      allow(StillActive::HttpHelper).to(receive(:get_json).and_return(nil))
+      expect(described_class.supported_ruby_range).to(be_nil)
+    end
+
+    it("returns nil when every known cycle is already EOL") do
+      past = cycles.map { |c| c.merge("eol" => "2000-01-01") }
+      allow(StillActive::HttpHelper).to(receive(:get_json).and_return(past))
+      expect(described_class.supported_ruby_range).to(be_nil)
+    end
+
+    it("returns nil rather than raising when the newest cycle's `latest` is malformed") do
+      # endoflife.date is best-effort third-party data; a garbled/preview `latest`
+      # must never crash the run (supported_ruby_range is fetched outside the
+      # per-gem rescue, so a raise here would abort the whole audit).
+      garbled = [cycles.first.merge("latest" => "unknown-preview"), *cycles[1..]]
+      allow(StillActive::HttpHelper).to(receive(:get_json).and_return(garbled))
+      expect { described_class.supported_ruby_range }.not_to(raise_error)
+      expect(described_class.supported_ruby_range).to(be_nil)
+    end
+  end
 end

--- a/spec/still_active/ruby_helper_spec.rb
+++ b/spec/still_active/ruby_helper_spec.rb
@@ -179,6 +179,29 @@ RSpec.describe(StillActive::RubyHelper) do
       expect(described_class.supported_ruby_range).to(be_nil)
     end
 
+    it("marks the latest stable fresh when the newest cycle shipped inside the grace window") do
+      recent = cycles.map.with_index { |c, i| i.zero? ? c.merge("releaseDate" => (Time.now - (10 * 86_400)).strftime("%Y-%m-%d")) : c }
+      allow(StillActive::HttpHelper).to(receive(:get_json).and_return(recent))
+      expect(described_class.supported_ruby_range[:latest_stable_fresh]).to(be(true))
+    end
+
+    it("marks the latest stable not-fresh once the newest cycle is older than the grace window") do
+      old = cycles.map.with_index { |c, i| i.zero? ? c.merge("releaseDate" => (Time.now - (400 * 86_400)).strftime("%Y-%m-%d")) : c }
+      allow(StillActive::HttpHelper).to(receive(:get_json).and_return(old))
+      expect(described_class.supported_ruby_range[:latest_stable_fresh]).to(be(false))
+    end
+
+    it("degrades freshness to false (does not raise or disable the window) on a malformed releaseDate") do
+      # A malformed-but-present releaseDate must not raise out of supported_ruby_range:
+      # that would null the whole range and silently disable EOL-forced criticals.
+      bad = cycles.map.with_index { |c, i| i.zero? ? c.merge("releaseDate" => "2023-13-99") : c }
+      allow(StillActive::HttpHelper).to(receive(:get_json).and_return(bad))
+      range = nil
+      expect { range = described_class.supported_ruby_range }.not_to(raise_error)
+      expect(range).not_to(be_nil)
+      expect(range[:latest_stable_fresh]).to(be(false))
+    end
+
     it("returns nil rather than raising when the newest cycle's `latest` is malformed") do
       # endoflife.date is best-effort third-party data; a garbled/preview `latest`
       # must never crash the run (supported_ruby_range is fetched outside the

--- a/spec/still_active/runtime_ceiling_helper_spec.rb
+++ b/spec/still_active/runtime_ceiling_helper_spec.rb
@@ -65,6 +65,23 @@ RSpec.describe(StillActive::RuntimeCeilingHelper) do
         expect(finding[:eol_forced]).to(be(false))
         expect(finding[:severity]).to(eq(:note))
       end
+
+      # Grace window: the week a new Ruby ships, every gem with any upper bound
+      # below it would fire a latest-not-yet note simultaneously, indicting the
+      # maintainers who were honest about untested compatibility. While the latest
+      # stable is still fresh, suppress the note entirely (it is about Ruby's
+      # release calendar, not the gem). EOL-forced is unaffected.
+      it("suppresses a latest-not-yet note while the latest stable is within its grace window") do
+        window = support_window.merge(latest_stable_fresh: true)
+        expect(described_class.analyze(requirement: "~> 3.3", support_window: window)).to(be_nil)
+      end
+
+      it("still flags an EOL-forced ceiling even while the latest stable is fresh (grace is note-only)") do
+        window = support_window.merge(latest_stable_fresh: true)
+        finding = described_class.analyze(requirement: "< 3.2", support_window: window)
+        expect(finding[:eol_forced]).to(be(true))
+        expect(finding[:severity]).to(eq(:critical))
+      end
     end
 
     context("with no ceiling") do

--- a/spec/still_active/runtime_ceiling_helper_spec.rb
+++ b/spec/still_active/runtime_ceiling_helper_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/helpers/runtime_ceiling_helper"
+
+RSpec.describe(StillActive::RuntimeCeilingHelper) do
+  # The runtime as of the fixtures: 3.3/3.4/4.0 supported, 3.2 and below EOL.
+  let(:support_window) do
+    {
+      oldest_supported: Gem::Version.new("3.3"),
+      latest_stable: Gem::Version.new("4.0.5"),
+      cycles: [
+        { version: Gem::Version.new("4.0"), eol: false, eol_date: Time.parse("2029-03-31") },
+        { version: Gem::Version.new("3.4"), eol: false, eol_date: Time.parse("2028-03-31") },
+        { version: Gem::Version.new("3.3"), eol: false, eol_date: Time.parse("2027-03-31") },
+        { version: Gem::Version.new("3.2"), eol: true, eol_date: Time.parse("2026-03-31") },
+        { version: Gem::Version.new("3.1"), eol: true, eol_date: Time.parse("2025-03-31") },
+        { version: Gem::Version.new("3.0"), eol: true, eol_date: Time.parse("2024-04-23") },
+      ],
+    }
+  end
+
+  def analyze(req) = described_class.analyze(requirement: req, support_window: support_window)
+
+  describe(".analyze") do
+    context("when EOL-forced (critical): the cap admits no supported runtime") do
+      it("flags a `< 3.2` cap that strands you on an EOL release, naming the ceiling and its EOL date") do
+        finding = analyze("< 3.2")
+        expect(finding[:eol_forced]).to(be(true))
+        expect(finding[:severity]).to(eq(:critical))
+        expect(finding[:ceiling_version]).to(eq("3.1")) # newest release the cap allows
+        expect(finding[:ceiling_eol_date]).to(eq(Time.parse("2025-03-31")))
+        expect(finding[:oldest_supported]).to(eq("3.3"))
+        expect(finding[:requirement]).to(eq("< 3.2"))
+      end
+
+      it("flags a `~> 3.1.0` cap that admits only an EOL release (3.1.x)") do
+        finding = analyze("~> 3.1.0")
+        expect(finding[:eol_forced]).to(be(true))
+        expect(finding[:severity]).to(eq(:critical))
+        expect(finding[:ceiling_version]).to(eq("3.1"))
+      end
+
+      # Registries render a floor+ceiling as one comma-joined string; both bounds
+      # must survive parsing or the ceiling is silently lost (real gems ship this:
+      # sorbet-runtime `>= 2.3.0, < 2.7.0.preview1`, nokogiri `>= 3.2, < 4.1.dev`).
+      it("flags a compound `>= 2.5, < 3.2` range, preserving the ceiling bound") do
+        finding = analyze(">= 2.5, < 3.2")
+        expect(finding[:eol_forced]).to(be(true))
+        expect(finding[:severity]).to(eq(:critical))
+        expect(finding[:ceiling_version]).to(eq("3.1"))
+        expect(finding[:requirement]).to(eq(">= 2.5, < 3.2")) # receipt keeps the full string
+      end
+    end
+
+    context("when latest-not-yet (note): runs on a supported runtime but not the latest stable") do
+      it("flags a `~> 3.3` cap as a note with the latest stable it lacks") do
+        finding = analyze("~> 3.3")
+        expect(finding[:eol_forced]).to(be(false))
+        expect(finding[:severity]).to(eq(:note))
+        expect(finding[:latest_stable]).to(eq("4.0.5"))
+      end
+
+      it("flags a compound `>= 3.3, < 4.0` range that supports the newest 3.x but not 4.0 as a note") do
+        finding = analyze(">= 3.3, < 4.0")
+        expect(finding[:eol_forced]).to(be(false))
+        expect(finding[:severity]).to(eq(:note))
+      end
+    end
+
+    context("with no ceiling") do
+      it("returns nil for a bare floor (`>= 3.1`, `>= 0`, empty, nil)") do
+        ["", nil, ">= 0", ">= 3.1", "> 3.0"].each do |req|
+          expect(analyze(req)).to(be_nil, "expected #{req.inspect} to be no ceiling")
+        end
+      end
+
+      it("returns nil when the cap already admits the latest stable (`< 5.0`, `~> 4.0`)") do
+        ["< 5.0", "~> 4.0"].each { |req| expect(analyze(req)).to(be_nil, "expected #{req.inspect} to be no ceiling") }
+      end
+
+      it("does NOT flag a `>= future` requires-newer floor as an EOL cap (`>= 4.1`)") do
+        # Excludes every supported cycle, but by requiring a NEWER release, not by
+        # capping you onto a dead one. That's a floor, not a ceiling: no finding.
+        expect(analyze(">= 4.1")).to(be_nil)
+        expect(analyze("~> 5.0")).to(be_nil)
+      end
+
+      it("does NOT flag a compound range whose ceiling admits the latest stable (`>= 3.2, < 4.1.dev`)") do
+        # nokogiri's real shape: >= 3.2 and < 4.1 still admits Ruby 4.0. No ceiling.
+        expect(analyze(">= 3.2, < 4.1.dev")).to(be_nil)
+      end
+    end
+
+    context("with robustness concerns") do
+      it("returns nil for an unparseable requirement rather than raising") do
+        expect(analyze("not a version")).to(be_nil)
+      end
+
+      it("returns nil for a malformed clause inside an otherwise compound string, rather than raising") do
+        expect { analyze(">= 2.5, <>< junk") }.not_to(raise_error)
+        expect(analyze(">= 2.5, <>< junk")).to(be_nil)
+      end
+
+      it("returns nil when the support window is nil") do
+        expect(described_class.analyze(requirement: "< 3.2", support_window: nil)).to(be_nil)
+      end
+    end
+  end
+end

--- a/spec/still_active/sarif/rules_spec.rb
+++ b/spec/still_active/sarif/rules_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe(StillActive::Sarif::Rules) do
   describe(".all") do
     subject(:rules) { described_class.all }
 
-    it("returns the SA001..SA008 catalog") do
-      expect(rules.map { |r| r[:id] }).to(eq(["SA001", "SA002", "SA003", "SA004", "SA005", "SA006", "SA007", "SA008"]))
+    it("returns the SA001..SA009 catalog") do
+      expect(rules.map { |r| r[:id] }).to(eq(["SA001", "SA002", "SA003", "SA004", "SA005", "SA006", "SA007", "SA008", "SA009"]))
     end
 
     it("every rule has required fields") do

--- a/spec/still_active/sarif_helper_spec.rb
+++ b/spec/still_active/sarif_helper_spec.rb
@@ -310,12 +310,20 @@ RSpec.describe(StillActive::SarifHelper) do
       expect(sa009).not_to(have_key("properties"))
     end
 
-    it("fingerprints on gem identity only, so a shifting Ruby window doesn't re-alert") do
+    it("fingerprints stably within a tier, so a shifting Ruby window doesn't re-alert cosmetic churn") do
       fp = lambda do |ceiling_ver|
         f = eol_finding.merge(ceiling_version: ceiling_ver)
         render(result: ceiling(f)).dig("runs", 0, "results").find { |r| r["ruleId"] == "SA009" }.dig("partialFingerprints", "stillActiveFinding/v1")
       end
       expect(fp.call("3.1")).to(eq(fp.call("3.0")))
+    end
+
+    it("mints a DIFFERENT fingerprint when a note escalates to EOL-forced, so a past dismissal can't mute the critical") do
+      note = { requirement: "~> 3.3", eol_forced: false, severity: :note, oldest_supported: "3.3", latest_stable: "4.0.5", fixed_by_upgrade: false }
+      fp = lambda do |finding|
+        render(result: ceiling(finding)).dig("runs", 0, "results").find { |r| r["ruleId"] == "SA009" }.dig("partialFingerprints", "stillActiveFinding/v1")
+      end
+      expect(fp.call(note)).not_to(eq(fp.call(eol_finding)))
     end
 
     it("does not fire for a gem without a ceiling") do

--- a/spec/still_active/sarif_helper_spec.rb
+++ b/spec/still_active/sarif_helper_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe(StillActive::SarifHelper) do
       expect(driver["informationUri"]).to(include("github.com/SeanLF/still_active"))
     end
 
-    it("emits all 8 rules in tool.driver.rules with required fields") do
+    it("emits all 9 rules in tool.driver.rules with required fields") do
       rules = doc.dig("runs", 0, "tool", "driver", "rules")
-      expect(rules.size).to(eq(8))
+      expect(rules.size).to(eq(9))
       rules.each do |r|
         expect(r).to(include("id", "name", "shortDescription", "fullDescription", "help", "helpUri", "defaultConfiguration", "properties"))
         expect(r["help"]).to(include("text", "markdown"))
@@ -49,7 +49,7 @@ RSpec.describe(StillActive::SarifHelper) do
       ["SA001", "SA003", "SA006", "SA007"].each do |id|
         expect(by_id[id]["properties"]["security-severity"]).to(match(/\A\d+\.\d+\z/))
       end
-      ["SA002", "SA004", "SA005", "SA008"].each do |id|
+      ["SA002", "SA004", "SA005", "SA008", "SA009"].each do |id|
         expect(by_id[id]["properties"]).not_to(have_key("security-severity"))
       end
     end
@@ -268,6 +268,67 @@ RSpec.describe(StillActive::SarifHelper) do
       )
       sa008 = render(result: poison([cap])).dig("runs", 0, "results").find { |r| r["ruleId"] == "SA008" }
       expect(sa008["suppressions"]).to(eq([{ "kind" => "external", "justification" => "vendored" }]))
+    end
+  end
+
+  describe("SA009 RubyRuntimeCeiling") do
+    def ceiling(finding, extra = {})
+      { "gem" => { version_used: "3.0.9", latest_version: "4.0.0", ruby_ceiling: finding }.merge(extra) }
+    end
+
+    let(:eol_finding) do
+      {
+        requirement: "< 3.2",
+        eol_forced: true,
+        severity: :critical,
+        ceiling_version: "3.1",
+        ceiling_eol_date: Time.new(2025, 3, 31),
+        oldest_supported: "3.3",
+        latest_stable: "4.0.5",
+        fixed_by_upgrade: true,
+      }
+    end
+
+    it("fires an error-level SA009 for an EOL-forcing cap with the receipt") do
+      results = render(result: ceiling(eol_finding)).dig("runs", 0, "results")
+      sa009 = results.select { |r| r["ruleId"] == "SA009" }
+      expect(sa009.size).to(eq(1))
+      expect(sa009[0]["level"]).to(eq("error")) # critical -> error
+      expect(sa009[0].dig("message", "text")).to(include("requires Ruby < 3.2, stranding you on end-of-life Ruby 3.1 (EOL 2025-03-31)"))
+      expect(sa009[0].dig("message", "text")).to(include("upgrade to 4.0.0 to lift it"))
+    end
+
+    it("fires a note-level SA009 for a latest-not-yet cap") do
+      finding = { requirement: "~> 3.3", eol_forced: false, severity: :note, oldest_supported: "3.3", latest_stable: "4.0.5", fixed_by_upgrade: false }
+      sa009 = render(result: ceiling(finding, { version_used: "1.0.0", latest_version: "1.0.0" })).dig("runs", 0, "results").find { |r| r["ruleId"] == "SA009" }
+      expect(sa009["level"]).to(eq("note"))
+      expect(sa009.dig("message", "text")).to(include("no Ruby 4.0.5 support yet"))
+    end
+
+    it("carries no security-severity (maintenance/compatibility, not a CVE)") do
+      sa009 = render(result: ceiling(eol_finding)).dig("runs", 0, "results").find { |r| r["ruleId"] == "SA009" }
+      expect(sa009).not_to(have_key("properties"))
+    end
+
+    it("fingerprints on gem identity only, so a shifting Ruby window doesn't re-alert") do
+      fp = lambda do |ceiling_ver|
+        f = eol_finding.merge(ceiling_version: ceiling_ver)
+        render(result: ceiling(f)).dig("runs", 0, "results").find { |r| r["ruleId"] == "SA009" }.dig("partialFingerprints", "stillActiveFinding/v1")
+      end
+      expect(fp.call("3.1")).to(eq(fp.call("3.0")))
+    end
+
+    it("does not fire for a gem without a ceiling") do
+      results = render(result: { "clean" => { version_used: "1.0.0" } }).dig("runs", 0, "results")
+      expect(results.any? { |r| r["ruleId"] == "SA009" }).to(be(false))
+    end
+
+    it("is suppressible via the :ruby_ceiling signal") do
+      StillActive.config.suppressions = StillActive::Suppressions.from(
+        [{ "gem" => "gem", "signal" => "ruby_ceiling", "reason" => "pinned on purpose" }],
+      )
+      sa009 = render(result: ceiling(eol_finding)).dig("runs", 0, "results").find { |r| r["ruleId"] == "SA009" }
+      expect(sa009["suppressions"]).to(eq([{ "kind" => "external", "justification" => "pinned on purpose" }]))
     end
 
     it("does NOT fire on a recent release") do

--- a/spec/still_active/terminal_helper_spec.rb
+++ b/spec/still_active/terminal_helper_spec.rb
@@ -353,5 +353,69 @@ RSpec.describe(StillActive::TerminalHelper) do
         expect(described_class.render(result)).not_to(include("poison:"))
       end
     end
+
+    context("with a language-runtime ceiling sub-line") do
+      def ceiling_gem(ceiling, extra = {})
+        {
+          version_used: "3.0.9",
+          latest_version: "4.0.0",
+          vulnerability_count: 0,
+          scorecard_score: nil,
+          ruby_ceiling: ceiling,
+        }.merge(extra)
+      end
+
+      it("prints a red critical receipt for an EOL-forcing cap, naming the stranded Ruby and its EOL date") do
+        result = {
+          "cfpropertylist" => ceiling_gem({
+            requirement: "< 3.2",
+            eol_forced: true,
+            severity: :critical,
+            ceiling_version: "3.1",
+            ceiling_eol_date: Time.new(2025, 3, 31),
+            oldest_supported: "3.3",
+            latest_stable: "4.0.5",
+            fixed_by_upgrade: true,
+          }),
+        }
+        out = described_class.render(result)
+        expect(out).to(match(/\e\[31m  ↳ ruby ceiling: requires Ruby < 3.2/)) # red = critical
+        expect(out).to(include("end-of-life Ruby 3.1 (EOL 2025-03-31)"))
+        expect(out).to(include("upgrade to 4.0.0 to lift it"))
+      end
+
+      it("prints a dim note receipt for a latest-not-yet cap") do
+        result = {
+          "somegem" => ceiling_gem(
+            {
+              requirement: "~> 3.3",
+              eol_forced: false,
+              severity: :note,
+              oldest_supported: "3.3",
+              latest_stable: "4.0.5",
+              fixed_by_upgrade: false,
+            },
+            { version_used: "1.0.0", latest_version: "1.0.0" },
+          ),
+        }
+        out = described_class.render(result)
+        expect(out).to(match(/\e\[2m  ↳ ruby ceiling: requires Ruby ~> 3.3/)) # dim = note
+        expect(out).to(include("no Ruby 4.0.5 support yet"))
+        expect(out).not_to(include("upgrade to"))
+      end
+
+      it("counts ruby ceilings in the summary line, worst-first by tier") do
+        result = {
+          "a" => ceiling_gem({ requirement: "< 3.2", eol_forced: true, severity: :critical, ceiling_version: "3.1", ceiling_eol_date: nil, oldest_supported: "3.3", latest_stable: "4.0.5", fixed_by_upgrade: false }),
+          "b" => ceiling_gem({ requirement: "~> 3.3", eol_forced: false, severity: :note, oldest_supported: "3.3", latest_stable: "4.0.5", fixed_by_upgrade: false }, { version_used: "1.0.0", latest_version: "1.0.0" }),
+        }
+        expect(described_class.render(result)).to(include("2 Ruby ceilings (1 critical, 1 note)"))
+      end
+
+      it("prints no ceiling line for a gem without one") do
+        result = { "rails" => { version_used: "7", latest_version: "7", vulnerability_count: 0, scorecard_score: nil } }
+        expect(described_class.render(result)).not_to(include("ruby ceiling:"))
+      end
+    end
   end
 end

--- a/spec/still_active/workflow_spec.rb
+++ b/spec/still_active/workflow_spec.rb
@@ -642,6 +642,21 @@ RSpec.describe(StillActive::Workflow) do
         expect(ceiling[:fixed_by_upgrade]).to(be(false))
       end
 
+      it("reads the canonical `ruby`-platform ruby_version, not a precompiled native variant's tighter cap") do
+        # Native gems ship a permissive `ruby` (source) platform plus precompiled
+        # per-platform variants that cap ruby_version to the ABIs they were built
+        # for. The source platform is the gem's true Ruby support, so a permissive
+        # `ruby` entry must win even when a capped native entry is listed first.
+        StillActive.config.gems = [{ name: "sqlite3", version: "2.8.1" }]
+        allow(Gems).to(receive(:versions).with("sqlite3").and_return([
+          { "number" => "2.8.1", "platform" => "x86_64-linux", "prerelease" => false, "created_at" => "2026-01-01T00:00:00Z", "licenses" => ["MIT"], "ruby_version" => ">= 3.1, < 3.5.dev" },
+          { "number" => "2.8.1", "platform" => "ruby", "prerelease" => false, "created_at" => "2026-01-01T00:00:00Z", "licenses" => ["MIT"], "ruby_version" => ">= 3.1" },
+        ]))
+        allow(Gems).to(receive(:info).with("sqlite3").and_return({ "homepage_uri" => nil, "source_code_uri" => nil }))
+
+        expect(result["sqlite3"]).not_to(have_key(:ruby_ceiling))
+      end
+
       it("does NOT flag a pinned version that declares no ruby_version, even if the latest version caps") do
         # Absent ruby_version means "runs on any Ruby" -> no ceiling. The cap on a
         # newer release must not be projected back onto the version in the tree.

--- a/spec/still_active/workflow_spec.rb
+++ b/spec/still_active/workflow_spec.rb
@@ -579,6 +579,25 @@ RSpec.describe(StillActive::Workflow) do
       end
     end
 
+    describe(".reconcile_ceiling_with_poison") do
+      it("drops a ceiling's fixed_by_upgrade when the same tree poisons that gem below the fix") do
+        result = {
+          "foo" => { ruby_ceiling: { requirement: "< 3.3", eol_forced: true, severity: :critical, fixed_by_upgrade: true } },
+          "bar" => { constraints: [{ dependency: "foo", requirement: "< 2.0", dep_latest: "2.0.0", majors_behind: 1, kind: :ceiling }] },
+        }
+        described_class.send(:reconcile_ceiling_with_poison, result)
+        expect(result["foo"][:ruby_ceiling][:fixed_by_upgrade]).to(be(false))
+        expect(result["foo"][:ruby_ceiling][:upgrade_blocked]).to(be(true))
+      end
+
+      it("leaves fixed_by_upgrade true when nothing caps that gem") do
+        result = { "foo" => { ruby_ceiling: { fixed_by_upgrade: true } } }
+        described_class.send(:reconcile_ceiling_with_poison, result)
+        expect(result["foo"][:ruby_ceiling][:fixed_by_upgrade]).to(be(true))
+        expect(result["foo"][:ruby_ceiling]).not_to(have_key(:upgrade_blocked))
+      end
+    end
+
     context("with a language-runtime ceiling") do
       let(:range) do
         {

--- a/spec/still_active/workflow_spec.rb
+++ b/spec/still_active/workflow_spec.rb
@@ -14,6 +14,10 @@ RSpec.describe(StillActive::Workflow) do
     # context overrides this per example. (WebMock would otherwise raise on the
     # unstubbed packages.ecosyste.ms call.)
     allow(StillActive::EcosystemsClient).to(receive(:declared_dependencies).and_return([]))
+    # Language-runtime ceiling enrichment fetches the Ruby support window once per
+    # run. Default it off (nil) so existing contexts stay network-free; the ceiling
+    # context stubs a real range. (WebMock would otherwise raise on endoflife.date.)
+    allow(StillActive::RubyHelper).to(receive(:supported_ruby_range).and_return(nil))
     # Pin a GitHub token so provider_for selects GithubClient (the path these
     # integration specs and their VCR cassettes assume), independent of whether
     # the host running the suite happens to have a `gh` token. The no-token
@@ -572,6 +576,98 @@ RSpec.describe(StillActive::Workflow) do
         data = result["protected_attributes"]
         expect(data).not_to(have_key(:constraints))
         expect(data[:latest_version]).to(eq("1.1.4"))
+      end
+    end
+
+    context("with a language-runtime ceiling") do
+      let(:range) do
+        {
+          oldest_supported: Gem::Version.new("3.3"),
+          latest_stable: Gem::Version.new("4.0.5"),
+          cycles: [
+            { version: Gem::Version.new("4.0"), eol: false, eol_date: Time.parse("2029-03-31") },
+            { version: Gem::Version.new("3.4"), eol: false, eol_date: Time.parse("2028-03-31") },
+            { version: Gem::Version.new("3.3"), eol: false, eol_date: Time.parse("2027-03-31") },
+            { version: Gem::Version.new("3.1"), eol: true, eol_date: Time.parse("2025-03-31") },
+          ],
+        }
+      end
+
+      before do
+        allow(StillActive::RubyHelper).to(receive(:supported_ruby_range).and_return(range))
+        allow(StillActive::DepsDevClient).to(receive_messages(version_info: nil, project_scorecard: nil))
+        allow(described_class).to(receive(:repo_signals).and_return({}))
+      end
+
+      # A maintained gem pinned at an old version whose ruby_version caps the
+      # runtime. NOT dormant: the ceiling is a compatibility fact regardless of
+      # maintenance, unlike poison. latest (4.0.0) lifts the cap.
+      def stub_gem_with_ruby_caps(name:, used:, used_ruby:, latest:, latest_ruby:)
+        allow(Gems).to(receive(:versions).with(name).and_return([
+          { "number" => latest, "prerelease" => false, "created_at" => "2026-01-01T00:00:00Z", "licenses" => ["MIT"], "ruby_version" => latest_ruby },
+          { "number" => used, "prerelease" => false, "created_at" => "2026-01-01T00:00:00Z", "licenses" => ["MIT"], "ruby_version" => used_ruby },
+        ]))
+        allow(Gems).to(receive(:info).with(name).and_return({ "homepage_uri" => nil, "source_code_uri" => nil }))
+      end
+
+      it("flags an EOL-forcing cap (critical) and notes that upgrading the gem lifts it") do
+        StillActive.config.gems = [{ name: "cfpropertylist", version: "3.0.9" }]
+        stub_gem_with_ruby_caps(name: "cfpropertylist", used: "3.0.9", used_ruby: "< 3.2", latest: "4.0.0", latest_ruby: ">= 3.2")
+
+        ceiling = result["cfpropertylist"][:ruby_ceiling]
+        expect(ceiling[:eol_forced]).to(be(true))
+        expect(ceiling[:severity]).to(eq(:critical))
+        expect(ceiling[:ceiling_version]).to(eq("3.1"))
+        expect(ceiling[:fixed_by_upgrade]).to(be(true))
+      end
+
+      it("flags a compound floor+ceiling ruby_version end-to-end (the real registry shape)") do
+        StillActive.config.gems = [{ name: "legacygem", version: "1.0.0" }]
+        stub_gem_with_ruby_caps(name: "legacygem", used: "1.0.0", used_ruby: ">= 2.3.0, < 3.2", latest: "2.0.0", latest_ruby: ">= 3.3")
+
+        ceiling = result["legacygem"][:ruby_ceiling]
+        expect(ceiling[:eol_forced]).to(be(true))
+        expect(ceiling[:severity]).to(eq(:critical))
+        expect(ceiling[:ceiling_version]).to(eq("3.1"))
+        expect(ceiling[:fixed_by_upgrade]).to(be(true))
+      end
+
+      it("flags a latest-not-yet cap on the resolved version as a note") do
+        StillActive.config.gems = [{ name: "somegem", version: "1.0.0" }]
+        stub_gem_with_ruby_caps(name: "somegem", used: "1.0.0", used_ruby: "~> 3.3", latest: "1.0.0", latest_ruby: "~> 3.3")
+
+        ceiling = result["somegem"][:ruby_ceiling]
+        expect(ceiling[:eol_forced]).to(be(false))
+        expect(ceiling[:severity]).to(eq(:note))
+        expect(ceiling[:fixed_by_upgrade]).to(be(false))
+      end
+
+      it("does NOT flag a pinned version that declares no ruby_version, even if the latest version caps") do
+        # Absent ruby_version means "runs on any Ruby" -> no ceiling. The cap on a
+        # newer release must not be projected back onto the version in the tree.
+        StillActive.config.gems = [{ name: "oldgem", version: "1.0.0" }]
+        allow(Gems).to(receive(:versions).with("oldgem").and_return([
+          { "number" => "2.0.0", "prerelease" => false, "created_at" => "2026-01-01T00:00:00Z", "licenses" => ["MIT"], "ruby_version" => "< 3.2" },
+          { "number" => "1.0.0", "prerelease" => false, "created_at" => "2026-01-01T00:00:00Z", "licenses" => ["MIT"] }, # no ruby_version
+        ]))
+        allow(Gems).to(receive(:info).with("oldgem").and_return({ "homepage_uri" => nil, "source_code_uri" => nil }))
+
+        expect(result["oldgem"]).not_to(have_key(:ruby_ceiling))
+      end
+
+      it("attaches nothing when the used version's ruby_version is a bare floor") do
+        StillActive.config.gems = [{ name: "modern", version: "2.0.0" }]
+        stub_gem_with_ruby_caps(name: "modern", used: "2.0.0", used_ruby: ">= 3.1", latest: "2.0.0", latest_ruby: ">= 3.1")
+
+        expect(result["modern"]).not_to(have_key(:ruby_ceiling))
+      end
+
+      it("attaches nothing when the Ruby support window is unavailable (range nil)") do
+        allow(StillActive::RubyHelper).to(receive(:supported_ruby_range).and_return(nil))
+        StillActive.config.gems = [{ name: "cfpropertylist", version: "3.0.9" }]
+        stub_gem_with_ruby_caps(name: "cfpropertylist", used: "3.0.9", used_ruby: "< 3.2", latest: "4.0.0", latest_ruby: ">= 3.2")
+
+        expect(result["cfpropertylist"]).not_to(have_key(:ruby_ceiling))
       end
     end
 


### PR DESCRIPTION
## What

Adds the **language-runtime ceiling** signal (SARIF `SA009`), the sibling of the poison pill. Poison caps a *dependency* below its latest major; this caps your *Ruby runtime*. A gem's resolved version declares a `ruby_version` that strands you either:

- **on an end-of-life Ruby** (critical) — a real upgrade blocker, no patched runtime is reachable, or
- **below the latest stable** (note) — an FYI ceiling to plan around, or a place to contribute Ruby-N support before you invest.

Unlike poison it is **not gated on dormancy**: the cap is a fact of the resolved version whether or not the gem is maintained, so a maintained gem pinned to an old release still surfaces. When a newer release lifts the cap, the finding says so (`upgrade to X to lift it`).

## Architecture (generic core, Ruby as calibration)

Kept deliberately generic, mirroring how poison keeps `ConstraintHelper` ecosystem-neutral:

- **Core** — `RuntimeCeilingHelper.analyze(requirement:, support_window:)` knows nothing about Ruby. It cycle-walks a support window (oldest-supported / latest-stable / EOL cycles) to distinguish an EOL cap (`< 3.2`) from a requires-newer floor (`>= 4.1`, `~> 4.0`).
- **Calibration** — `RubyHelper.supported_ruby_range` builds that window from endoflife.date.
- **Boundary** — the workflow reads `ruby_version`, calls the core, attaches `ruby_ceiling`, renders "Ruby".

A future `requires_python` path reuses the core with a Python calibration rather than a rewrite.

## Correctness / robustness

- **Compound ranges.** Registries render a floor+ceiling as one comma-joined string (real: `sorbet-runtime ">= 2.3.0, < 2.7.0.preview1"`, `nokogiri ">= 3.2, < 4.1.dev"`). `Gem::Requirement.new` can't parse that one-string form and raises, so the analyzer splits clauses and preserves both bounds. Without this the ceiling is silently dropped — the exact case the signal exists to catch. (Caught by the silent-failure and code review agents.)
- **Never crash the audit.** The support-window fetch is guarded against malformed endoflife data and wrapped so it degrades to "signal sits out", never aborts the fan-out.
- **No false positive from a newer release.** A version pinned with no `ruby_version` (runs on anything) is never flagged just because a later release caps.

## Surface

- Terminal sub-line, markdown section, SARIF `SA009` (note by default, error when EOL-forcing), JSON `ruby_ceiling`.
- Gate: `--fail-if-ruby-ceiling[=TIER]` (bare = warning threshold), suppressible via the `:ruby_ceiling` signal.
- Reuses the poison severity model end to end (`eol_forced -> :critical` short-circuit added to `ConstraintHelper.constraint_severity`).
- **JSON schema** now documents the compatibility-signal fields (`poison` and the new `ruby_ceiling`) that real output already emitted but the `additionalProperties: false` contract had been silently rejecting.

## Validation

- TDD throughout; 952 examples green, rubocop clean, no new runtime dependencies.
- Reviewed by code-reviewer + silent-failure-hunter + simplifier; both agents' critical findings fixed and re-verified against live data.
- **Dogfooded on five real lockfiles** (gitlab 759, mastodon 351, discourse 305, mastodon-2018 269, plus the CFPropertyList hero): **zero false positives**; true positives on the legacy trees (`i18n-tasks 0.9.21` caps EOL Ruby 2.7; `CFPropertyList 3.0.9` the canonical `< 3.2` case).

No release (per "stellar first").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
