### PR TITLE
feat: generalize runtime ceiling to a language-ceiling family, add Python (SBOM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ Usage: still_active [options]
                                      Exit 1 if any gem has vulnerabilities (optionally at or above SEVERITY)
         --fail-if-outdated=LIBYEARS  Exit 1 if any gem exceeds LIBYEARS behind latest
         --fail-if-poison[=TIER]      Exit 1 on a poison-pill at or above TIER (note|warning|critical; default warning)
-        --fail-if-ruby-ceiling[=TIER]
-                                     Exit 1 on a Ruby-runtime ceiling (default: EOL-forced only; =note also gates latest-not-yet)
+        --fail-if-language-ceiling[=TIER]
+                                     Exit 1 on a language-runtime ceiling (Ruby/Python; default: EOL-forced only; =note also gates latest-not-yet)
         --ignore=GEM,GEM2,...        Exclude gems from pass/fail checks (still shown in output)
         --critical-warning-emoji=EMOJI
         --futurist-emoji=EMOJI
@@ -375,7 +375,7 @@ fail_if_critical: true
 fail_if_vulnerable: high       # true, or a minimum severity: low|medium|high|critical
 fail_if_outdated: 3            # libyears
 fail_if_poison: warning        # true (=warning), or a tier: note|warning|critical (severity scales with majors-behind)
-fail_if_ruby_ceiling: true     # true = EOL-forced ceilings only; :note also gates latest-not-yet (fluctuates with Ruby's release calendar)
+fail_if_language_ceiling: true # true = EOL-forced ceilings only; :note also gates latest-not-yet (fluctuates with the runtime's release calendar)
 unreleased_commits: true
 output: json                   # terminal | markdown | json
 direct_only: true              # audit only declared deps, not the full transitive graph (--direct-only)
@@ -393,7 +393,7 @@ ignore:
 
   # Accept staleness on a vendored gem, but still fail if it gets a CVE
   - gem: legacy_thing
-    signal: activity            # activity | vulnerability | libyear | poison | ruby_ceiling
+    signal: activity            # activity | vulnerability | libyear | poison | language_ceiling
     reason: "vendored, intentionally frozen"
 
   # A bare gem name keeps the old whole-gem behaviour (mutes every signal)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -128,19 +128,21 @@ When uploaded via `github/codeql-action/upload-sarif`, findings appear in the Gi
 
 ---
 
-## SA009 — Ruby Runtime Ceiling {#sa009}
+## SA009 — Language Runtime Ceiling {#sa009}
 
-**Triggers when:** a resolved gem version's declared `ruby_version` caps the Ruby you can run: either below every still-supported release (an EOL-forcing cap) or below the latest stable (a latest-not-yet cap). The runtime support window comes from [endoflife.date](https://endoflife.date/ruby).
+**Triggers when:** a resolved package version's declared runtime constraint caps the language runtime you can run: either below every still-supported release (an EOL-forcing cap) or below the latest stable (a latest-not-yet cap). The constraint is the gem's `ruby_version` on the native Ruby path and a package's `requires_python` on the cross-ecosystem (`--sbom`) path. The runtime support window comes from [endoflife.date](https://endoflife.date/) (Ruby and Python calendars).
 
-**Why it matters:** this is the language-runtime sibling of the poison pill. Where a poison pill caps a dependency, this caps your interpreter. An EOL-forcing cap strands you on a Ruby that receives no security patches, a genuine upgrade blocker. A latest-not-yet cap is a lower-stakes heads-up: a compatibility ceiling to plan around before you invest, or a place to contribute Ruby-N support upstream. It is not gated on maintenance status, since the cap is a fact of the resolved version whether or not the gem is still shipping.
+**Why it matters:** this is the language-runtime sibling of the poison pill. Where a poison pill caps a dependency, this caps your interpreter. An EOL-forcing cap strands you on a runtime that receives no security patches, a genuine upgrade blocker. A latest-not-yet cap is a lower-stakes heads-up: a compatibility ceiling to plan around before you invest, or a place to contribute support for the newest runtime upstream. It is not gated on maintenance status, since the cap is a fact of the resolved version whether or not the package is still shipping.
+
+**Enforcement:** both `ruby_version` (RubyGems/Bundler) and `requires_python` (pip) are *hard install walls*: the resolver refuses an incompatible runtime, so an EOL-forcing cap is a real block, not an inference. still_active reports what the resolver enforces; runtime-correctness beyond that (a native extension that silently breaks) is out of static sight.
 
 **SARIF level:** `note` by default, raised to `error` per result for an EOL-forcing cap · **security-severity:** none (a maintenance/compatibility finding, not a vulnerability) · **CWE:** [CWE-1104](https://cwe.mitre.org/data/definitions/1104.html)
 
-**How to fix:** if a newer release of the gem lifts the cap, upgrade it (the finding says so when it does, unless a poison-pill on the same gem blocks that upgrade). Otherwise replace or fork the gem, or contribute Ruby-N support upstream.
+**How to fix:** if a newer release of the package lifts the cap, upgrade it (the finding says so when it does, unless a poison-pill on the same package blocks that upgrade). Otherwise replace or fork the package, or contribute support for the newer runtime upstream.
 
-**Reading the negative space:** a declared `ruby_version` cap is a maintainer being honest about tested compatibility, not a defect. Equally, **no SA009 findings does not mean "safe to bump Ruby"**: the signal only sees gems that *declare* a cap. The most common real upgrade blockers (native extensions that fail to compile, removed stdlib, deprecated C-API) declare nothing and are invisible here. A latest-not-yet cap is also suppressed for a grace period after a new Ruby ships, since "doesn't support it yet" three days in is about the release calendar, not the gem.
+**Reading the negative space:** a declared runtime cap is a maintainer being honest about tested compatibility, not a defect. Equally, **no SA009 findings does not mean "safe to bump your runtime"**: the signal only sees packages that *declare* a cap. The most common real upgrade blockers (native extensions that fail to compile, removed stdlib, deprecated C-API) declare nothing and are invisible here. A latest-not-yet cap is also suppressed for a grace period after a new runtime ships, since "doesn't support it yet" three days in is about the release calendar, not the package.
 
-**When to suppress:** when the pinned version is deliberate and the runtime ceiling is accepted. Suppress the `ruby_ceiling` signal for the specific gem in `.still_active.yml`, ideally with an `expires:` date so the acceptance is revisited.
+**When to suppress:** when the pinned version is deliberate and the runtime ceiling is accepted. Suppress the `language_ceiling` signal for the specific package in `.still_active.yml`, ideally with an `expires:` date so the acceptance is revisited.
 
 ---
 

--- a/docs/still_active.schema.json
+++ b/docs/still_active.schema.json
@@ -90,7 +90,7 @@
         "poison": { "type": "boolean" },
         "poison_severity": { "type": "string", "enum": ["note", "warning", "critical"] },
         "constraints": { "type": "array", "items": { "$ref": "#/$defs/constraint" } },
-        "ruby_ceiling": { "$ref": "#/$defs/ruby_ceiling" }
+        "language_ceiling": { "$ref": "#/$defs/language_ceiling" }
       }
     },
     "constraint": {
@@ -105,11 +105,12 @@
         "kind": { "type": "string", "enum": ["ceiling", "exact_pin", "permissive"] }
       }
     },
-    "ruby_ceiling": {
+    "language_ceiling": {
       "type": "object",
-      "required": ["requirement", "eol_forced", "severity", "oldest_supported", "latest_stable"],
+      "required": ["runtime", "requirement", "eol_forced", "severity", "oldest_supported", "latest_stable"],
       "additionalProperties": false,
       "properties": {
+        "runtime": { "type": "string" },
         "requirement": { "type": "string" },
         "eol_forced": { "type": "boolean" },
         "severity": { "type": "string", "enum": ["note", "warning", "critical"] },

--- a/lib/helpers/endoflife_helper.rb
+++ b/lib/helpers/endoflife_helper.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "time"
+require_relative "http_helper"
+
+module StillActive
+  # The ecosystem-neutral support-window builder over an endoflife.date feed.
+  # Given a feed path (`/api/ruby.json`, `/api/python.json`, ...) it returns the
+  # runtime facts a per-package language ceiling is measured against: the oldest
+  # cycle still receiving security releases, the latest stable release, a
+  # grace-window flag, and the normalized cycle list. RubyHelper and PythonHelper
+  # are thin calibration wrappers that only choose the feed path, exactly as
+  # RuntimeCeilingHelper keeps the ceiling math generic and pushes the runtime
+  # specifics to the edges. RubyHelper#ruby_freshness also reuses the cycle-date
+  # parsing here so there is one home for reading this best-effort feed.
+  #
+  # Everything degrades on bad third-party data rather than raising: the window is
+  # fetched once outside the per-package rescue, so an unguarded raise would abort
+  # the whole audit. A single malformed field must cost at most the finding it
+  # feeds, never the whole signal.
+  module EndoflifeHelper
+    extend self
+
+    ENDOFLIFE_URI = URI("https://endoflife.date/")
+
+    # How long a newly-released runtime gets before packages are held accountable
+    # for not yet declaring support for it. Below this, a latest-not-yet ceiling
+    # is about the release calendar, not the package, so the note is suppressed.
+    LATEST_STABLE_GRACE_SECONDS = 90 * 24 * 60 * 60
+
+    # => { oldest_supported:, latest_stable:, latest_stable_fresh:, cycles: } of
+    # Gem::Versions plus normalized EOL cycles, or nil when the feed is
+    # unavailable, empty, or every known cycle is EOL (no supported floor to
+    # compare against). `latest_stable` is nil when the newest cycle's `latest` is
+    # malformed -- see below.
+    def support_window(feed_path:)
+      cycles = fetch_cycles(feed_path)
+      return if cycles.nil? || cycles.empty?
+
+      normalized = cycles.filter_map { |cycle| normalize_cycle(cycle) }
+      supported = normalized.reject { |cycle| cycle[:eol] }
+      return if supported.empty?
+
+      # A malformed/preview `latest` on the newest cycle must not sink the whole
+      # window: latest_stable feeds only the latest-not-yet NOTE, whereas the
+      # EOL-forced CRITICAL depends solely on the cycles' eol flags. Degrade it to
+      # nil (the note is then suppressed) rather than returning nil, which would
+      # silently disable criticals too.
+      latest = cycles.first["latest"]
+      latest_stable = latest && Gem::Version.correct?(latest) ? Gem::Version.new(latest) : nil
+
+      {
+        oldest_supported: supported.map { |cycle| cycle[:version] }.min,
+        latest_stable: latest_stable,
+        latest_stable_fresh: !latest_stable.nil? && latest_stable_fresh?(cycles.first),
+        cycles: normalized,
+      }
+    end
+
+    # A best-effort date parse over this feed's values: nil for a missing OR
+    # malformed date, never a raise. endoflife.date is third-party data; a garbled
+    # date on one cycle must degrade that cycle, not abort the run.
+    def parse_date(date_string)
+      return if date_string.nil?
+
+      Time.parse(date_string)
+    rescue ArgumentError
+      nil
+    end
+
+    def parse_eol(value)
+      case value
+      when String then parse_date(value)
+      end
+    end
+
+    # true / false when the eol date is known, nil when it's absent or malformed
+    # (so callers can decide how to treat "unknown"). Routes through parse_date, so
+    # a garbled eol string degrades to nil rather than raising.
+    def eol_reached?(value)
+      case value
+      when true then true
+      when false then false
+      when String
+        parsed = parse_date(value)
+        parsed.nil? ? nil : parsed <= Time.now
+      end
+    end
+
+    private
+
+    def fetch_cycles(feed_path)
+      HttpHelper.get_json(ENDOFLIFE_URI, feed_path)
+    end
+
+    def normalize_cycle(cycle)
+      version = cycle["cycle"]
+      return unless version && Gem::Version.correct?(version)
+
+      {
+        version: Gem::Version.new(version),
+        eol: eol_reached?(cycle["eol"]) == true,
+        eol_date: parse_eol(cycle["eol"]),
+      }
+    end
+
+    def latest_stable_fresh?(latest_cycle)
+      released = parse_date(latest_cycle["releaseDate"])
+      return false if released.nil?
+
+      (Time.now - released) < LATEST_STABLE_GRACE_SECONDS
+    end
+  end
+end

--- a/lib/helpers/http_helper.rb
+++ b/lib/helpers/http_helper.rb
@@ -6,7 +6,7 @@ require "json"
 
 module StillActive
   module HttpHelper
-    TRUSTED_HOSTS = ["github.com", "gitlab.com", "codeberg.org", "api.deps.dev", "endoflife.date", "rubygems.pkg.github.com", "repos.ecosyste.ms", "packages.ecosyste.ms"].freeze
+    TRUSTED_HOSTS = ["github.com", "gitlab.com", "codeberg.org", "api.deps.dev", "endoflife.date", "rubygems.pkg.github.com", "repos.ecosyste.ms", "packages.ecosyste.ms", "pypi.org"].freeze
     # Transport-level failures ("host unreachable / connection broke", not an HTTP
     # error status). Every network entry point degrades to a safe empty result on
     # these rather than letting one escape and vanish a gem from the audit.

--- a/lib/helpers/markdown_helper.rb
+++ b/lib/helpers/markdown_helper.rb
@@ -139,33 +139,35 @@ module StillActive
       lines.join("\n")
     end
 
-    # The language-runtime ceiling: a resolved version whose `ruby_version` caps
-    # the runtime onto an EOL Ruby (critical) or below the latest stable (note).
-    # Ranked worst-first with a tier label, mirroring the poison section.
-    def ruby_ceiling_section(result)
-      flagged = result.select { |_name, data| data[:ruby_ceiling] }
+    # The language-runtime ceiling: a resolved version whose declared runtime
+    # constraint (Ruby `ruby_version`, Python `requires_python`) caps the runtime
+    # onto an EOL release (critical) or below the latest stable (note). Ranked
+    # worst-first with a tier label, mirroring the poison section.
+    def language_ceiling_section(result)
+      flagged = result.select { |_name, data| data[:language_ceiling] }
       return "" if flagged.empty?
 
-      lines = ["", "**Ruby ceiling findings** (a resolved version's `ruby_version` capping your Ruby runtime):"]
-      ranked = flagged.sort_by { |name, data| [-ConstraintHelper::SEVERITY.index(data[:ruby_ceiling][:severity] || :note), name.to_s] }
+      lines = ["", "**Runtime ceiling findings** (a resolved version capping the language runtime it can run on):"]
+      ranked = flagged.sort_by { |name, data| [-ConstraintHelper::SEVERITY.index(data[:language_ceiling][:severity] || :note), name.to_s] }
       ranked.each do |name, data|
-        ceiling = data[:ruby_ceiling]
-        lines << "- **#{ceiling[:severity] || :note}** #{MarkdownEscape.code_span(name)} #{ruby_ceiling_receipt(ceiling, data)}"
+        ceiling = data[:language_ceiling]
+        lines << "- **#{ceiling[:severity] || :note}** #{MarkdownEscape.code_span(name)} #{language_ceiling_receipt(ceiling, data)}"
       end
       lines.join("\n")
     end
 
     private
 
-    def ruby_ceiling_receipt(ceiling, data)
+    def language_ceiling_receipt(ceiling, data)
+      runtime = ceiling[:runtime]
       req = MarkdownEscape.code_span(ceiling[:requirement])
       base =
         if ceiling[:eol_forced]
           eol = ceiling[:ceiling_eol_date]
           eol_part = eol ? " (EOL #{eol.strftime("%Y-%m-%d")})" : ""
-          "requires Ruby #{req}, stranding you on end-of-life Ruby #{ceiling[:ceiling_version]}#{eol_part}"
+          "requires #{runtime} #{req}, stranding you on end-of-life #{runtime} #{ceiling[:ceiling_version]}#{eol_part}"
         else
-          "requires Ruby #{req}, no Ruby #{ceiling[:latest_stable]} support yet"
+          "requires #{runtime} #{req}, no #{runtime} #{ceiling[:latest_stable]} support yet"
         end
       fix = ceiling[:fixed_by_upgrade] && data[:latest_version] ? "; upgrade to #{data[:latest_version]} to lift it" : ""
       "#{base}#{fix}"

--- a/lib/helpers/pep440_helper.rb
+++ b/lib/helpers/pep440_helper.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module StillActive
+  # Translates a PEP 440 `requires_python` specifier into a RubyGems requirement
+  # STRING, so the generic RuntimeCeilingHelper can reason about a Python runtime
+  # ceiling with no core change -- the same way Ruby's `ruby_version` already
+  # feeds it. PEP 440 and RubyGems disagree on two operators that matter here:
+  #
+  #   - `~=` (compatible release) is a syntax error to Gem::Requirement, so a
+  #     naive parse raises and the ceiling is silently missed. It maps cleanly to
+  #     RubyGems `~>` for the major.minor.patch shapes `requires_python` uses.
+  #   - `== X.*` / `== X.Y.*` prefix wildcards are likewise unparseable and map to
+  #     a pessimistic `~>` over the prefix.
+  #
+  # `!=` exclusions are dropped: a hole-punch can never create an upper bound, so
+  # it cannot be a runtime ceiling, and dropping it can only ADMIT more runtimes
+  # (fewer findings) -- conservative, never a false ceiling. Anything that still
+  # won't parse degrades to a dropped clause (or nil overall), never a raise: this
+  # feeds the core audit and must fail safe, matching RuntimeCeilingHelper's
+  # best-effort contract.
+  module Pep440Helper
+    extend self
+
+    # Match ConstraintHelper / RuntimeCeilingHelper: bound pathological registry
+    # input before it reaches Gem::Requirement's own regex.
+    MAX_SPECIFIER_LENGTH = 256
+
+    CLAUSE_PATTERN = /\A(===|==|~=|!=|<=|>=|<|>)\s*(.+)\z/
+
+    # => a comma-joined RubyGems requirement string, or nil when nothing usable
+    # survives translation. The caller feeds the string to RuntimeCeilingHelper,
+    # which splits and splats it exactly like a `ruby_version` string.
+    def to_gem_requirement_string(specifier)
+      spec = specifier.to_s
+      return if spec.strip.empty? || spec.length > MAX_SPECIFIER_LENGTH
+
+      clauses = spec.split(",").filter_map { |clause| translate_clause(clause.strip) }
+      return if clauses.empty?
+
+      clauses.join(", ")
+    end
+
+    private
+
+    def translate_clause(clause)
+      match = CLAUSE_PATTERN.match(clause)
+      return if match.nil?
+
+      operator = match[1]
+      version = match[2].strip
+
+      case operator
+      when "!=" then nil # hole-punch: never an upper bound, drop it
+      when "~=" then compatible_release(version)
+      when "==", "===" then equality(version)
+      else comparison(operator, version)
+      end
+    end
+
+    # `~= X.Y[.Z]` is `>= X.Y[.Z], == X.Y.*` which is exactly RubyGems `~> X.Y[.Z]`.
+    def compatible_release(version)
+      return unless parseable?(version)
+
+      "~> #{version}"
+    end
+
+    def equality(version)
+      if version.end_with?(".*")
+        prefix_match(version.delete_suffix(".*"))
+      elsif parseable?(version)
+        "= #{version}"
+      end
+    end
+
+    # `== P.*` matches every release whose version starts with prefix P, i.e.
+    # `>= P, < P-with-last-segment-incremented`. RubyGems spells that as `~> P.0`
+    # (append one segment so the pessimistic bump lands on P's last segment):
+    #   ==3.*   -> ~> 3.0   (>=3, <4)
+    #   ==3.7.* -> ~> 3.7.0 (>=3.7, <3.8)
+    def prefix_match(prefix)
+      return unless parseable?(prefix)
+
+      "~> #{prefix}.0"
+    end
+
+    def comparison(operator, version)
+      return unless parseable?(version)
+
+      "#{operator} #{version}"
+    end
+
+    def parseable?(version)
+      Gem::Version.correct?(version)
+    end
+  end
+end

--- a/lib/helpers/pep440_helper.rb
+++ b/lib/helpers/pep440_helper.rb
@@ -25,7 +25,11 @@ module StillActive
     # input before it reaches Gem::Requirement's own regex.
     MAX_SPECIFIER_LENGTH = 256
 
-    CLAUSE_PATTERN = /\A(===|==|~=|!=|<=|>=|<|>)\s*(.+)\z/
+    # Operator, then the version as a run of non-space chars. `\s*(\S+)` (not
+    # `\s*(.+)`) keeps the two groups over disjoint character classes so there's no
+    # polynomial backtracking on pathological input like "<" + many spaces (a PEP
+    # 440 version never contains internal spaces, so this loses nothing).
+    CLAUSE_PATTERN = /\A(===|==|~=|!=|<=|>=|<|>)\s*(\S+)\z/
 
     # => a comma-joined RubyGems requirement string, or nil when nothing usable
     # survives translation. The caller feeds the string to RuntimeCeilingHelper,

--- a/lib/helpers/python_helper.rb
+++ b/lib/helpers/python_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative "endoflife_helper"
+
+module StillActive
+  # Python's calibration for the language-runtime ceiling: the thin sibling of
+  # RubyHelper.supported_ruby_range. Python declares its runtime constraint as a
+  # PEP 440 `requires_python` specifier (translate with Pep440Helper before
+  # handing it to RuntimeCeilingHelper), and its release calendar lives in the
+  # same endoflife.date feed. Everything ecosystem-neutral is in EndoflifeHelper;
+  # Python only chooses the feed path.
+  module PythonHelper
+    extend self
+
+    def supported_python_range
+      EndoflifeHelper.support_window(feed_path: "/api/python.json")
+    end
+  end
+end

--- a/lib/helpers/ruby_helper.rb
+++ b/lib/helpers/ruby_helper.rb
@@ -2,6 +2,7 @@
 
 require "time"
 require_relative "bundler_helper"
+require_relative "endoflife_helper"
 require_relative "http_helper"
 require_relative "libyear_helper"
 
@@ -24,15 +25,15 @@ module StillActive
       return if latest_cycle.nil?
 
       latest_version = latest_cycle["latest"]
-      latest_release_date = parse_date(latest_cycle["releaseDate"])
-      current_release_date = parse_date(current_cycle&.dig("releaseDate"))
+      latest_release_date = EndoflifeHelper.parse_date(latest_cycle["releaseDate"])
+      current_release_date = EndoflifeHelper.parse_date(current_cycle&.dig("releaseDate"))
       eol_value = current_cycle&.dig("eol")
 
       {
         version: current,
         release_date: current_release_date,
-        eol_date: parse_eol(eol_value),
-        eol: eol_reached?(eol_value),
+        eol_date: EndoflifeHelper.parse_eol(eol_value),
+        eol: EndoflifeHelper.eol_reached?(eol_value),
         latest_version: latest_version,
         latest_release_date: latest_release_date,
         libyear: LibyearHelper.gem_libyear(
@@ -42,66 +43,15 @@ module StillActive
       }
     end
 
-    # The runtime facts a per-gem language ceiling is measured against: the
-    # oldest Ruby cycle still receiving security releases, the latest stable
-    # release, and the normalized cycle list (version + EOL flag/date) so a
-    # ceiling finding can name the exact Ruby a cap strands you on and how long
-    # it's been dead. Reuses the same endoflife.date feed as #ruby_freshness.
-    # Returns nil when the feed is unavailable or every known cycle is EOL (no
-    # supported floor to compare against).
+    # The runtime facts a per-gem language ceiling is measured against, sourced
+    # from the shared endoflife.date support-window builder. Ruby only picks the
+    # feed; the ecosystem-neutral logic (support floor, latest stable, grace
+    # window, cycle normalization) lives in EndoflifeHelper.
     def supported_ruby_range
-      cycles = fetch_cycles
-      return if cycles.nil? || cycles.empty?
-
-      # endoflife.date is best-effort third-party data. Guard the newest cycle's
-      # `latest` the same way normalize_cycle guards `cycle`: a malformed/preview
-      # value must degrade to "sit out" (nil), not raise. This method is fetched
-      # once outside the per-gem rescue, so an unguarded raise would abort the
-      # entire audit, contrary to the best-effort contract.
-      latest = cycles.first["latest"]
-      return unless latest && Gem::Version.correct?(latest)
-
-      normalized = cycles.filter_map { |cycle| normalize_cycle(cycle) }
-      supported = normalized.reject { |cycle| cycle[:eol] }
-      return if supported.empty?
-
-      {
-        oldest_supported: supported.map { |cycle| cycle[:version] }.min,
-        latest_stable: Gem::Version.new(latest),
-        latest_stable_fresh: latest_stable_fresh?(cycles.first),
-        cycles: normalized,
-      }
-    end
-
-    # How long a newly-released runtime gets before gems are held accountable for
-    # not yet declaring support for it. Below this, a latest-not-yet ceiling is
-    # about the release calendar, not the gem, so the note is suppressed.
-    LATEST_STABLE_GRACE_SECONDS = 90 * 24 * 60 * 60
-
-    def latest_stable_fresh?(latest_cycle)
-      released = parse_date(latest_cycle["releaseDate"])
-      return false if released.nil?
-
-      (Time.now - released) < LATEST_STABLE_GRACE_SECONDS
-    rescue ArgumentError
-      # A malformed (non-nil) releaseDate from the best-effort feed must degrade to
-      # "not fresh" (notes fire as normal), never raise: raising here would null the
-      # whole support window and silently disable EOL-forced criticals too.
-      false
+      EndoflifeHelper.support_window(feed_path: "/api/ruby.json")
     end
 
     private
-
-    def normalize_cycle(cycle)
-      version = cycle["cycle"]
-      return unless version && Gem::Version.correct?(version)
-
-      {
-        version: Gem::Version.new(version),
-        eol: eol_reached?(cycle["eol"]) == true,
-        eol_date: parse_eol(cycle["eol"]),
-      }
-    end
 
     def current_ruby_version
       lockfile_ruby_version || (RUBY_ENGINE == "ruby" ? RUBY_VERSION : nil)
@@ -126,26 +76,6 @@ module StillActive
     def find_cycle(cycles, version)
       major_minor = version.split(".")[0..1].join(".")
       cycles.find { |c| c["cycle"] == major_minor }
-    end
-
-    def parse_date(date_string)
-      return if date_string.nil?
-
-      Time.parse(date_string)
-    end
-
-    def parse_eol(value)
-      case value
-      when String then parse_date(value)
-      end
-    end
-
-    def eol_reached?(value)
-      case value
-      when true then true
-      when false then false
-      when String then Time.parse(value) <= Time.now
-      end
     end
   end
 end

--- a/lib/helpers/runtime_ceiling_helper.rb
+++ b/lib/helpers/runtime_ceiling_helper.rb
@@ -45,7 +45,7 @@ module StillActive
 
       if supported_allowed.empty?
         eol_forced_finding(req, requirement, support_window)
-      elsif !req.satisfied_by?(support_window[:latest_stable]) && !support_window[:latest_stable_fresh]
+      elsif !support_window[:latest_stable].nil? && !req.satisfied_by?(support_window[:latest_stable]) && !support_window[:latest_stable_fresh]
         # Runs on a supported runtime but not the latest stable. Suppressed while
         # the latest stable is still within its grace window (see supported_ruby_
         # range): right after a runtime ships, "doesn't support it yet" indicts the

--- a/lib/helpers/sarif_helper.rb
+++ b/lib/helpers/sarif_helper.rb
@@ -145,37 +145,38 @@ module StillActive
         out << mark_suppressed(result("SA008", name, poison_message(name, version, data), location, level: poison_level(data)), name, :poison)
       end
 
-      if data[:ruby_ceiling]
+      if data[:language_ceiling]
         # Level tracks the ceiling tier: critical (EOL-forced) -> error, note
         # (latest-not-yet) -> note. Fingerprint is (rule_id, gem_name, state) where
         # state is the eol_forced boolean: cosmetic churn (which patch, which
         # latest) doesn't re-alert, but a note -> EOL-forced escalation (a supported
-        # Ruby went EOL) mints a NEW alert so a past dismissal of the note can't
+        # runtime went EOL) mints a NEW alert so a past dismissal of the note can't
         # silently mute the critical -- that transition is exactly the one a human
         # must see.
-        state = data[:ruby_ceiling][:eol_forced] ? "eol_forced" : "latest_not_yet"
-        out << mark_suppressed(result("SA009", name, ruby_ceiling_message(name, version, data), location, level: ruby_ceiling_level(data), fp_extra: state), name, :ruby_ceiling)
+        state = data[:language_ceiling][:eol_forced] ? "eol_forced" : "latest_not_yet"
+        out << mark_suppressed(result("SA009", name, language_ceiling_message(name, version, data), location, level: language_ceiling_level(data), fp_extra: state), name, :language_ceiling)
       end
 
       out
     end
 
-    def ruby_ceiling_level(data)
-      { critical: "error", warning: "warning", note: "note" }.fetch(data[:ruby_ceiling][:severity], "note")
+    def language_ceiling_level(data)
+      { critical: "error", warning: "warning", note: "note" }.fetch(data[:language_ceiling][:severity], "note")
     end
 
-    def ruby_ceiling_message(name, version, data)
-      ceiling = data[:ruby_ceiling]
+    def language_ceiling_message(name, version, data)
+      ceiling = data[:language_ceiling]
+      runtime = ceiling[:runtime]
       body =
         if ceiling[:eol_forced]
           eol = ceiling[:ceiling_eol_date]
           eol_part = eol ? " (EOL #{format_date(eol)})" : ""
-          "stranding you on end-of-life Ruby #{ceiling[:ceiling_version]}#{eol_part}"
+          "stranding you on end-of-life #{runtime} #{ceiling[:ceiling_version]}#{eol_part}"
         else
-          "no Ruby #{ceiling[:latest_stable]} support yet"
+          "no #{runtime} #{ceiling[:latest_stable]} support yet"
         end
       fix = ceiling[:fixed_by_upgrade] && data[:latest_version] ? "; upgrade to #{data[:latest_version]} to lift it" : ""
-      "#{name} #{version}: requires Ruby #{ceiling[:requirement]}, #{body}#{fix}#{transitive_suffix(data)}."
+      "#{name} #{version}: requires #{runtime} #{ceiling[:requirement]}, #{body}#{fix}#{transitive_suffix(data)}."
     end
 
     # The poison receipt for a Code Scanning alert: the worst 3 caps (shared

--- a/lib/helpers/terminal_helper.rb
+++ b/lib/helpers/terminal_helper.rb
@@ -145,27 +145,29 @@ module StillActive
       end
       # A language-runtime ceiling is orthogonal to poison/alternatives (a gem can
       # be maintained yet still cap your Ruby), so it always gets its own line.
-      lines << ruby_ceiling_line(data)
+      lines << language_ceiling_line(data)
       lines.compact
     end
 
-    # "  ↳ ruby ceiling: <receipt>", coloured by tier (red = strands you on an EOL
-    # Ruby, dim = an FYI cap below the latest stable). Reuses poison_colour.
-    def ruby_ceiling_line(data)
-      ceiling = data[:ruby_ceiling]
+    # "  ↳ ruby ceiling: <receipt>" (or "python ceiling"), coloured by tier (red =
+    # strands you on an EOL runtime, dim = an FYI cap below the latest stable).
+    # Reuses poison_colour; the runtime name comes off the finding, not hardcoded.
+    def language_ceiling_line(data)
+      ceiling = data[:language_ceiling]
       return if ceiling.nil?
 
-      AnsiHelper.public_send(poison_colour(ceiling[:severity]), "  ↳ ruby ceiling: #{ruby_ceiling_receipt(ceiling, data)}")
+      AnsiHelper.public_send(poison_colour(ceiling[:severity]), "  ↳ #{ceiling[:runtime].downcase} ceiling: #{language_ceiling_receipt(ceiling, data)}")
     end
 
-    def ruby_ceiling_receipt(ceiling, data)
+    def language_ceiling_receipt(ceiling, data)
+      runtime = ceiling[:runtime]
       base =
         if ceiling[:eol_forced]
-          "requires Ruby #{ceiling[:requirement]}, stranding you on end-of-life Ruby #{ceiling[:ceiling_version]}#{eol_suffix(ceiling[:ceiling_eol_date])}"
+          "requires #{runtime} #{ceiling[:requirement]}, stranding you on end-of-life #{runtime} #{ceiling[:ceiling_version]}#{eol_suffix(ceiling[:ceiling_eol_date])}"
         else
-          "requires Ruby #{ceiling[:requirement]}, no Ruby #{ceiling[:latest_stable]} support yet"
+          "requires #{runtime} #{ceiling[:requirement]}, no #{runtime} #{ceiling[:latest_stable]} support yet"
         end
-      "#{base}#{ruby_ceiling_fix_hint(ceiling, data)}"
+      "#{base}#{language_ceiling_fix_hint(ceiling, data)}"
     end
 
     def eol_suffix(eol_date)
@@ -175,7 +177,7 @@ module StillActive
     # Name the actionable fix when a newer release of the gem lifts the cap; the
     # gem's own name sits on the row directly above, so "upgrade to <latest>" reads
     # unambiguously without repeating it.
-    def ruby_ceiling_fix_hint(ceiling, data)
+    def language_ceiling_fix_hint(ceiling, data)
       return "" unless ceiling[:fixed_by_upgrade] && data[:latest_version]
 
       "; upgrade to #{data[:latest_version]} to lift it"
@@ -304,8 +306,10 @@ module StillActive
       poison_tiers = result.each_value.select { |data| data[:poison] }.map { |data| data[:poison_severity] }
       poison_part = tier_summary_part(poison_tiers, "#{poison_tiers.size} poison-#{poison_tiers.size == 1 ? "pill" : "pills"}")
       parts << poison_part if poison_part
-      ceilings = result.each_value.filter_map { |data| data[:ruby_ceiling] }
-      ceiling_part = tier_summary_part(ceilings.map { |ceiling| ceiling[:severity] }, "#{ceilings.size} Ruby ceiling#{"s" unless ceilings.size == 1}")
+      ceilings = result.each_value.filter_map { |data| data[:language_ceiling] }
+      runtimes = ceilings.map { |ceiling| ceiling[:runtime] }.uniq
+      runtime_label = runtimes.size == 1 ? runtimes.first : "language"
+      ceiling_part = tier_summary_part(ceilings.map { |ceiling| ceiling[:severity] }, "#{ceilings.size} #{runtime_label} ceiling#{"s" unless ceilings.size == 1}")
       parts << ceiling_part if ceiling_part
       total_libyear = LibyearHelper.total_libyear(result)
       parts << "#{total_libyear.round(1)} libyears behind" if total_libyear > 0

--- a/lib/still_active/ceiling_reconciler.rb
+++ b/lib/still_active/ceiling_reconciler.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module StillActive
+  # Whole-tree correlation between the two capping signals, run once after the
+  # fan-out (native or SBOM) has assembled every package's findings. A language
+  # ceiling that says "upgrade <package> to lift it" is wrong if the same tree
+  # poisons <package> below that upgrade (a dormant dependency caps it): the
+  # report must never advise an upgrade its own poison finding says is impossible.
+  # All data is already in the assembled result, so this is one pass, no fetches.
+  # "The correlation layer must correlate."
+  module CeilingReconciler
+    extend self
+
+    def reconcile_ceiling_with_poison(result_object)
+      # Qualify each capped dependency by the ecosystem that declares the cap. A
+      # capped dep resolves in its parent's ecosystem, so a poison finding on a
+      # `pypi` package caps a `pypi` dependency. A mixed SBOM has two flat-
+      # resolution ecosystems (rubygems + pypi), so a bare-name match alone would
+      # let a rubygems poison-cap on "foo" wrongly block a pypi "foo"'s ceiling.
+      # Native results carry no :ecosystem (all rubygems) -> nil on both sides,
+      # still consistent.
+      capped = result_object.each_value
+        .flat_map do |data|
+          Array(data[:constraints])
+            .select { |constraint| constraint[:majors_behind].to_i.positive? }
+            .map { |constraint| "#{data[:ecosystem]}/#{constraint[:dependency]}" }
+        end
+        .uniq
+      result_object.each do |key, data|
+        ceiling = data[:language_ceiling]
+        next unless ceiling && ceiling[:fixed_by_upgrade]
+
+        # Native results are keyed by the bare gem name; SBOM results are keyed by
+        # "ecosystem/name@version" and carry the bare name in :name.
+        package_name = data[:name] || key
+        next unless capped.include?("#{data[:ecosystem]}/#{package_name}")
+
+        ceiling[:fixed_by_upgrade] = false
+        ceiling[:upgrade_blocked] = true
+      end
+    end
+  end
+end

--- a/lib/still_active/cli.rb
+++ b/lib/still_active/cli.rb
@@ -341,8 +341,8 @@ module StillActive
       end
       poison = MarkdownHelper.poison_section(result)
       puts poison unless poison.empty?
-      ruby_ceiling = MarkdownHelper.ruby_ceiling_section(result)
-      puts ruby_ceiling unless ruby_ceiling.empty?
+      language_ceiling = MarkdownHelper.language_ceiling_section(result)
+      puts language_ceiling unless language_ceiling.empty?
       alternatives = MarkdownHelper.alternatives_section(result)
       puts alternatives unless alternatives.empty?
       transitive = MarkdownHelper.transitive_section(result)
@@ -355,7 +355,7 @@ module StillActive
 
     def check_exit_status(result)
       config = StillActive.config
-      return unless config.fail_if_critical || config.fail_if_warning || config.fail_if_vulnerable || config.fail_if_outdated || config.fail_if_poison || config.fail_if_ruby_ceiling
+      return unless config.fail_if_critical || config.fail_if_warning || config.fail_if_vulnerable || config.fail_if_outdated || config.fail_if_poison || config.fail_if_language_ceiling
 
       warn_unknown_severity_gate(result, config)
       exit(1) if result.any? { |name, data| gate_failed?(name, data, config) }
@@ -396,7 +396,7 @@ module StillActive
         failed_vulnerability?(name, data, config, suppressions) ||
         failed_outdated?(name, data, config, suppressions) ||
         failed_poison?(name, data, config, suppressions) ||
-        failed_ruby_ceiling?(name, data, config, suppressions)
+        failed_language_ceiling?(name, data, config, suppressions)
     end
 
     def failed_poison?(name, data, config, suppressions)
@@ -409,17 +409,17 @@ module StillActive
       ConstraintHelper.severity_at_or_above?(data[:poison_severity], threshold)
     end
 
-    def failed_ruby_ceiling?(name, data, config, suppressions)
-      return false unless config.fail_if_ruby_ceiling
-      return false if suppressions.suppressed?(gem: name, signal: :ruby_ceiling)
+    def failed_language_ceiling?(name, data, config, suppressions)
+      return false unless config.fail_if_language_ceiling
+      return false if suppressions.suppressed?(gem: name, signal: :language_ceiling)
 
       # Ceiling findings are only ever :critical (EOL-forced) or :note
       # (latest-not-yet) -- there is no :warning tier for this signal -- so the
-      # bare flag defaults to :critical (the genuine blocker: no supported Ruby is
-      # reachable). A latest-not-yet :note is an FYI/contribution lead that gates
+      # bare flag defaults to :critical (the genuine blocker: no supported runtime
+      # is reachable). A latest-not-yet :note is an FYI/contribution lead that gates
       # only when the user explicitly opts in with =note.
-      threshold = config.fail_if_ruby_ceiling == true ? :critical : config.fail_if_ruby_ceiling
-      ConstraintHelper.severity_at_or_above?(data.dig(:ruby_ceiling, :severity), threshold)
+      threshold = config.fail_if_language_ceiling == true ? :critical : config.fail_if_language_ceiling
+      ConstraintHelper.severity_at_or_above?(data.dig(:language_ceiling, :severity), threshold)
     end
 
     def failed_activity?(name, data, config, suppressions)

--- a/lib/still_active/config.rb
+++ b/lib/still_active/config.rb
@@ -18,7 +18,7 @@ module StillActive
       :cyclonedx_version,
       :fail_if_critical,
       :fail_if_poison,
-      :fail_if_ruby_ceiling,
+      :fail_if_language_ceiling,
       :fail_if_warning,
       :futurist_emoji,
       :gems,
@@ -41,7 +41,7 @@ module StillActive
       @direct_only = false
       @fail_if_critical = false
       @fail_if_poison = false
-      @fail_if_ruby_ceiling = false
+      @fail_if_language_ceiling = false
       @fail_if_outdated = nil
       @fail_if_vulnerable = nil
       @fail_if_warning = false

--- a/lib/still_active/config_file.rb
+++ b/lib/still_active/config_file.rb
@@ -50,7 +50,7 @@ module StillActive
         when "fail_if_critical" then set_boolean(config, :fail_if_critical=, value, key, warnings)
         when "fail_if_warning" then set_boolean(config, :fail_if_warning=, value, key, warnings)
         when "fail_if_poison" then apply_fail_if_poison(config, value, warnings)
-        when "fail_if_ruby_ceiling" then apply_fail_if_ruby_ceiling(config, value, warnings)
+        when "fail_if_language_ceiling" then apply_fail_if_language_ceiling(config, value, warnings)
         when "alternatives" then set_boolean(config, :alternatives=, value, key, warnings)
         when "unreleased_commits" then set_boolean(config, :unreleased_commits=, value, key, warnings)
         when "direct_only" then set_boolean(config, :direct_only=, value, key, warnings)
@@ -151,13 +151,13 @@ module StillActive
 
     # true/false, or a severity tier (note|warning|critical). Mirrors the CLI
     # flag: bare `true` fails at :warning, a tier sets an explicit threshold.
-    def apply_fail_if_ruby_ceiling(config, value, warnings)
+    def apply_fail_if_language_ceiling(config, value, warnings)
       if value == true || value == false
-        config.fail_if_ruby_ceiling = value
+        config.fail_if_language_ceiling = value
       elsif ConstraintHelper::SEVERITY.map(&:to_s).include?(value.to_s)
-        config.fail_if_ruby_ceiling = value.to_sym
+        config.fail_if_language_ceiling = value.to_sym
       else
-        warnings << "#{FILENAME}: fail_if_ruby_ceiling must be true/false or one of #{ConstraintHelper::SEVERITY.join(", ")} (got #{value.inspect}), ignoring it"
+        warnings << "#{FILENAME}: fail_if_language_ceiling must be true/false or one of #{ConstraintHelper::SEVERITY.join(", ")} (got #{value.inspect}), ignoring it"
       end
     end
 

--- a/lib/still_active/ecosystem_lens.rb
+++ b/lib/still_active/ecosystem_lens.rb
@@ -3,8 +3,11 @@
 require_relative "deps_dev_client"
 require_relative "ecosystems_client"
 require_relative "github_client"
+require_relative "pypi_client"
 require_relative "../helpers/activity_helper"
 require_relative "../helpers/constraint_helper"
+require_relative "../helpers/pep440_helper"
+require_relative "../helpers/runtime_ceiling_helper"
 require_relative "../helpers/vulnerability_helper"
 
 module StillActive
@@ -46,7 +49,7 @@ module StillActive
     # deps.dev; silence beats a false "holds your tree hostage".
     FLAT_RESOLUTION_ECOSYSTEMS = [:rubygems, :pypi].freeze
 
-    def assess(ecosystem:, name:, version:, constraint_cache: {})
+    def assess(ecosystem:, name:, version:, constraint_cache: {}, python_range: nil)
       info = DepsDevClient.version_info(gem_name: name, version: version, system: ecosystem)
       default = DepsDevClient.default_version_info(name: name, system: ecosystem)
       # Recover the repo from the default version when the exact locked version
@@ -74,10 +77,52 @@ module StillActive
         vulnerabilities: vulnerabilities,
       }
       attach_constraints(gem_data, ecosystem: ecosystem, name: name, version: version, cache: constraint_cache)
+      attach_language_ceiling(gem_data, ecosystem: ecosystem, name: name, version: version, latest_version: default&.dig(:version), python_range: python_range)
       gem_data
     end
 
     private
+
+    # Language-runtime ceiling for the cross-ecosystem path, the sibling of the
+    # native Ruby ceiling in Workflow. Python declares its runtime constraint as a
+    # PEP 440 `requires_python`, an enforced pip install wall; translate it and run
+    # the same generic RuntimeCeilingHelper against Python's support window. Unlike
+    # poison this is NOT gated on dormancy (a cap is a fact of the resolved version
+    # whether or not the package is maintained), so it costs one PyPI read per
+    # pypi package; other ecosystems carry no ceiling here rather than a wrong one
+    # (cargo's rust_version is a soft MSRV hint, not an install wall). Best-effort:
+    # a nil range (endoflife feed down) or absent requires_python yields nothing.
+    def attach_language_ceiling(gem_data, ecosystem:, name:, version:, latest_version:, python_range:)
+      return if python_range.nil?
+      return unless ecosystem == :pypi
+
+      requirement = Pep440Helper.to_gem_requirement_string(PypiClient.requires_python(name: name, version: version))
+      finding = requirement && RuntimeCeilingHelper.analyze(requirement: requirement, support_window: python_range)
+      return if finding.nil?
+
+      finding[:runtime] = "Python"
+      finding[:fixed_by_upgrade] = python_ceiling_lifted_by_upgrade?(name: name, version: version, latest_version: latest_version, python_range: python_range)
+      gem_data[:language_ceiling] = finding
+    end
+
+    # Does upgrading the package to its latest release lift the cap? Requires
+    # POSITIVE confirmation, unlike the native ruby_ceiling_lifted_by_upgrade?
+    # whose latest requirement is read from data already in hand. Here the latest
+    # requires_python is a fresh PyPI read, and PypiClient returns nil for BOTH
+    # "declares no constraint" AND "the fetch failed" -- indistinguishable. Reading
+    # that nil as "no ceiling, safe to bump" would fabricate remediation on a
+    # transient PyPI error, the exact over-claim this tool must never make. So a
+    # nil specifier yields false (we don't advise an upgrade we couldn't verify);
+    # only a readable constraint that analyze confirms is non-capping lifts it.
+    def python_ceiling_lifted_by_upgrade?(name:, version:, latest_version:, python_range:)
+      return false if latest_version.nil? || latest_version == version
+
+      latest_specifier = PypiClient.requires_python(name: name, version: latest_version)
+      return false if latest_specifier.nil?
+
+      latest_requirement = Pep440Helper.to_gem_requirement_string(latest_specifier)
+      RuntimeCeilingHelper.analyze(requirement: latest_requirement, support_window: python_range).nil?
+    end
 
     # Poison-pill enrichment for the cross-ecosystem path, mirroring the native
     # Bundler path: gated on dormancy so a maintained package is never flagged,

--- a/lib/still_active/options.rb
+++ b/lib/still_active/options.rb
@@ -173,19 +173,19 @@ module StillActive
           StillActive.config { |config| config.fail_if_poison = true }
         end
       end
-      opts.on("--fail-if-ruby-ceiling[=TIER]", "Exit 1 on a Ruby-runtime ceiling (default: EOL-forced only; =note also gates latest-not-yet)") do |value|
+      opts.on("--fail-if-language-ceiling[=TIER]", "Exit 1 on a language-runtime ceiling (Ruby/Python; default: EOL-forced only; =note also gates latest-not-yet)") do |value|
         if value
           valid = StillActive::ConstraintHelper::SEVERITY.map(&:to_s)
-          raise ArgumentError, "--fail-if-ruby-ceiling tier must be one of: #{valid.join(", ")} (got #{value})" unless valid.include?(value)
+          raise ArgumentError, "--fail-if-language-ceiling tier must be one of: #{valid.join(", ")} (got #{value})" unless valid.include?(value)
 
           # Ceiling findings are only ever :critical or :note, so =warning can't
           # match anything the bare (=critical) default doesn't already catch.
           if value == "warning"
-            $stderr.puts("warning: --fail-if-ruby-ceiling=warning has no effect (runtime ceilings are only critical or note); behaves as =critical")
+            $stderr.puts("warning: --fail-if-language-ceiling=warning has no effect (runtime ceilings are only critical or note); behaves as =critical")
           end
-          StillActive.config { |config| config.fail_if_ruby_ceiling = value.to_sym }
+          StillActive.config { |config| config.fail_if_language_ceiling = value.to_sym }
         else
-          StillActive.config { |config| config.fail_if_ruby_ceiling = true }
+          StillActive.config { |config| config.fail_if_language_ceiling = true }
         end
       end
     end

--- a/lib/still_active/pypi_client.rb
+++ b/lib/still_active/pypi_client.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative "../helpers/http_helper"
+require_relative "version"
+
+module StillActive
+  # The authoritative source for a PyPI release's declared Python constraint,
+  # used by the cross-ecosystem language-runtime ceiling. `requires_python` is
+  # set once per release and enforced by pip as a hard install wall (a real
+  # resolver refuses an incompatible interpreter), so still_active reads it from
+  # PyPI's release-level `info.requires_python` rather than a per-file wheel value
+  # or deps.dev (which does not carry the field). pypi.org is a public source,
+  # queried with no credentials.
+  #
+  # Best-effort like every other network entry point: an unindexed version,
+  # schema drift, or a transport failure degrades to nil (no ceiling), never a
+  # raise that could abort the per-package audit.
+  module PypiClient
+    extend self
+
+    BASE_URI = URI("https://pypi.org/")
+    # Polite identification, matching EcosystemsClient's convention.
+    USER_AGENT = "still_active/#{StillActive::VERSION} (+https://github.com/SeanLF/still_active)"
+
+    # The PEP 440 `requires_python` specifier a release declares (e.g.
+    # ">=3.8,<3.13"), or nil when the version is unreadable or declares none.
+    # PyPI renders an unset constraint as an empty string; normalize it to nil so
+    # callers get a single "no constraint" signal.
+    def requires_python(name:, version:)
+      return if name.nil? || version.nil?
+
+      path = "/pypi/#{encode(name)}/#{encode(version)}/json"
+      body = HttpHelper.get_json(BASE_URI, path, headers: { "User-Agent" => USER_AGENT })
+      return unless body.is_a?(Hash)
+
+      # Guard the nested read: a non-Hash `info` (schema drift) would make
+      # Hash#dig raise TypeError, which -- since this is the LAST enrichment in
+      # EcosystemLens#assess -- would propagate to the per-package rescue and
+      # discard the package's already-computed vuln/poison/staleness findings.
+      # Best-effort must never demote the core audit; degrade to nil.
+      info = body["info"]
+      return unless info.is_a?(Hash)
+
+      value = info["requires_python"]
+      return unless value.is_a?(String) && !value.strip.empty?
+
+      value
+    end
+
+    private
+
+    def encode(segment)
+      URI.encode_www_form_component(segment)
+    end
+  end
+end

--- a/lib/still_active/sarif/rules.rb
+++ b/lib/still_active/sarif/rules.rb
@@ -117,10 +117,10 @@ module StillActive
         },
         {
           id: "SA009",
-          name: "RubyRuntimeCeiling",
-          short: "Resolved gem version caps the Ruby runtime",
-          full: "A resolved gem version's declared `ruby_version` caps the Ruby you can run: either below every still-supported release (stranding you on an end-of-life Ruby with no security patches) or below the latest stable (a compatibility ceiling to plan around). The default level is note; an EOL-forcing cap is raised to error per result.",
-          help_text: "If a newer release of the gem lifts the cap, upgrade it. Otherwise replace or fork the gem, or contribute Ruby-N support upstream.",
+          name: "RuntimeCeiling",
+          short: "Resolved package version caps its language runtime",
+          full: "A resolved package version's declared runtime constraint (Ruby `ruby_version`, Python `requires_python`) caps the language runtime you can run: either below every still-supported release (stranding you on an end-of-life runtime with no security patches) or below the latest stable (a compatibility ceiling to plan around). The default level is note; an EOL-forcing cap is raised to error per result.",
+          help_text: "If a newer release of the package lifts the cap, upgrade it. Otherwise replace or fork the package, or contribute support for the newer runtime upstream.",
           level: "note",
           security_severity: nil, # maintenance/compatibility, not a CVE (as SA002/SA004/SA005/SA008)
           tags: ["maintenance", "runtime", "external/cwe/cwe-1104"],

--- a/lib/still_active/sbom_workflow.rb
+++ b/lib/still_active/sbom_workflow.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require_relative "ecosystem_lens"
+require_relative "ceiling_reconciler"
+require_relative "../helpers/python_helper"
 require "async"
 require "async/barrier"
 require "async/semaphore"
@@ -29,6 +31,16 @@ module StillActive
     def call(sbom_result, &on_progress)
       dependencies = sbom_result.dependencies
       Async do
+        # The Python runtime support window, fetched once for the whole SBOM (the
+        # language-ceiling input for pypi deps). Guarded like the native Ruby path:
+        # a feed failure degrades to "no ceiling checks", never aborts the audit.
+        python_range =
+          begin
+            PythonHelper.supported_python_range
+          rescue StandardError => e
+            $stderr.puts("warning: Python support window lookup failed: #{e.class} (#{e.message}); skipping language-ceiling checks")
+            nil
+          end
         barrier = Async::Barrier.new
         semaphore = Async::Semaphore.new(StillActive.config.parallelism, parent: barrier)
         result = {}
@@ -44,7 +56,7 @@ module StillActive
         dependencies.each do |dep|
           semaphore.async do
             result["#{dep[:ecosystem]}/#{dep[:name]}@#{dep[:version]}"] =
-              EcosystemLens.assess(ecosystem: dep[:ecosystem], name: dep[:name], version: dep[:version], constraint_cache: constraint_cache)
+              EcosystemLens.assess(ecosystem: dep[:ecosystem], name: dep[:name], version: dep[:version], constraint_cache: constraint_cache, python_range: python_range)
           rescue StandardError => e
             # One dependency's failure must not abort the audit, but it must not
             # disappear either: record it as an unassessable entry (same shape as
@@ -57,6 +69,10 @@ module StillActive
           end
         end
         barrier.wait
+        # Whole-tree correlation once every package's signals are in: a Python
+        # ceiling's "upgrade to lift it" must not contradict a poison finding that
+        # caps the same package below that upgrade (same guarantee as the native path).
+        CeilingReconciler.reconcile_ceiling_with_poison(result)
         # Stable, diffable order regardless of async completion order.
         Outcome.new(
           assessed: result.sort_by { |key, _| key }.to_h,

--- a/lib/still_active/suppressions.rb
+++ b/lib/still_active/suppressions.rb
@@ -16,7 +16,7 @@ module StillActive
   # name an explicit advisory id, so a newly disclosed CVE on the same gem is
   # never pre-silenced.
   class Suppressions
-    GATEABLE_SIGNALS = [:activity, :vulnerability, :libyear, :poison, :ruby_ceiling].freeze
+    GATEABLE_SIGNALS = [:activity, :vulnerability, :libyear, :poison, :language_ceiling].freeze
 
     Entry = Struct.new(:gem, :advisory, :signal, :reason, :expires, keyword_init: true) do
       def whole_gem?

--- a/lib/still_active/workflow.rb
+++ b/lib/still_active/workflow.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "artifactory_client"
+require_relative "ceiling_reconciler"
 require_relative "deps_dev_client"
 require_relative "ecosystems_client"
 require_relative "forgejo_client"
@@ -93,7 +94,7 @@ module StillActive
         # Whole-tree correlation, once every gem's signals are in: a ceiling's
         # "upgrade to lift it" must not contradict a poison finding that caps the
         # same gem below that upgrade.
-        reconcile_ceiling_with_poison(result_object)
+        CeilingReconciler.reconcile_ceiling_with_poison(result_object)
         # Gems are inserted as their async tasks finish, so the natural order is
         # nondeterministic completion order. Sort by name once here so every
         # consumer (JSON, SARIF, the baseline diff) gets a stable, diffable order.
@@ -107,26 +108,6 @@ module StillActive
     end
 
     private
-
-    # A ceiling that says "upgrade <gem> to lift it" is wrong if the same tree
-    # poisons <gem> below that upgrade (a dormant dep caps it). Correlate the two
-    # signals so the report never advises an upgrade its own poison finding says is
-    # impossible: clear fixed_by_upgrade and mark the block. All data is already in
-    # the assembled result, so this is one whole-tree pass, no extra fetches.
-    def reconcile_ceiling_with_poison(result_object)
-      capped = result_object.each_value
-        .flat_map { |data| Array(data[:constraints]) }
-        .select { |constraint| constraint[:majors_behind].to_i.positive? }
-        .map { |constraint| constraint[:dependency] }
-        .uniq
-      result_object.each do |name, data|
-        ceiling = data[:ruby_ceiling]
-        next unless ceiling && ceiling[:fixed_by_upgrade] && capped.include?(name)
-
-        ceiling[:fixed_by_upgrade] = false
-        ceiling[:upgrade_blocked] = true
-      end
-    end
 
     def gem_info(gem_name:, result_object:, gem_version: nil, source_type: :rubygems, source_uri: nil, direct: true, dependency_path: nil, advisory_db: nil, catalog: nil, constraint_cache: {}, ruby_range: nil)
       result_object[gem_name] = { source_type: source_type, direct: direct }
@@ -264,7 +245,11 @@ module StillActive
       return if finding.nil?
 
       finding[:fixed_by_upgrade] = ruby_ceiling_lifted_by_upgrade?(used_req: used_ruby_requirement, latest_req: latest_ruby_requirement, ruby_range: ruby_range)
-      gem_data[:ruby_ceiling] = finding
+      # The runtime this cap is against, so the shared renderers (terminal, md,
+      # SARIF) name it without hardcoding "Ruby". The Python SBOM path attaches the
+      # same shape with runtime "Python"; everything downstream is runtime-neutral.
+      finding[:runtime] = "Ruby"
+      gem_data[:language_ceiling] = finding
     end
 
     # Does bumping the gem to its latest lift the ceiling? True only when the cap

--- a/spec/still_active/ceiling_reconciler_spec.rb
+++ b/spec/still_active/ceiling_reconciler_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/still_active/ceiling_reconciler"
+
+RSpec.describe(StillActive::CeilingReconciler) do
+  describe ".reconcile_ceiling_with_poison" do
+    it "drops a ceiling's fixed_by_upgrade when the same tree poisons that package below the fix" do
+      result = {
+        "foo" => { language_ceiling: { requirement: "< 3.3", eol_forced: true, severity: :critical, fixed_by_upgrade: true } },
+        "bar" => { constraints: [{ dependency: "foo", requirement: "< 2.0", dep_latest: "2.0.0", majors_behind: 1, kind: :ceiling }] },
+      }
+      described_class.reconcile_ceiling_with_poison(result)
+      expect(result["foo"][:language_ceiling][:fixed_by_upgrade]).to(be(false))
+      expect(result["foo"][:language_ceiling][:upgrade_blocked]).to(be(true))
+    end
+
+    it "leaves fixed_by_upgrade true when nothing caps that package" do
+      result = { "foo" => { language_ceiling: { fixed_by_upgrade: true } } }
+      described_class.reconcile_ceiling_with_poison(result)
+      expect(result["foo"][:language_ceiling][:fixed_by_upgrade]).to(be(true))
+      expect(result["foo"][:language_ceiling]).not_to(have_key(:upgrade_blocked))
+    end
+
+    it "matches on the package :name for SBOM-keyed results (key is ecosystem/name@version)" do
+      # SBOM results are keyed by "pypi/foo@1.2.0" but poison names the bare dep,
+      # so the correlation must use data[:name], not the compound key.
+      result = {
+        "pypi/foo@1.2.0" => { ecosystem: :pypi, name: "foo", language_ceiling: { requirement: "<3.10", eol_forced: true, fixed_by_upgrade: true } },
+        "pypi/bar@0.1.0" => { ecosystem: :pypi, name: "bar", constraints: [{ dependency: "foo", requirement: "<1.0", dep_latest: "2.0.0", majors_behind: 2, kind: :ceiling }] },
+      }
+      described_class.reconcile_ceiling_with_poison(result)
+      expect(result["pypi/foo@1.2.0"][:language_ceiling][:fixed_by_upgrade]).to(be(false))
+      expect(result["pypi/foo@1.2.0"][:language_ceiling][:upgrade_blocked]).to(be(true))
+    end
+
+    it "does not let a poison-cap in ONE ecosystem block a same-named package's ceiling in ANOTHER" do
+      # Both rubygems and pypi are flat-resolution, so a mixed SBOM can hold a
+      # rubygems "foo" (poison-capped) and a pypi "foo" (with a ceiling). The
+      # rubygems cap must not flip the pypi package's fixed_by_upgrade.
+      result = {
+        "pypi/foo@1.2.0" => { ecosystem: :pypi, name: "foo", language_ceiling: { fixed_by_upgrade: true } },
+        "rubygems/foo@0.1.0" => { ecosystem: :rubygems, name: "foo", constraints: [{ dependency: "foo", requirement: "<1.0", dep_latest: "2.0.0", majors_behind: 2, kind: :ceiling }] },
+      }
+      described_class.reconcile_ceiling_with_poison(result)
+      expect(result["pypi/foo@1.2.0"][:language_ceiling][:fixed_by_upgrade]).to(be(true))
+      expect(result["pypi/foo@1.2.0"][:language_ceiling]).not_to(have_key(:upgrade_blocked))
+    end
+  end
+end

--- a/spec/still_active/cli_spec.rb
+++ b/spec/still_active/cli_spec.rb
@@ -275,7 +275,8 @@ RSpec.describe(StillActive::CLI) do
           direct: true,
           version_used: "3.0.9",
           latest_version: "4.0.0",
-          ruby_ceiling: {
+          language_ceiling: {
+            runtime: "Ruby",
             requirement: "< 3.2",
             eol_forced: true,
             severity: :critical,
@@ -790,10 +791,10 @@ RSpec.describe(StillActive::CLI) do
     end
   end
 
-  describe("--fail-if-ruby-ceiling") do
+  describe("--fail-if-language-ceiling") do
     def ceiling_gem(severity = :critical)
       gem_data(last_commit_date: recent_date).merge(
-        ruby_ceiling: { requirement: "< 3.2", eol_forced: severity == :critical, severity: severity },
+        language_ceiling: { requirement: "< 3.2", eol_forced: severity == :critical, severity: severity },
       )
     end
 
@@ -801,18 +802,18 @@ RSpec.describe(StillActive::CLI) do
     # (latest-not-yet) -- there is no :warning tier -- so the bare gate defaults to
     # :critical (the real blocker), not the :warning poison uses.
     it("exits 1 when an EOL-forcing (critical) ceiling meets the default (critical) threshold") do
-      StillActive.config.fail_if_ruby_ceiling = true
+      StillActive.config.fail_if_language_ceiling = true
       expect { cli.send(:check_exit_status, { "cfpropertylist" => ceiling_gem(:critical) }) }
         .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(1)) })
     end
 
     it("does NOT exit on a note-level ceiling under the default (critical) threshold") do
-      StillActive.config.fail_if_ruby_ceiling = true
+      StillActive.config.fail_if_language_ceiling = true
       expect { cli.send(:check_exit_status, { "somegem" => ceiling_gem(:note) }) }.not_to(raise_error)
     end
 
     it("exits on a note-level ceiling when the threshold is lowered to note") do
-      StillActive.config.fail_if_ruby_ceiling = :note
+      StillActive.config.fail_if_language_ceiling = :note
       expect { cli.send(:check_exit_status, { "somegem" => ceiling_gem(:note) }) }
         .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(1)) })
     end
@@ -821,10 +822,10 @@ RSpec.describe(StillActive::CLI) do
       expect { cli.send(:check_exit_status, { "cfpropertylist" => ceiling_gem }) }.not_to(raise_error)
     end
 
-    it("does not exit when the gem's ruby_ceiling signal is suppressed in .still_active.yml") do
-      StillActive.config.fail_if_ruby_ceiling = true
+    it("does not exit when the gem's language_ceiling signal is suppressed in .still_active.yml") do
+      StillActive.config.fail_if_language_ceiling = true
       StillActive.config.suppressions = StillActive::Suppressions.from(
-        [{ "gem" => "cfpropertylist", "signal" => "ruby_ceiling", "reason" => "pinned on purpose" }],
+        [{ "gem" => "cfpropertylist", "signal" => "language_ceiling", "reason" => "pinned on purpose" }],
       )
       expect { cli.send(:check_exit_status, { "cfpropertylist" => ceiling_gem }) }.not_to(raise_error)
     end

--- a/spec/still_active/config_file_spec.rb
+++ b/spec/still_active/config_file_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe(StillActive::ConfigFile) do
         "fail_if_critical" => true,
         "fail_if_warning" => true,
         "fail_if_poison" => true,
-        "fail_if_ruby_ceiling" => "note",
+        "fail_if_language_ceiling" => "note",
         "fail_if_vulnerable" => "high",
         "fail_if_outdated" => 2.5,
         "alternatives" => true,
@@ -61,7 +61,7 @@ RSpec.describe(StillActive::ConfigFile) do
       expect(config.fail_if_critical).to(be(true))
       expect(config.fail_if_warning).to(be(true))
       expect(config.fail_if_poison).to(be(true))
-      expect(config.fail_if_ruby_ceiling).to(eq(:note))
+      expect(config.fail_if_language_ceiling).to(eq(:note))
       expect(config.fail_if_vulnerable).to(eq("high"))
       expect(config.fail_if_outdated).to(eq(2.5))
       expect(config.alternatives).to(be(true))

--- a/spec/still_active/ecosystem_lens_spec.rb
+++ b/spec/still_active/ecosystem_lens_spec.rb
@@ -293,4 +293,102 @@ RSpec.describe(StillActive::EcosystemLens) do
       expect(StillActive::EcosystemsClient).not_to(have_received(:declared_dependencies))
     end
   end
+
+  describe(".assess language ceiling (Python)") do
+    # Python support window fixture: 3.14/3.10 supported, 3.9/3.8 EOL, latest
+    # stable 3.14.6 (not fresh). Mirrors the live endoflife.date shape.
+    let(:python_range) do
+      {
+        oldest_supported: Gem::Version.new("3.10"),
+        latest_stable: Gem::Version.new("3.14.6"),
+        latest_stable_fresh: false,
+        cycles: [
+          { version: Gem::Version.new("3.14"), eol: false, eol_date: Time.parse("2030-10-31") },
+          { version: Gem::Version.new("3.10"), eol: false, eol_date: Time.parse("2026-10-31") },
+          { version: Gem::Version.new("3.9"), eol: true, eol_date: Time.parse("2025-10-31") },
+          { version: Gem::Version.new("3.8"), eol: true, eol_date: Time.parse("2024-10-14") },
+        ],
+      }
+    end
+
+    before do
+      # deps.dev default version 9.9.9 is the "latest" for the fixed_by_upgrade probe.
+      stub_version(source_repo: "https://github.com/numba/numba")
+      stub_package(default_published_at: "2026-06-01T00:00:00Z")
+      stub_project_scorecard
+      stub_ecosystems_repo(archived: false)
+    end
+
+    it("flags an EOL-forcing requires_python cap as a critical Python ceiling, noting the gem upgrade lifts it") do
+      allow(StillActive::PypiClient).to(receive(:requires_python).with(name: "numba", version: "0.53.1").and_return(">=3.6,<3.10"))
+      allow(StillActive::PypiClient).to(receive(:requires_python).with(name: "numba", version: "9.9.9").and_return(">=3.10"))
+
+      result = described_class.assess(ecosystem: :pypi, name: "numba", version: "0.53.1", python_range: python_range)
+
+      ceiling = result[:language_ceiling]
+      expect(ceiling[:runtime]).to(eq("Python"))
+      expect(ceiling[:eol_forced]).to(be(true))
+      expect(ceiling[:severity]).to(eq(:critical))
+      expect(ceiling[:ceiling_version]).to(eq("3.9"))
+      expect(ceiling[:fixed_by_upgrade]).to(be(true))
+    end
+
+    it("does not claim fixed_by_upgrade when the latest version's requires_python can't be read (no over-claim on a failed fetch)") do
+      # PypiClient returns nil for BOTH "declares nothing" and "fetch failed"; the
+      # ceiling must not advise an upgrade it couldn't positively verify.
+      allow(StillActive::PypiClient).to(receive(:requires_python).with(name: "numba", version: "0.53.1").and_return(">=3.6,<3.10"))
+      allow(StillActive::PypiClient).to(receive(:requires_python).with(name: "numba", version: "9.9.9").and_return(nil))
+
+      result = described_class.assess(ecosystem: :pypi, name: "numba", version: "0.53.1", python_range: python_range)
+
+      ceiling = result[:language_ceiling]
+      expect(ceiling[:eol_forced]).to(be(true))
+      expect(ceiling[:fixed_by_upgrade]).to(be(false))
+    end
+
+    it("flags a cap below the latest stable (but on a supported Python) as a note") do
+      allow(StillActive::PypiClient).to(receive(:requires_python).and_return(">=3.8,<3.13"))
+
+      result = described_class.assess(ecosystem: :pypi, name: "scipy", version: "1.7.3", python_range: python_range)
+
+      ceiling = result[:language_ceiling]
+      expect(ceiling[:runtime]).to(eq("Python"))
+      expect(ceiling[:eol_forced]).to(be(false))
+      expect(ceiling[:severity]).to(eq(:note))
+    end
+
+    it("does not flag a pure floor requires_python (a floor is not a ceiling)") do
+      allow(StillActive::PypiClient).to(receive(:requires_python).and_return(">=3.8"))
+
+      result = described_class.assess(ecosystem: :pypi, name: "numpy", version: "1.21.0", python_range: python_range)
+
+      expect(result).not_to(have_key(:language_ceiling))
+    end
+
+    it("does not flag when the package declares no requires_python") do
+      allow(StillActive::PypiClient).to(receive(:requires_python).and_return(nil))
+
+      result = described_class.assess(ecosystem: :pypi, name: "loose", version: "1.0.0", python_range: python_range)
+
+      expect(result).not_to(have_key(:language_ceiling))
+    end
+
+    it("does not read requires_python for a non-Python ecosystem, even with a window") do
+      allow(StillActive::PypiClient).to(receive(:requires_python))
+
+      result = described_class.assess(ecosystem: :npm, name: "express", version: "5.2.1", python_range: python_range)
+
+      expect(result).not_to(have_key(:language_ceiling))
+      expect(StillActive::PypiClient).not_to(have_received(:requires_python))
+    end
+
+    it("does nothing when the Python support window is unavailable (nil range)") do
+      allow(StillActive::PypiClient).to(receive(:requires_python))
+
+      result = described_class.assess(ecosystem: :pypi, name: "numba", version: "0.53.1", python_range: nil)
+
+      expect(result).not_to(have_key(:language_ceiling))
+      expect(StillActive::PypiClient).not_to(have_received(:requires_python))
+    end
+  end
 end

--- a/spec/still_active/endoflife_helper_spec.rb
+++ b/spec/still_active/endoflife_helper_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/helpers/endoflife_helper"
+
+RSpec.describe(StillActive::EndoflifeHelper) do
+  # The ecosystem-neutral support-window builder over an endoflife.date feed.
+  # RubyHelper and PythonHelper both delegate here; the only difference between
+  # them is the feed path. Fixtures mirror the ruby.json / python.json shape.
+  let(:cycles) do
+    [
+      { "cycle" => "3.13", "latest" => "3.13.2", "releaseDate" => "2024-10-07", "eol" => "2029-10-31" },
+      { "cycle" => "3.12", "latest" => "3.12.9", "releaseDate" => "2023-10-02", "eol" => "2028-10-31" },
+      { "cycle" => "3.9", "latest" => "3.9.21", "releaseDate" => "2020-10-05", "eol" => "2025-10-31" },
+      { "cycle" => "3.8", "latest" => "3.8.20", "releaseDate" => "2019-10-14", "eol" => "2024-10-14" },
+    ]
+  end
+
+  before do
+    allow(StillActive::HttpHelper).to(receive(:get_json).and_return(cycles))
+  end
+
+  def window
+    described_class.support_window(feed_path: "/api/python.json")
+  end
+
+  it "fetches the given feed path" do
+    window
+    expect(StillActive::HttpHelper).to(have_received(:get_json).with(anything, "/api/python.json"))
+  end
+
+  it "reports the oldest still-supported cycle and the latest stable release" do
+    # 3.13/3.12 future EOL, 3.9/3.8 past -> supported floor 3.12, newest 3.13.2.
+    expect(window[:oldest_supported]).to(eq(Gem::Version.new("3.12")))
+    expect(window[:latest_stable]).to(eq(Gem::Version.new("3.13.2")))
+  end
+
+  it "exposes normalized cycles (version, eol flag, eol date)" do
+    eol_38 = window[:cycles].find { |c| c[:version] == Gem::Version.new("3.8") }
+    expect(eol_38[:eol]).to(be(true))
+    expect(eol_38[:eol_date]).to(eq(Time.parse("2024-10-14")))
+    live = window[:cycles].find { |c| c[:version] == Gem::Version.new("3.13") }
+    expect(live[:eol]).to(be(false))
+  end
+
+  it "returns nil when the endoflife feed is unavailable" do
+    allow(StillActive::HttpHelper).to(receive(:get_json).and_return(nil))
+    expect(window).to(be_nil)
+  end
+
+  it "returns nil when the feed is empty" do
+    allow(StillActive::HttpHelper).to(receive(:get_json).and_return([]))
+    expect(window).to(be_nil)
+  end
+
+  it "returns nil when every known cycle is already EOL" do
+    past = cycles.map { |c| c.merge("eol" => "2000-01-01") }
+    allow(StillActive::HttpHelper).to(receive(:get_json).and_return(past))
+    expect(window).to(be_nil)
+  end
+
+  it "skips a cycle whose version is malformed rather than crashing" do
+    garbled_cycle = cycles + [{ "cycle" => "not-a-version", "latest" => "9.9", "eol" => "2029-01-01" }]
+    allow(StillActive::HttpHelper).to(receive(:get_json).and_return(garbled_cycle))
+    expect { window }.not_to(raise_error)
+    expect(window[:cycles].map { |c| c[:version] }).not_to(include(nil))
+  end
+
+  it "marks the latest stable fresh inside the grace window" do
+    recent = cycles.map.with_index { |c, i| i.zero? ? c.merge("releaseDate" => (Time.now - (10 * 86_400)).strftime("%Y-%m-%d")) : c }
+    allow(StillActive::HttpHelper).to(receive(:get_json).and_return(recent))
+    expect(window[:latest_stable_fresh]).to(be(true))
+  end
+
+  it "marks the latest stable not-fresh past the grace window" do
+    old = cycles.map.with_index { |c, i| i.zero? ? c.merge("releaseDate" => (Time.now - (400 * 86_400)).strftime("%Y-%m-%d")) : c }
+    allow(StillActive::HttpHelper).to(receive(:get_json).and_return(old))
+    expect(window[:latest_stable_fresh]).to(be(false))
+  end
+
+  it "degrades freshness to false (never raises, never nulls the window) on a malformed releaseDate" do
+    bad = cycles.map.with_index { |c, i| i.zero? ? c.merge("releaseDate" => "2023-13-99") : c }
+    allow(StillActive::HttpHelper).to(receive(:get_json).and_return(bad))
+    range = nil
+    expect { range = window }.not_to(raise_error)
+    expect(range).not_to(be_nil)
+    expect(range[:latest_stable_fresh]).to(be(false))
+  end
+
+  it "keeps the window with nil latest_stable when the newest cycle's `latest` is malformed (criticals depend only on the eol flags, so they must still fire)" do
+    garbled = [cycles.first.merge("latest" => "unknown-preview"), *cycles[1..]]
+    allow(StillActive::HttpHelper).to(receive(:get_json).and_return(garbled))
+    expect { window }.not_to(raise_error)
+    expect(window).not_to(be_nil)
+    expect(window[:latest_stable]).to(be_nil)
+    expect(window[:latest_stable_fresh]).to(be(false))
+    expect(window[:oldest_supported]).to(eq(Gem::Version.new("3.12")))
+  end
+
+  it "degrades a single cycle's malformed eol to non-EOL rather than raising and nulling the whole window" do
+    # A garbled eol on one cycle must cost at most that cycle, never disable the
+    # signal tree-wide (which would hide EOL-forced criticals).
+    bad = cycles.map { |c| c["cycle"] == "3.9" ? c.merge("eol" => "2024-13-99") : c }
+    allow(StillActive::HttpHelper).to(receive(:get_json).and_return(bad))
+    expect { window }.not_to(raise_error)
+    expect(window).not_to(be_nil)
+    cycle_39 = window[:cycles].find { |c| c[:version] == Gem::Version.new("3.9") }
+    expect(cycle_39[:eol]).to(be(false))
+  end
+
+  describe ".parse_date" do
+    it "returns nil for a malformed date rather than raising" do
+      expect { described_class.parse_date("2024-13-99") }.not_to(raise_error)
+      expect(described_class.parse_date("2024-13-99")).to(be_nil)
+      expect(described_class.parse_date(nil)).to(be_nil)
+    end
+  end
+
+  describe ".eol_reached?" do
+    it "returns nil for a malformed eol string rather than raising" do
+      expect(described_class.eol_reached?("nonsense")).to(be_nil)
+    end
+
+    it "returns true/false for valid past/future eol dates and passes booleans through" do
+      expect(described_class.eol_reached?("2000-01-01")).to(be(true))
+      expect(described_class.eol_reached?("2999-01-01")).to(be(false))
+      expect(described_class.eol_reached?(true)).to(be(true))
+      expect(described_class.eol_reached?(false)).to(be(false))
+    end
+  end
+end

--- a/spec/still_active/markdown_helper_spec.rb
+++ b/spec/still_active/markdown_helper_spec.rb
@@ -417,9 +417,9 @@ RSpec.describe(StillActive::MarkdownHelper) do
     end
   end
 
-  describe(".ruby_ceiling_section") do
+  describe(".language_ceiling_section") do
     def ceiling_gem(ceiling, extra = {})
-      { source_type: :rubygems, latest_version: "4.0.0", ruby_ceiling: ceiling }.merge(extra)
+      { source_type: :rubygems, latest_version: "4.0.0", language_ceiling: { runtime: "Ruby" }.merge(ceiling) }.merge(extra)
     end
 
     it("lists an EOL-forcing ceiling with the stranded Ruby, its EOL date, and the upgrade fix") do
@@ -435,8 +435,8 @@ RSpec.describe(StillActive::MarkdownHelper) do
           fixed_by_upgrade: true,
         }),
       }
-      out = described_class.ruby_ceiling_section(result)
-      expect(out).to(include("**Ruby ceiling findings**"))
+      out = described_class.language_ceiling_section(result)
+      expect(out).to(include("**Runtime ceiling findings**"))
       expect(out).to(include("**critical** `cfpropertylist` requires Ruby `< 3.2`, stranding you on end-of-life Ruby 3.1 (EOL 2025-03-31); upgrade to 4.0.0 to lift it"))
     end
 
@@ -454,7 +454,7 @@ RSpec.describe(StillActive::MarkdownHelper) do
           { latest_version: "1.0.0" },
         ),
       }
-      out = described_class.ruby_ceiling_section(result)
+      out = described_class.language_ceiling_section(result)
       expect(out).to(include("**note** `somegem` requires Ruby `~> 3.3`, no Ruby 4.0.5 support yet"))
       expect(out).not_to(include("upgrade to"))
     end
@@ -464,12 +464,12 @@ RSpec.describe(StillActive::MarkdownHelper) do
         "minor" => ceiling_gem({ requirement: "~> 3.3", eol_forced: false, severity: :note, oldest_supported: "3.3", latest_stable: "4.0.5", fixed_by_upgrade: false }, { latest_version: "1.0.0" }),
         "blocker" => ceiling_gem({ requirement: "< 3.2", eol_forced: true, severity: :critical, ceiling_version: "3.1", ceiling_eol_date: nil, oldest_supported: "3.3", latest_stable: "4.0.5", fixed_by_upgrade: false }),
       }
-      out = described_class.ruby_ceiling_section(result)
+      out = described_class.language_ceiling_section(result)
       expect(out.index("blocker")).to(be < out.index("minor"))
     end
 
     it("returns empty string when no gem has a ceiling") do
-      expect(described_class.ruby_ceiling_section({ "rails" => { source_type: :rubygems } })).to(eq(""))
+      expect(described_class.language_ceiling_section({ "rails" => { source_type: :rubygems } })).to(eq(""))
     end
   end
 

--- a/spec/still_active/options_spec.rb
+++ b/spec/still_active/options_spec.rb
@@ -136,25 +136,25 @@ RSpec.describe(StillActive::Options) do
       expect(StillActive.config.fail_if_outdated).to(eq(3.0))
     end
 
-    it("sets fail-if-ruby-ceiling to true when bare") do
-      described_class.new.parse!(["--fail-if-ruby-ceiling", "--gems=rails"])
-      expect(StillActive.config.fail_if_ruby_ceiling).to(be(true))
+    it("sets fail-if-language-ceiling to true when bare") do
+      described_class.new.parse!(["--fail-if-language-ceiling", "--gems=rails"])
+      expect(StillActive.config.fail_if_language_ceiling).to(be(true))
     end
 
-    it("sets fail-if-ruby-ceiling to a tier symbol when given one") do
-      described_class.new.parse!(["--fail-if-ruby-ceiling=note", "--gems=rails"])
-      expect(StillActive.config.fail_if_ruby_ceiling).to(eq(:note))
+    it("sets fail-if-language-ceiling to a tier symbol when given one") do
+      described_class.new.parse!(["--fail-if-language-ceiling=note", "--gems=rails"])
+      expect(StillActive.config.fail_if_language_ceiling).to(eq(:note))
     end
 
-    it("raises when the fail-if-ruby-ceiling tier is invalid") do
-      expect { described_class.new.parse!(["--fail-if-ruby-ceiling=banana", "--gems=rails"]) }
+    it("raises when the fail-if-language-ceiling tier is invalid") do
+      expect { described_class.new.parse!(["--fail-if-language-ceiling=banana", "--gems=rails"]) }
         .to(raise_error(ArgumentError, /tier must be one of/))
     end
 
-    it("warns that fail-if-ruby-ceiling=warning is a no-op tier but still accepts it") do
-      expect { described_class.new.parse!(["--fail-if-ruby-ceiling=warning", "--gems=rails"]) }
+    it("warns that fail-if-language-ceiling=warning is a no-op tier but still accepts it") do
+      expect { described_class.new.parse!(["--fail-if-language-ceiling=warning", "--gems=rails"]) }
         .to(output(/no effect.*behaves as =critical/).to_stderr)
-      expect(StillActive.config.fail_if_ruby_ceiling).to(eq(:warning))
+      expect(StillActive.config.fail_if_language_ceiling).to(eq(:warning))
     end
 
     it("sets ignored gems from comma-separated list") do

--- a/spec/still_active/pep440_helper_spec.rb
+++ b/spec/still_active/pep440_helper_spec.rb
@@ -130,5 +130,12 @@ RSpec.describe(StillActive::Pep440Helper) do
     it "bounds pathologically long input" do
       expect(translate.call(">=#{"9" * 500}")).to(be_nil)
     end
+
+    it "handles a space-heavy operator/version split in linear time (no polynomial backtracking)" do
+      # Exercises the previously-ambiguous `\s*(.+)` split (CodeQL ReDoS); the
+      # `\s*(\S+)` form matches or fails linearly on runs of spaces.
+      expect(translate.call("< #{" " * 200}x")).to(be_nil) # x is not a version -> dropped
+      expect(admits?(">=#{" " * 50}3.7", "3.8")).to(be(true)) # spaces before the version are fine
+    end
   end
 end

--- a/spec/still_active/pep440_helper_spec.rb
+++ b/spec/still_active/pep440_helper_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/helpers/pep440_helper"
+
+RSpec.describe(StillActive::Pep440Helper) do
+  # The shim translates a PEP 440 `requires_python` specifier into a RubyGems
+  # requirement STRING that Gem::Requirement can parse, so the generic
+  # RuntimeCeilingHelper can reason about Python ceilings with no code change.
+  # We assert SEMANTICS (which Python versions the translation admits/rejects),
+  # not the exact string, since several PEP 440 operators have no literal
+  # RubyGems spelling.
+  subject(:translate) { ->(spec) { described_class.to_gem_requirement_string(spec) } }
+
+  # Build a Gem::Requirement from the translated string the way the core does
+  # (split on comma, splat) and ask whether it admits a Python version.
+  def admits?(spec, python_version)
+    string = translate.call(spec)
+    return :untranslatable if string.nil?
+
+    clauses = string.split(",").map(&:strip)
+    Gem::Requirement.new(*clauses).satisfied_by?(Gem::Version.new(python_version))
+  end
+
+  describe "simple comparison operators pass through" do
+    it "keeps a lower-bound floor" do
+      expect(admits?(">=3.7", "3.7")).to(be(true))
+      expect(admits?(">=3.7", "3.13")).to(be(true))
+      expect(admits?(">=3.7", "3.6")).to(be(false))
+    end
+
+    it "keeps an upper-bound cap" do
+      expect(admits?("<3.11", "3.10")).to(be(true))
+      expect(admits?("<3.11", "3.11")).to(be(false))
+    end
+
+    it "tolerates whitespace around the operator" do
+      expect(admits?(">= 3.7", "3.8")).to(be(true))
+      expect(admits?(">= 3.7", "3.6")).to(be(false))
+    end
+
+    it "preserves both bounds of a comma-joined floor+cap" do
+      expect(admits?(">=3.7, <3.11", "3.10")).to(be(true))
+      expect(admits?(">=3.7, <3.11", "3.11")).to(be(false))
+      expect(admits?(">=3.7, <3.11", "3.6")).to(be(false))
+    end
+  end
+
+  describe "compatible-release operator ~= (PEP 440 semantics differ from string)" do
+    # ~=3.7 means >=3.7, ==3.* i.e. >=3.7, <4
+    it "translates ~=X.Y to >=X.Y, <(X+1)" do
+      expect(admits?("~=3.7", "3.7")).to(be(true))
+      expect(admits?("~=3.7", "3.13")).to(be(true))
+      expect(admits?("~=3.7", "3.6")).to(be(false))
+      expect(admits?("~=3.7", "4.0")).to(be(false))
+    end
+
+    # ~=3.7.2 means >=3.7.2, ==3.7.* i.e. >=3.7.2, <3.8
+    it "translates ~=X.Y.Z to >=X.Y.Z, <X.(Y+1)" do
+      expect(admits?("~=3.7.2", "3.7.4")).to(be(true))
+      expect(admits?("~=3.7.2", "3.7.1")).to(be(false))
+      expect(admits?("~=3.7.2", "3.8")).to(be(false))
+    end
+  end
+
+  describe "prefix-match wildcards (silently missed today: Gem::Requirement raises on them)" do
+    # ==3.* means >=3, <4
+    it "translates ==X.* to a major-series match" do
+      expect(admits?("==3.*", "3.0")).to(be(true))
+      expect(admits?("==3.*", "3.13")).to(be(true))
+      expect(admits?("==3.*", "2.7")).to(be(false))
+      expect(admits?("==3.*", "4.0")).to(be(false))
+    end
+
+    # ==3.7.* means >=3.7, <3.8
+    it "translates ==X.Y.* to a minor-series match" do
+      expect(admits?("==3.7.*", "3.7.4")).to(be(true))
+      expect(admits?("==3.7.*", "3.8")).to(be(false))
+      expect(admits?("==3.7.*", "3.6")).to(be(false))
+    end
+  end
+
+  describe "exact and arbitrary equality" do
+    it "translates ==X to an exact pin" do
+      expect(admits?("==3.9", "3.9")).to(be(true))
+      expect(admits?("==3.9", "3.10")).to(be(false))
+    end
+
+    it "translates arbitrary equality ===X like an exact pin" do
+      expect(admits?("===3.9", "3.9")).to(be(true))
+      expect(admits?("===3.9", "3.10")).to(be(false))
+    end
+  end
+
+  describe "!= is dropped (a hole-punch never creates a ceiling; dropping is conservative)" do
+    it "drops an exclusion clause but keeps the rest of the specifier" do
+      # >=3.7, !=3.9.* -> we keep >=3.7 and drop the exclusion, so 3.9 is admitted
+      # (fewer findings, never a false ceiling).
+      expect(admits?(">=3.7, !=3.9.*", "3.7")).to(be(true))
+      expect(admits?(">=3.7, !=3.9.*", "3.9")).to(be(true))
+    end
+
+    it "yields no constraint when only exclusions are present" do
+      expect(translate.call("!=3.9")).to(be_nil)
+      expect(translate.call("!=3.9.*")).to(be_nil)
+    end
+  end
+
+  describe "best-effort degradation (never raise, degrade to no-constraint)" do
+    it "returns nil for nil / empty / whitespace input" do
+      expect(translate.call(nil)).to(be_nil)
+      expect(translate.call("")).to(be_nil)
+      expect(translate.call("   ")).to(be_nil)
+    end
+
+    it "returns nil for a wholly unparseable specifier" do
+      expect(translate.call("not a version")).to(be_nil)
+    end
+
+    it "drops an unparseable clause but keeps a usable one" do
+      # A PEP 440 epoch bound Gem::Version can't parse must not sink the floor.
+      expect(admits?(">=3.7, <1!3.11", "3.8")).to(be(true))
+    end
+
+    it "yields no constraint when the only clause is unparseable" do
+      # `+local` / epoch versions have no RubyGems spelling; drop and degrade.
+      expect(translate.call(">=3.9+local")).to(be_nil)
+      expect(translate.call("<1!3.11")).to(be_nil)
+    end
+
+    it "bounds pathologically long input" do
+      expect(translate.call(">=#{"9" * 500}")).to(be_nil)
+    end
+  end
+end

--- a/spec/still_active/pypi_client_spec.rb
+++ b/spec/still_active/pypi_client_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/still_active/pypi_client"
+
+RSpec.describe(StillActive::PypiClient) do
+  describe ".requires_python" do
+    def stub_pypi(name, version, info)
+      stub_request(:get, "https://pypi.org/pypi/#{name}/#{version}/json")
+        .to_return(status: 200, body: { "info" => info }.to_json, headers: { "Content-Type" => "application/json" })
+    end
+
+    it "returns the release-level requires_python specifier" do
+      stub_pypi("numba", "0.53.1", { "requires_python" => ">=3.6,<3.10" })
+      expect(described_class.requires_python(name: "numba", version: "0.53.1")).to(eq(">=3.6,<3.10"))
+    end
+
+    it "returns nil when requires_python is absent from info" do
+      stub_pypi("tensorflow", "2.5.0", {})
+      expect(described_class.requires_python(name: "tensorflow", version: "2.5.0")).to(be_nil)
+    end
+
+    it "treats PyPI's empty-string (unset) requires_python as nil" do
+      stub_pypi("tensorflow", "2.5.0", { "requires_python" => "" })
+      expect(described_class.requires_python(name: "tensorflow", version: "2.5.0")).to(be_nil)
+    end
+
+    it "returns nil on a 404 (unindexed version) without raising" do
+      stub_request(:get, "https://pypi.org/pypi/ghost/9.9.9/json").to_return(status: 404)
+      expect(described_class.requires_python(name: "ghost", version: "9.9.9")).to(be_nil)
+    end
+
+    it "returns nil rather than raising on a non-Hash body (schema drift)" do
+      stub_request(:get, "https://pypi.org/pypi/weird/1.0/json")
+        .to_return(status: 200, body: [1, 2].to_json, headers: { "Content-Type" => "application/json" })
+      expect(described_class.requires_python(name: "weird", version: "1.0")).to(be_nil)
+    end
+
+    it "returns nil rather than raising when `info` is a non-Hash (schema drift would make dig raise)" do
+      stub_request(:get, "https://pypi.org/pypi/weird2/1.0/json")
+        .to_return(status: 200, body: { "info" => "not-a-hash" }.to_json, headers: { "Content-Type" => "application/json" })
+      expect { described_class.requires_python(name: "weird2", version: "1.0") }.not_to(raise_error)
+      expect(described_class.requires_python(name: "weird2", version: "1.0")).to(be_nil)
+    end
+
+    it "returns nil for a nil name or version (no request made)" do
+      expect(described_class.requires_python(name: nil, version: "1.0")).to(be_nil)
+      expect(described_class.requires_python(name: "x", version: nil)).to(be_nil)
+    end
+  end
+end

--- a/spec/still_active/python_helper_spec.rb
+++ b/spec/still_active/python_helper_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/helpers/python_helper"
+
+RSpec.describe(StillActive::PythonHelper) do
+  let(:cycles) do
+    [
+      { "cycle" => "3.13", "latest" => "3.13.2", "releaseDate" => "2024-10-07", "eol" => "2029-10-31" },
+      { "cycle" => "3.12", "latest" => "3.12.9", "releaseDate" => "2023-10-02", "eol" => "2028-10-31" },
+      { "cycle" => "3.9", "latest" => "3.9.21", "releaseDate" => "2020-10-05", "eol" => "2025-10-31" },
+    ]
+  end
+
+  before do
+    allow(StillActive::HttpHelper).to(receive(:get_json).and_return(cycles))
+  end
+
+  describe ".supported_python_range" do
+    it "sources the window from the python.json endoflife feed" do
+      described_class.supported_python_range
+      expect(StillActive::HttpHelper).to(have_received(:get_json).with(anything, "/api/python.json"))
+    end
+
+    it "reports the oldest supported cycle and latest stable (3.9 is EOL as of the fixture)" do
+      range = described_class.supported_python_range
+      expect(range[:oldest_supported]).to(eq(Gem::Version.new("3.12")))
+      expect(range[:latest_stable]).to(eq(Gem::Version.new("3.13.2")))
+    end
+
+    it "returns nil when the feed is unavailable" do
+      allow(StillActive::HttpHelper).to(receive(:get_json).and_return(nil))
+      expect(described_class.supported_python_range).to(be_nil)
+    end
+  end
+end

--- a/spec/still_active/ruby_helper_spec.rb
+++ b/spec/still_active/ruby_helper_spec.rb
@@ -202,14 +202,17 @@ RSpec.describe(StillActive::RubyHelper) do
       expect(range[:latest_stable_fresh]).to(be(false))
     end
 
-    it("returns nil rather than raising when the newest cycle's `latest` is malformed") do
+    it("keeps the window with nil latest_stable when the newest cycle's `latest` is malformed (so EOL-forced criticals still fire)") do
       # endoflife.date is best-effort third-party data; a garbled/preview `latest`
-      # must never crash the run (supported_ruby_range is fetched outside the
-      # per-gem rescue, so a raise here would abort the whole audit).
+      # feeds only the latest-not-yet note, so it degrades latest_stable to nil
+      # rather than nulling the whole window and silently disabling criticals.
       garbled = [cycles.first.merge("latest" => "unknown-preview"), *cycles[1..]]
       allow(StillActive::HttpHelper).to(receive(:get_json).and_return(garbled))
-      expect { described_class.supported_ruby_range }.not_to(raise_error)
-      expect(described_class.supported_ruby_range).to(be_nil)
+      range = nil
+      expect { range = described_class.supported_ruby_range }.not_to(raise_error)
+      expect(range).not_to(be_nil)
+      expect(range[:latest_stable]).to(be_nil)
+      expect(range[:oldest_supported]).to(eq(Gem::Version.new("3.3")))
     end
   end
 end

--- a/spec/still_active/runtime_ceiling_helper_spec.rb
+++ b/spec/still_active/runtime_ceiling_helper_spec.rb
@@ -122,5 +122,23 @@ RSpec.describe(StillActive::RuntimeCeilingHelper) do
         expect(described_class.analyze(requirement: "< 3.2", support_window: nil)).to(be_nil)
       end
     end
+
+    context("when latest_stable is nil (a malformed `latest` on the feed's newest cycle)") do
+      # The note needs latest_stable to compare against; the EOL-forced critical
+      # needs only the cycles' eol flags. A nil latest_stable must suppress the
+      # note WITHOUT hiding criticals.
+      let(:support_window) { super().merge(latest_stable: nil, latest_stable_fresh: false) }
+
+      it("still fires an EOL-forced critical (independent of latest_stable)") do
+        finding = analyze("< 3.2")
+        expect(finding[:eol_forced]).to(be(true))
+        expect(finding[:severity]).to(eq(:critical))
+      end
+
+      it("suppresses the latest-not-yet note rather than crashing on nil") do
+        expect { analyze("~> 3.3") }.not_to(raise_error)
+        expect(analyze("~> 3.3")).to(be_nil)
+      end
+    end
   end
 end

--- a/spec/still_active/sarif_helper_spec.rb
+++ b/spec/still_active/sarif_helper_spec.rb
@@ -271,9 +271,9 @@ RSpec.describe(StillActive::SarifHelper) do
     end
   end
 
-  describe("SA009 RubyRuntimeCeiling") do
+  describe("SA009 RuntimeCeiling") do
     def ceiling(finding, extra = {})
-      { "gem" => { version_used: "3.0.9", latest_version: "4.0.0", ruby_ceiling: finding }.merge(extra) }
+      { "gem" => { version_used: "3.0.9", latest_version: "4.0.0", language_ceiling: { runtime: "Ruby" }.merge(finding) }.merge(extra) }
     end
 
     let(:eol_finding) do
@@ -331,9 +331,9 @@ RSpec.describe(StillActive::SarifHelper) do
       expect(results.any? { |r| r["ruleId"] == "SA009" }).to(be(false))
     end
 
-    it("is suppressible via the :ruby_ceiling signal") do
+    it("is suppressible via the :language_ceiling signal") do
       StillActive.config.suppressions = StillActive::Suppressions.from(
-        [{ "gem" => "gem", "signal" => "ruby_ceiling", "reason" => "pinned on purpose" }],
+        [{ "gem" => "gem", "signal" => "language_ceiling", "reason" => "pinned on purpose" }],
       )
       sa009 = render(result: ceiling(eol_finding)).dig("runs", 0, "results").find { |r| r["ruleId"] == "SA009" }
       expect(sa009["suppressions"]).to(eq([{ "kind" => "external", "justification" => "pinned on purpose" }]))

--- a/spec/still_active/terminal_helper_spec.rb
+++ b/spec/still_active/terminal_helper_spec.rb
@@ -361,7 +361,7 @@ RSpec.describe(StillActive::TerminalHelper) do
           latest_version: "4.0.0",
           vulnerability_count: 0,
           scorecard_score: nil,
-          ruby_ceiling: ceiling,
+          language_ceiling: { runtime: "Ruby" }.merge(ceiling),
         }.merge(extra)
       end
 

--- a/spec/still_active/workflow_spec.rb
+++ b/spec/still_active/workflow_spec.rb
@@ -579,25 +579,6 @@ RSpec.describe(StillActive::Workflow) do
       end
     end
 
-    describe(".reconcile_ceiling_with_poison") do
-      it("drops a ceiling's fixed_by_upgrade when the same tree poisons that gem below the fix") do
-        result = {
-          "foo" => { ruby_ceiling: { requirement: "< 3.3", eol_forced: true, severity: :critical, fixed_by_upgrade: true } },
-          "bar" => { constraints: [{ dependency: "foo", requirement: "< 2.0", dep_latest: "2.0.0", majors_behind: 1, kind: :ceiling }] },
-        }
-        described_class.send(:reconcile_ceiling_with_poison, result)
-        expect(result["foo"][:ruby_ceiling][:fixed_by_upgrade]).to(be(false))
-        expect(result["foo"][:ruby_ceiling][:upgrade_blocked]).to(be(true))
-      end
-
-      it("leaves fixed_by_upgrade true when nothing caps that gem") do
-        result = { "foo" => { ruby_ceiling: { fixed_by_upgrade: true } } }
-        described_class.send(:reconcile_ceiling_with_poison, result)
-        expect(result["foo"][:ruby_ceiling][:fixed_by_upgrade]).to(be(true))
-        expect(result["foo"][:ruby_ceiling]).not_to(have_key(:upgrade_blocked))
-      end
-    end
-
     context("with a language-runtime ceiling") do
       let(:range) do
         {
@@ -633,7 +614,8 @@ RSpec.describe(StillActive::Workflow) do
         StillActive.config.gems = [{ name: "cfpropertylist", version: "3.0.9" }]
         stub_gem_with_ruby_caps(name: "cfpropertylist", used: "3.0.9", used_ruby: "< 3.2", latest: "4.0.0", latest_ruby: ">= 3.2")
 
-        ceiling = result["cfpropertylist"][:ruby_ceiling]
+        ceiling = result["cfpropertylist"][:language_ceiling]
+        expect(ceiling[:runtime]).to(eq("Ruby"))
         expect(ceiling[:eol_forced]).to(be(true))
         expect(ceiling[:severity]).to(eq(:critical))
         expect(ceiling[:ceiling_version]).to(eq("3.1"))
@@ -644,7 +626,7 @@ RSpec.describe(StillActive::Workflow) do
         StillActive.config.gems = [{ name: "legacygem", version: "1.0.0" }]
         stub_gem_with_ruby_caps(name: "legacygem", used: "1.0.0", used_ruby: ">= 2.3.0, < 3.2", latest: "2.0.0", latest_ruby: ">= 3.3")
 
-        ceiling = result["legacygem"][:ruby_ceiling]
+        ceiling = result["legacygem"][:language_ceiling]
         expect(ceiling[:eol_forced]).to(be(true))
         expect(ceiling[:severity]).to(eq(:critical))
         expect(ceiling[:ceiling_version]).to(eq("3.1"))
@@ -655,7 +637,7 @@ RSpec.describe(StillActive::Workflow) do
         StillActive.config.gems = [{ name: "somegem", version: "1.0.0" }]
         stub_gem_with_ruby_caps(name: "somegem", used: "1.0.0", used_ruby: "~> 3.3", latest: "1.0.0", latest_ruby: "~> 3.3")
 
-        ceiling = result["somegem"][:ruby_ceiling]
+        ceiling = result["somegem"][:language_ceiling]
         expect(ceiling[:eol_forced]).to(be(false))
         expect(ceiling[:severity]).to(eq(:note))
         expect(ceiling[:fixed_by_upgrade]).to(be(false))
@@ -673,7 +655,7 @@ RSpec.describe(StillActive::Workflow) do
         ]))
         allow(Gems).to(receive(:info).with("sqlite3").and_return({ "homepage_uri" => nil, "source_code_uri" => nil }))
 
-        expect(result["sqlite3"]).not_to(have_key(:ruby_ceiling))
+        expect(result["sqlite3"]).not_to(have_key(:language_ceiling))
       end
 
       it("does NOT flag a pinned version that declares no ruby_version, even if the latest version caps") do
@@ -686,14 +668,14 @@ RSpec.describe(StillActive::Workflow) do
         ]))
         allow(Gems).to(receive(:info).with("oldgem").and_return({ "homepage_uri" => nil, "source_code_uri" => nil }))
 
-        expect(result["oldgem"]).not_to(have_key(:ruby_ceiling))
+        expect(result["oldgem"]).not_to(have_key(:language_ceiling))
       end
 
       it("attaches nothing when the used version's ruby_version is a bare floor") do
         StillActive.config.gems = [{ name: "modern", version: "2.0.0" }]
         stub_gem_with_ruby_caps(name: "modern", used: "2.0.0", used_ruby: ">= 3.1", latest: "2.0.0", latest_ruby: ">= 3.1")
 
-        expect(result["modern"]).not_to(have_key(:ruby_ceiling))
+        expect(result["modern"]).not_to(have_key(:language_ceiling))
       end
 
       it("attaches nothing when the Ruby support window is unavailable (range nil)") do
@@ -701,7 +683,7 @@ RSpec.describe(StillActive::Workflow) do
         StillActive.config.gems = [{ name: "cfpropertylist", version: "3.0.9" }]
         stub_gem_with_ruby_caps(name: "cfpropertylist", used: "3.0.9", used_ruby: "< 3.2", latest: "4.0.0", latest_ruby: ">= 3.2")
 
-        expect(result["cfpropertylist"]).not_to(have_key(:ruby_ceiling))
+        expect(result["cfpropertylist"]).not_to(have_key(:language_ceiling))
       end
     end
 


### PR DESCRIPTION
## What

Generalizes the runtime-ceiling signal from Ruby-only to a **`language_ceiling` family** and adds **Python** support on the `--sbom` path. The signal's value is cross-tree *enforced-constraint* correlation, and that travels to any runtime with an enforced install wall plus an EOL calendar. Python's `requires_python` is exactly that: pip refuses an incompatible interpreter, as RubyGems refuses `ruby_version`. Done now while SA009 and the `ruby_ceiling` key are still unreleased, so the rename is free.

## Changes

- **Rename** the data key `ruby_ceiling` → `language_ceiling` with a `runtime` field; the terminal/markdown/SARIF renderers now parameterize on it. Flag → `--fail-if-language-ceiling`, SARIF SA009 name → `RuntimeCeiling`, suppression signal → `language_ceiling`. **Ruby output is byte-identical** (`runtime: "Ruby"`).
- **`Pep440Helper`** translates a PEP 440 `requires_python` into a RubyGems requirement string so the generic `RuntimeCeilingHelper` handles Python unchanged. `Gem::Requirement` *raises* on `~=` / `==X.*`, so a naive parse silently missed those caps.
- **`EndoflifeHelper`** extracts the ecosystem-neutral support-window builder out of `RubyHelper` (both it and the new `PythonHelper` delegate). A single malformed feed field now degrades one cycle or the note, never disables the signal tree-wide.
- **`PypiClient`** reads the authoritative release-level `info.requires_python`. **`EcosystemLens`** attaches the ceiling for pypi on the SBOM path — not gated on dormancy, since a cap is a fact of the resolved version. `fixed_by_upgrade` requires *positive confirmation*, so a failed latest-version fetch can never fabricate "upgrade lifts it."
- **`CeilingReconciler`** extracts the ceiling↔poison whole-tree reconcile so the SBOM path gets it too, ecosystem-qualified so a mixed rubygems+pypi SBOM can't cross-match a same-named dep.

## Enforcement / honesty

Both `ruby_version` and `requires_python` are hard install walls (the resolver refuses an incompatible runtime), so an EOL-forced **critical** is a real block, not an inference. The report states what the resolver enforces; runtime-correctness beyond that (a native ext that silently breaks) is out of static sight, and the docs say so ("no findings ≠ safe to bump").

## Dogfood (real data, live PyPI / deps.dev / endoflife)

| package | `requires_python` | result |
|---|---|---|
| numba 0.53.1, llvmlite 0.36.0 | `>=3.6,<3.10` | **critical** — strands on EOL Python 3.9 |
| scipy 1.7.3, numba 0.55.2 | `>=3.7,<3.11` | **note** |
| numpy 1.26.4, requests 2.31.0 | floors | no ceiling |

Gate verified on the SBOM path: `--fail-if-language-ceiling` exits 1 on a critical, exits 0 on a note (unless `=note`). **0 false positives across 715 real locked deps** (Apache Airflow constraints).

## Review

`code-reviewer` + `silent-failure-hunter` + `code-simplifier` all ran; every finding is addressed with coverage — the `fixed_by_upgrade` over-claim on a failed fetch, the malformed-feed guards (one bad field must not disable criticals), the PyPI schema-drift `TypeError`, the cross-ecosystem reconcile collision, and the removed duplication. 1015 specs green, RuboCop clean.

Held for your review — no merge, no release.
