### PR TITLE
feat: compute libyear on the cross-ecosystem (SBOM) path

### DIFF
--- a/lib/still_active/deps_dev_client.rb
+++ b/lib/still_active/deps_dev_client.rb
@@ -22,6 +22,10 @@ module StillActive
       {
         advisory_keys: body.dig("advisoryKeys")&.map { |a| a["id"] } || [],
         project_id: extract_project_id(body),
+        # The locked version's release date -- the cross-ecosystem libyear input
+        # (paired with the package's latest-release date). Already in this response,
+        # so no extra fetch; nil when the feed omits it.
+        published_at: body["publishedAt"],
       }
     end
 

--- a/lib/still_active/ecosystem_lens.rb
+++ b/lib/still_active/ecosystem_lens.rb
@@ -4,8 +4,10 @@ require_relative "deps_dev_client"
 require_relative "ecosystems_client"
 require_relative "github_client"
 require_relative "pypi_client"
+require "time"
 require_relative "../helpers/activity_helper"
 require_relative "../helpers/constraint_helper"
+require_relative "../helpers/libyear_helper"
 require_relative "../helpers/pep440_helper"
 require_relative "../helpers/runtime_ceiling_helper"
 require_relative "../helpers/vulnerability_helper"
@@ -63,11 +65,21 @@ module StillActive
       scorecard = DepsDevClient.project_scorecard(project_id: project_id)
       repo = repo_signals(project_id)
 
+      used_release_date = info&.dig(:published_at)
+      latest_release_date = default&.dig(:published_at)
       gem_data = {
         ecosystem: ecosystem,
         name: name,
         version_used: version,
-        latest_version_release_date: default&.dig(:published_at),
+        version_used_release_date: used_release_date,
+        latest_version_release_date: latest_release_date,
+        # libyear parity with the native path: how far behind latest the locked
+        # version is, in release-years. Both dates come from deps.dev responses
+        # already fetched above (no extra call); nil when either date is missing.
+        libyear: LibyearHelper.gem_libyear(
+          version_used_release_date: parse_time(used_release_date),
+          latest_version_release_date: parse_time(latest_release_date),
+        ),
         repository_url: project_id && "https://#{project_id}",
         last_commit_date: repo[:last_commit_date],
         archived: repo[:archived],
@@ -196,6 +208,19 @@ module StillActive
     # 60), so an untokened cross-ecosystem run still resolves a large SBOM.
     def repo_provider
       StillActive.config.github_oauth_token ? GithubClient : EcosystemsClient
+    end
+
+    # deps.dev renders dates as ISO8601 strings; libyear needs Time to subtract.
+    # nil-safe, and a malformed value degrades to nil rather than raising.
+    def parse_time(value)
+      # Guard the type, not just nil: a non-String publishedAt (schema drift) would
+      # make Time.parse raise TypeError (unrescued) and, since this enrichment runs
+      # in assess, demote an otherwise-healthy package. Best-effort must degrade.
+      return unless value.is_a?(String)
+
+      Time.parse(value)
+    rescue ArgumentError
+      nil
     end
   end
 end

--- a/spec/still_active/deps_dev_client_spec.rb
+++ b/spec/still_active/deps_dev_client_spec.rb
@@ -13,6 +13,17 @@ RSpec.describe(StillActive::DepsDevClient) do
       end
     end
 
+    it("extracts the locked version's publishedAt (the cross-ecosystem libyear input)") do
+      stub_request(:get, %r{api\.deps\.dev/v3alpha/systems/pypi/packages/lxml/versions/6\.0\.2})
+        .to_return(
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: { "advisoryKeys" => [], "publishedAt" => "2025-09-22T04:04:12Z" }.to_json,
+        )
+      result = described_class.version_info(gem_name: "lxml", version: "6.0.2", system: :pypi)
+      expect(result[:published_at]).to(eq("2025-09-22T04:04:12Z"))
+    end
+
     it("returns nil when gem_name is nil") do
       expect(described_class.version_info(gem_name: nil, version: "1.0.0")).to(be_nil)
     end

--- a/spec/still_active/ecosystem_lens_spec.rb
+++ b/spec/still_active/ecosystem_lens_spec.rb
@@ -14,10 +14,11 @@ RSpec.describe(StillActive::EcosystemLens) do
     allow(StillActive::EcosystemsClient).to(receive(:declared_dependencies).and_return([]))
   end
 
-  # Stub the deps.dev version endpoint (advisory keys + SOURCE_REPO link).
-  def stub_version(advisory_keys: [], source_repo: nil)
+  # Stub the deps.dev version endpoint (advisory keys + SOURCE_REPO link + the
+  # locked version's publishedAt, the libyear input).
+  def stub_version(advisory_keys: [], source_repo: nil, published_at: nil)
     links = source_repo ? [{ "label" => "SOURCE_REPO", "url" => source_repo }] : []
-    body = { "advisoryKeys" => advisory_keys.map { { "id" => _1 } }, "links" => links }
+    body = { "advisoryKeys" => advisory_keys.map { { "id" => _1 } }, "links" => links, "publishedAt" => published_at }
     stub_request(:get, %r{api\.deps\.dev/v3alpha/systems/[^/]+/packages/.+/versions/.+})
       .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: body.to_json)
   end
@@ -69,6 +70,29 @@ RSpec.describe(StillActive::EcosystemLens) do
         vulnerability_count: 0,
       ))
       expect(StillActive::StatusHelper.gem_status(result)).to(eq(:ok))
+    end
+
+    it("computes libyear from the locked and latest release dates (cross-ecosystem parity with the native path)") do
+      stub_version(source_repo: "https://github.com/psf/requests", published_at: "2023-05-22T15:12:42Z")
+      stub_package(default_published_at: "2026-05-22T15:12:42Z") # 3 years newer
+      stub_project_scorecard
+      stub_ecosystems_repo(archived: false)
+
+      result = described_class.assess(ecosystem: :pypi, name: "requests", version: "2.31.0")
+
+      expect(result[:version_used_release_date]).to(eq("2023-05-22T15:12:42Z"))
+      expect(result[:libyear]).to(be_within(0.1).of(3.0))
+    end
+
+    it("leaves libyear nil when the locked version's release date is unavailable, rather than guessing") do
+      stub_version(source_repo: "https://github.com/psf/requests") # no publishedAt
+      stub_package(default_published_at: "2026-05-22T15:12:42Z")
+      stub_project_scorecard
+      stub_ecosystems_repo(archived: false)
+
+      result = described_class.assess(ecosystem: :pypi, name: "requests", version: "2.31.0")
+
+      expect(result[:libyear]).to(be_nil)
     end
 
     it("reads a clean, long-dormant pypi package as :legacy") do


### PR DESCRIPTION
## What

Adds **libyear** to the cross-ecosystem (`--sbom`) path, closing a signal gap versus the native Ruby path — part of the breadth-parity work toward "a comprehensive health check on any repo."

## How

- `DepsDevClient.version_info` now keeps the locked version's `publishedAt` — it's already in the response, so **no new fetch**.
- `EcosystemLens.assess` feeds that + the latest-release date (already fetched) to the existing `LibyearHelper.gem_libyear`, and emits `version_used_release_date` + `libyear` per dependency (matching the native path's shape).
- `parse_time` guards both type and malformed dates: a bad value degrades to "no libyear" — never a wrong number, and never a raise that would demote an otherwise-healthy package.

## Verified

- Dogfood: news-digest monorepo (37 pypi + 199 cargo) → **236/236 deps now carry libyear** (windows-sys 1.9, cssutils 1.9, matchit 1.7…).
- Focused correctness review clean (parse_time degradation, date order, no misleading 0.0). 1019 specs green, RuboCop clean.

Stacked on #107 (now merged).
