### PR TITLE
fix: canary deps.dev advisory schema (guard silent false-clean on vulns)

### DIFF
--- a/lib/still_active/cli.rb
+++ b/lib/still_active/cli.rb
@@ -114,6 +114,12 @@ module StillActive
     def run_sbom
       path = StillActive.config.sbom_path
       require_parseable_sbom(path)
+      # deps.dev is the SBOM path's sole vulnerability source and an alpha API; a
+      # field rename would silently zero every vuln count. Canary the schema once
+      # and warn loudly so a degraded run never reads as an authoritative all-clear.
+      unless DepsDevClient.advisory_schema_ok?
+        $stderr.puts("warning: deps.dev vulnerability schema check failed (its `advisoryKeys` field may have changed, or the API is unreachable); vulnerability counts may be understated -- a clean result is NOT authoritative")
+      end
       sbom = SbomReader.parse(path)
       outcome = if $stderr.tty?
         SbomWorkflow.call(sbom) { |done, total| $stderr.print("\rAssessing #{done}/#{total} dependencies...") }

--- a/lib/still_active/deps_dev_client.rb
+++ b/lib/still_active/deps_dev_client.rb
@@ -8,6 +8,22 @@ module StillActive
 
     BASE_URI = URI("https://api.deps.dev/")
 
+    # A known-vulnerable package used to canary the `advisoryKeys` schema. deps.dev
+    # is an explicitly ALPHA API (v3alpha), and every cross-ecosystem vulnerability
+    # count flows through the `advisoryKeys` field with a field-level degrade to
+    # `[]` -- so a rename or drop of that field would silently turn every count to
+    # 0 and read a known-vulnerable package as clean (exit 0). django 3.0.0 carries
+    # 30+ permanent advisories; if the canary returns none, the schema drifted.
+    ADVISORY_CANARY = { system: "pypi", name: "django", version: "3.0.0" }.freeze
+
+    # Is deps.dev still returning advisories in the shape we parse? False when the
+    # canary comes back empty (schema drift) or unreachable (can't confirm). The
+    # caller warns loudly rather than presenting a possibly-understated "all clear".
+    def advisory_schema_ok?
+      info = version_info(gem_name: ADVISORY_CANARY[:name], version: ADVISORY_CANARY[:version], system: ADVISORY_CANARY[:system])
+      !(info.nil? || info[:advisory_keys].empty?)
+    end
+
     # `system` is the deps.dev package system, lowercased: rubygems, npm, pypi,
     # cargo, go, maven, nuget. It matches the ecosystem symbol SbomReader emits,
     # so a cross-ecosystem caller threads it straight through. An unknown system

--- a/spec/still_active/cli_spec.rb
+++ b/spec/still_active/cli_spec.rb
@@ -946,6 +946,16 @@ RSpec.describe(StillActive::CLI) do
       allow($stdout).to(receive(:tty?).and_return(false))
       allow($stderr).to(receive(:tty?).and_return(false))
       allow(StillActive::SbomWorkflow).to(receive(:call).and_return(outcome({ "pypi/flask@2.0.0" => lens_data })))
+      # deps.dev vuln-schema canary runs once per SBOM audit; keep it green by
+      # default so unrelated cases stay network-free. The degraded case is its own test.
+      allow(StillActive::DepsDevClient).to(receive(:advisory_schema_ok?).and_return(true))
+    end
+
+    it("warns loudly (does not present an authoritative all-clear) when the deps.dev vuln schema canary fails") do
+      allow(StillActive::DepsDevClient).to(receive(:advisory_schema_ok?).and_return(false))
+      allow($stdout).to(receive(:puts))
+      expect { cli.run(["--sbom=sbom.json"]) }
+        .to(output(/deps\.dev vulnerability schema check failed.*not authoritative/im).to_stderr)
     end
 
     it("dispatches on --sbom without a Gemfile, emitting an SBOM-shaped JSON report") do

--- a/spec/still_active/deps_dev_client_spec.rb
+++ b/spec/still_active/deps_dev_client_spec.rb
@@ -1,6 +1,31 @@
 # frozen_string_literal: true
 
 RSpec.describe(StillActive::DepsDevClient) do
+  describe(".advisory_schema_ok?") do
+    # Guards against the alpha v3alpha API renaming/dropping `advisoryKeys`, which
+    # would degrade every vuln count to 0 and render known-vulnerable packages
+    # "clean" (a silent false-negative on a tool that trades on no-false-positives).
+    def stub_canary(body)
+      stub_request(:get, %r{api\.deps\.dev/v3alpha/systems/pypi/packages/django/versions/3\.0\.0})
+        .to_return(status: 200, headers: { "Content-Type" => "application/json" }, body: body.to_json)
+    end
+
+    it "is true when the canary package still carries advisoryKeys (schema intact)" do
+      stub_canary({ "advisoryKeys" => [{ "id" => "GHSA-x" }, { "id" => "GHSA-y" }] })
+      expect(described_class.advisory_schema_ok?).to(be(true))
+    end
+
+    it "is false when the canary comes back with no advisories (field renamed/dropped)" do
+      stub_canary({ "advisoryKeys" => [] })
+      expect(described_class.advisory_schema_ok?).to(be(false))
+    end
+
+    it "is false when the canary can't be reached (can't confirm the schema)" do
+      stub_request(:get, %r{api\.deps\.dev/v3alpha/systems/pypi/packages/django/versions/3\.0\.0}).to_return(status: 500)
+      expect(described_class.advisory_schema_ok?).to(be(false))
+    end
+  end
+
   describe(".version_info") do
     it("returns advisory keys and project id for a known gem") do
       VCR.use_cassette("deps_dev_version") do


### PR DESCRIPTION
## What
`deps.dev` is the SBOM path's **sole** vulnerability source and an explicitly **alpha** API (`v3alpha`). Every vuln count flows through the `advisoryKeys` field with a field-level degrade to `[]` — so if that field is renamed or dropped, every count silently becomes 0 and a **known-vulnerable package renders clean, exit 0**. That's the inverse of the no-false-positives promise, and it's a *when-not-if* on an alpha API.

## Fix
Canary the advisory schema once per SBOM run against a package with 30+ permanent advisories (`django 3.0.0`). On failure (empty advisories = field drift, or unreachable), warn loudly that a clean result is **not authoritative** — so a degraded run never masquerades as an all-clear. The native path keeps ruby-advisory-db as a second source, so this specifically guards the single-sourced SBOM path.

Surfaced by an adversarial technical review (the "single most likely to embarrass the project" finding). TDD; 1023 specs green.
