### PR TITLE
fix: yanked-lock ceiling FP + poison/reconciler regression guards (review follow-ups)

### DIFF
--- a/lib/still_active/workflow.rb
+++ b/lib/still_active/workflow.rb
@@ -199,13 +199,20 @@ module StillActive
         })
       end
 
-      attach_ruby_ceiling(
-        gem_data: result_object[gem_name],
-        used_ruby_requirement: canonical_ruby_requirement(vs, version_used),
-        latest_ruby_requirement: canonical_ruby_requirement(vs, last_release),
-        pinned: !version_used.nil?,
-        ruby_range: ruby_range,
-      )
+      # A version pinned to a now-yanked release has no resolvable ruby_version to
+      # judge, and `pinned: !version_used.nil?` would otherwise fall through to the
+      # latest version's cap and attach IT to the locked gem -- a false ceiling on a
+      # version we can't actually read. Skip; the yanked lock is already flagged.
+      yanked_lock = !gem_version.nil? && version_used.nil? && !vs.empty?
+      unless yanked_lock
+        attach_ruby_ceiling(
+          gem_data: result_object[gem_name],
+          used_ruby_requirement: canonical_ruby_requirement(vs, version_used),
+          latest_ruby_requirement: canonical_ruby_requirement(vs, last_release),
+          pinned: !version_used.nil?,
+          ruby_range: ruby_range,
+        )
+      end
     end
 
     # The ruby_version to judge a language ceiling against, read from the canonical

--- a/spec/still_active/ecosystems_client_spec.rb
+++ b/spec/still_active/ecosystems_client_spec.rb
@@ -128,6 +128,27 @@ RSpec.describe(StillActive::EcosystemsClient) do
         .to(eq([{ package_name: "activemodel", requirements: "< 5.0" }]))
     end
 
+    it("excludes PyPI environment-marker and extra dependencies, which aren't unconditionally in the tree") do
+      # Bibliothecary (via ecosyste.ms) encodes a PyPI dep's environment marker or
+      # extra AS the `kind` -- e.g. `colorama; platform_system == "Windows"` becomes
+      # kind "platform_system==Windows", and an `[socks]` extra becomes kind "socks"
+      # (verified live on click 8.1.7 / requests). RUNTIME_KINDS admits only
+      # "runtime"/"normal", so a conditional dep can never contribute a poison cap
+      # for a package that was never installed on this interpreter/platform. This
+      # locks that immunity: the marker/extra deps must be dropped, only the
+      # unconditional runtime dep survives.
+      stub_deps({
+        "dependencies" => [
+          { "package_name" => "charset-normalizer", "requirements" => "< 4, >= 2", "kind" => "runtime" },
+          { "package_name" => "importlib-metadata", "requirements" => "*", "kind" => "python_version<3.8" },
+          { "package_name" => "colorama", "requirements" => "*", "kind" => "platform_system==Windows" },
+          { "package_name" => "PySocks", "requirements" => ">= 1.5.6", "kind" => "socks" },
+        ],
+      })
+      expect(described_class.declared_dependencies(name: "protected_attributes", version: "1.1.4"))
+        .to(eq([{ package_name: "charset-normalizer", requirements: "< 4, >= 2" }]))
+    end
+
     it("treats cargo's 'normal' kind as runtime, and excludes its dev/build kinds") do
       # cargo labels runtime deps 'normal' (not 'runtime'); a `== \"runtime\"`
       # filter silently drops every cargo dependency and never flags a cargo pill.

--- a/spec/still_active/sbom_workflow_spec.rb
+++ b/spec/still_active/sbom_workflow_spec.rb
@@ -8,6 +8,33 @@ RSpec.describe(StillActive::SbomWorkflow) do
   end
 
   describe(".call") do
+    it("reconciles a language ceiling against a poison cap end-to-end, on the assembled key/name shape (not a hand-built hash)") do
+      # The reconciler's cross-path contract (data[:name] + "ecosystem/name@version"
+      # keys) is unit-tested with hand-built hashes; this exercises it through the
+      # REAL SbomWorkflow assembly, so a drift in the gem_data shape (e.g. assess
+      # stops setting :name) can't pass green. `foo` carries a Python ceiling that
+      # says "upgrade to lift it"; `bar` poison-caps `foo` below that upgrade, so the
+      # reconcile must clear fixed_by_upgrade and set upgrade_blocked.
+      allow(StillActive::PythonHelper).to(receive(:supported_python_range).and_return(nil))
+      allow(StillActive::EcosystemLens).to(receive(:assess)) do |ecosystem:, name:, version:, **_|
+        base = { ecosystem:, name:, version_used: version }
+        if name == "foo"
+          base.merge(language_ceiling: { runtime: "Python", eol_forced: true, fixed_by_upgrade: true, requirement: "< 3.10" })
+        else
+          base.merge(constraints: [{ dependency: "foo", requirement: "< 1.0", dep_latest: "2.0.0", majors_behind: 2, kind: :ceiling }])
+        end
+      end
+
+      out = described_class.call(result_with([
+        { ecosystem: :pypi, name: "foo", version: "1.0.0" },
+        { ecosystem: :pypi, name: "bar", version: "0.1.0" },
+      ]))
+
+      ceiling = out.assessed["pypi/foo@1.0.0"][:language_ceiling]
+      expect(ceiling[:fixed_by_upgrade]).to(be(false))
+      expect(ceiling[:upgrade_blocked]).to(be(true))
+    end
+
     it("runs the lens over each dependency, keyed by ecosystem/name@version") do
       deps = [
         { ecosystem: :npm, name: "express", version: "5.2.1" },

--- a/spec/still_active/workflow_spec.rb
+++ b/spec/still_active/workflow_spec.rb
@@ -622,6 +622,20 @@ RSpec.describe(StillActive::Workflow) do
         expect(ceiling[:fixed_by_upgrade]).to(be(true))
       end
 
+      it("does not project the latest version's ceiling onto a pinned-but-yanked version we can't actually read") do
+        StillActive.config.gems = [{ name: "yankedcap", version: "0.9.0" }]
+        # 0.9.0 is gone from the registry (yanked); only latest 2.0.0 remains, and it
+        # caps ruby_version. Attaching 2.0.0's ceiling to the yanked 0.9.0 would be a
+        # false attribution -- we have no idea what 0.9.0's ruby_version was.
+        allow(Gems).to(receive(:versions).with("yankedcap").and_return([
+          { "number" => "2.0.0", "prerelease" => false, "created_at" => "2026-01-01T00:00:00Z", "licenses" => ["MIT"], "ruby_version" => "< 3.2" },
+        ]))
+        allow(Gems).to(receive(:info).with("yankedcap").and_return({ "homepage_uri" => nil, "source_code_uri" => nil }))
+
+        expect(result["yankedcap"][:version_yanked]).to(be(true))
+        expect(result["yankedcap"]).not_to(have_key(:language_ceiling))
+      end
+
       it("flags a compound floor+ceiling ruby_version end-to-end (the real registry shape)") do
         StillActive.config.gems = [{ name: "legacygem", version: "1.0.0" }]
         stub_gem_with_ruby_caps(name: "legacygem", used: "1.0.0", used_ruby: ">= 2.3.0, < 3.2", latest: "2.0.0", latest_ruby: ">= 3.3")


### PR DESCRIPTION
Three follow-ups from the adversarial technical review. Two of the flagged items turned out sound-by-design once verified against the real data pipeline — so those get regression guards rather than "fixes" — and one was a genuine false-positive worth fixing.

## Fix: yanked-lock ceiling projection (real FP)
When a lockfile pins a now-yanked release, its version hash isn't in the registry list, so `version_used` is nil and `pinned: !version_used.nil?` fell through to the **latest** version's `ruby_version` cap — attaching that ceiling to the yanked lock, a false attribution on a version we can't actually read. Now skipped (the yanked lock is already flagged via `version_yanked`); the latest-only audit case is unaffected.

## Guard: poison marker-immunity (claim refuted, locked)
The review theorized PyPI environment markers / extras could reach the poison signal as tree-wide caps. **Verified live and refuted:** ecosyste.ms (Bibliothecary) encodes every marker/extra *as the dependency `kind`* — `colorama; platform_system == "Windows"` → `kind "platform_system==Windows"`, a `[socks]` extra → `kind "socks"` — and `RUNTIME_KINDS` admits only `runtime`/`normal`, so a conditional dep can never contribute a cap. Added a regression test so that immunity can't silently break.

## Guard: reconciler cross-path integration test
`CeilingReconciler`'s cross-path contract (`data[:name]` + `"ecosystem/name@version"` keys) was only unit-tested with hand-built hashes. Added an end-to-end `SbomWorkflow` test (a Python ceiling `fixed_by_upgrade` flipped by a poison cap on the same package) so a drift in the assembled `gem_data` shape can't pass green.

1022 specs green, RuboCop clean.

_(The review's "enforced-fact / precompiled-variant" item is a deliberate, documented tradeoff — reading the source gem's true Ruby support, not a precompiled variant's tighter ABI cap — so it's left as-is; the FN-safe direction.)_
