### PR TITLE
feat: security-relevant poison (dead dep pins a vulnerable dep) + fix CVSS-4/unscored false-clean

### DIFF
--- a/docs/still_active.schema.json
+++ b/docs/still_active.schema.json
@@ -89,6 +89,7 @@
         "libyear": { "type": ["number", "null"] },
         "poison": { "type": "boolean" },
         "poison_severity": { "type": "string", "enum": ["note", "warning", "critical"] },
+        "poison_security_relevant": { "type": "boolean" },
         "constraints": { "type": "array", "items": { "$ref": "#/$defs/constraint" } },
         "language_ceiling": { "$ref": "#/$defs/language_ceiling" }
       }
@@ -102,7 +103,8 @@
         "requirement": { "type": "string" },
         "dep_latest": { "type": ["string", "null"] },
         "majors_behind": { "type": "integer", "minimum": 0 },
-        "kind": { "type": "string", "enum": ["ceiling", "exact_pin", "permissive"] }
+        "kind": { "type": "string", "enum": ["ceiling", "exact_pin", "permissive"] },
+        "capped_dep_vulnerable": { "type": "boolean" }
       }
     },
     "language_ceiling": {

--- a/lib/helpers/cyclonedx_helper.rb
+++ b/lib/helpers/cyclonedx_helper.rb
@@ -142,10 +142,12 @@ module StillActive
     end
 
     def rating(advisory)
-      score = advisory[:cvss3_score] || advisory[:cvss2_score]
+      # effective_score drops deps.dev's cvss3=0 sentinel; an unscored advisory
+      # gets no numeric rating (honest) rather than a masquerading 0.0.
+      score = VulnerabilityHelper.effective_score(advisory)
       return if score.nil?
 
-      method = advisory[:cvss3_score] ? "CVSSv3" : "CVSSv2"
+      method = advisory[:cvss3_score]&.positive? ? "CVSSv3" : "CVSSv2"
       rating = { "score" => score, "severity" => VulnerabilityHelper.highest_severity([advisory]) || "unknown", "method" => method }
       rating["vector"] = advisory[:cvss3_vector] if advisory[:cvss3_vector]
       rating

--- a/lib/helpers/sarif_helper.rb
+++ b/lib/helpers/sarif_helper.rb
@@ -221,7 +221,11 @@ module StillActive
     end
 
     def vulnerability_result(name, version, vuln, location, data = {})
-      score = vuln[:cvss3_score] || vuln[:cvss2_score]
+      # effective_score treats deps.dev's cvss3=0 sentinel (CVSS-4-only advisories)
+      # as unscored, so a HIGH finding can't be exported as a note/0.0 that a code-
+      # scanning gate reads as informational -- the same false-clean the CLI gate
+      # guards. An unscored-but-confirmed advisory maps to warning (see cvss_to_level).
+      score = VulnerabilityHelper.effective_score(vuln)
       level = Sarif::Rules.cvss_to_level(score)
       severity = Sarif::Rules.cvss_to_security_severity(score)
       advisory_id = vuln[:id] || Array(vuln[:aliases]).first || "unknown"

--- a/lib/helpers/vulnerability_helper.rb
+++ b/lib/helpers/vulnerability_helper.rb
@@ -9,17 +9,21 @@ module StillActive
     def highest_severity(vulnerabilities)
       return if vulnerabilities.nil? || vulnerabilities.empty?
 
-      max_score = vulnerabilities.filter_map { |v| v[:cvss3_score] || v[:cvss2_score] }.max
+      max_score = vulnerabilities.filter_map { |v| effective_score(v) }.max
       return if max_score.nil?
 
       severity_label(max_score)
     end
 
-    # An advisory carries a CVSS score only sometimes; a freshly disclosed CVE
-    # often has none yet, and the cross-ecosystem lens emits a minimal advisory
-    # when detail-fetch fails. "No score" is not "no severity".
+    # An advisory carries a usable CVSS score only sometimes; a freshly disclosed
+    # CVE often has none yet, the cross-ecosystem lens emits a minimal advisory when
+    # detail-fetch fails, and -- critically -- deps.dev only stores CVSS 3.x, so a
+    # CVSS-4-only advisory comes back with cvss3Score 0 (verified: two HIGH protobuf
+    # GHSAs scored CVSS 4.0 arrive as 0). A 0 is deps.dev's "no 3.x score" sentinel,
+    # not a genuine severity of zero (which real advisories never carry), so it must
+    # read as UNSCORED, not low -- otherwise a HIGH finding silently clears a gate.
     def unknown_severity?(vulnerability)
-      (vulnerability[:cvss3_score] || vulnerability[:cvss2_score]).nil?
+      effective_score(vulnerability).nil?
     end
 
     # True when at least one advisory has no fixed version available -- the gem
@@ -27,6 +31,17 @@ module StillActive
     # today; a deps.dev-only advisory leaves it nil (unknown), which reads false.
     def no_fix_available?(vulnerabilities)
       Array(vulnerabilities).any? { |vulnerability| vulnerability[:no_fix_available] }
+    end
+
+    # The best real CVSS score for an advisory, preferring v3, or nil when neither
+    # is usable. A score of 0 is treated as absent: deps.dev only stores CVSS 3.x,
+    # so a CVSS-4-only advisory (e.g. two HIGH protobuf GHSAs) comes back with
+    # cvss3Score 0 -- its "no 3.x score" sentinel, not a genuine severity of zero
+    # (which published advisories never carry). Every consumer of a numeric score
+    # (severity labels, SARIF level, CycloneDX rating) routes through here so a 0
+    # can't masquerade as "low" and silently clear a gate.
+    def effective_score(vulnerability)
+      [vulnerability[:cvss3_score], vulnerability[:cvss2_score]].find { |score| score&.positive? }
     end
 
     def severity_at_or_above?(vulnerabilities, threshold)

--- a/lib/still_active/poison_security_correlator.rb
+++ b/lib/still_active/poison_security_correlator.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative "../helpers/vulnerability_helper"
+
+module StillActive
+  # Whole-tree correlation, run once after the fan-out: a poison cap is far more
+  # urgent when the dependency it pins is ITSELF vulnerable in the same tree --
+  # "a dormant package is holding you on a known-vulnerable dependency, below the
+  # version that fixes it." Both facts are already assembled (the poison
+  # constraints and every dependency's vulnerability count), so this is one pass,
+  # no extra fetches. It marks the security-relevant caps so the report can lead
+  # with them and demote the FYI caps on healthy dependencies.
+  #
+  # The moat's strongest case (verified on real repos): several archived Google
+  # client libraries pin a vulnerable `protobuf` three majors below the fix.
+  module PoisonSecurityCorrelator
+    extend self
+
+    # Only a HIGH-or-above advisory on the capped dep makes the cap security-
+    # relevant. Most advisories are low-threat noise (research: ~95% of vulnerable
+    # deps are unreachable/low-impact), so a low/medium CVE on the pinned dep isn't
+    # the "you're stuck below the fix" story. Unscored advisories fail CLOSED (a
+    # confirmed advisory we can't score could be severe), matching --fail-if-
+    # vulnerable. Reachability/exploitability is beyond static, metadata-only sight
+    # and deliberately out of scope -- this gates on severity, not exploitability.
+    SECURITY_THRESHOLD = "high"
+
+    def correlate(result_object)
+      # Ecosystem-qualified map of each tree package's advisories. A capped dep
+      # resolves in its capper's ecosystem, so match "ecosystem/name" on both
+      # sides; native results carry no :ecosystem (nil on both) and still match.
+      advisories = result_object.each_with_object({}) do |(key, data), map|
+        next unless data[:vulnerability_count].to_i.positive?
+
+        name = data[:name] || key
+        map["#{data[:ecosystem]}/#{name}"] = data[:vulnerabilities] || []
+      end
+
+      result_object.each_value do |data|
+        constraints = data[:constraints]
+        next if constraints.nil? || constraints.empty?
+
+        eco = data[:ecosystem]
+        constraints.each do |constraint|
+          vulns = advisories["#{eco}/#{constraint[:dependency]}"]
+          next if vulns.nil?
+
+          constraint[:capped_dep_vulnerable] = true if VulnerabilityHelper.severity_at_or_above?(vulns, SECURITY_THRESHOLD)
+        end
+        data[:poison_security_relevant] = true if constraints.any? { |c| c[:capped_dep_vulnerable] }
+      end
+    end
+  end
+end

--- a/lib/still_active/sarif/rules.rb
+++ b/lib/still_active/sarif/rules.rb
@@ -20,7 +20,11 @@ module StillActive
       # CVSS 0-10 -> SARIF level. Per GitHub Code Scanning convention,
       # scores >= 7.0 map to error, 4.0-6.9 to warning, below 4.0 to note.
       def cvss_to_level(score)
-        return "note" if score.nil?
+        # A confirmed-but-unscored advisory (nil after effective_score, e.g. a
+        # CVSS-4-only advisory deps.dev returns as 0, or a fresh CVE) is elevated to
+        # warning, not note: it's a real finding a gate must not read as
+        # informational -- the SARIF analogue of the CLI gate's fail-closed.
+        return "warning" if score.nil?
         return "error" if score >= 7.0
         return "warning" if score >= 4.0
 

--- a/lib/still_active/sbom_workflow.rb
+++ b/lib/still_active/sbom_workflow.rb
@@ -2,6 +2,7 @@
 
 require_relative "ecosystem_lens"
 require_relative "ceiling_reconciler"
+require_relative "poison_security_correlator"
 require_relative "../helpers/python_helper"
 require "async"
 require "async/barrier"
@@ -73,6 +74,9 @@ module StillActive
         # ceiling's "upgrade to lift it" must not contradict a poison finding that
         # caps the same package below that upgrade (same guarantee as the native path).
         CeilingReconciler.reconcile_ceiling_with_poison(result)
+        # Flag poison caps that pin a vulnerable dependency (the moat's strongest
+        # case: an archived package holding you on a known-vulnerable dep).
+        PoisonSecurityCorrelator.correlate(result)
         # Stable, diffable order regardless of async completion order.
         Outcome.new(
           assessed: result.sort_by { |key, _| key }.to_h,

--- a/lib/still_active/workflow.rb
+++ b/lib/still_active/workflow.rb
@@ -3,6 +3,7 @@
 require_relative "artifactory_client"
 require_relative "ceiling_reconciler"
 require_relative "deps_dev_client"
+require_relative "poison_security_correlator"
 require_relative "ecosystems_client"
 require_relative "forgejo_client"
 require_relative "github_client"
@@ -95,6 +96,9 @@ module StillActive
         # "upgrade to lift it" must not contradict a poison finding that caps the
         # same gem below that upgrade.
         CeilingReconciler.reconcile_ceiling_with_poison(result_object)
+        # Flag poison caps that pin a vulnerable dependency: "a dormant package is
+        # holding you on a known-vulnerable dep, below the fix." No extra fetches.
+        PoisonSecurityCorrelator.correlate(result_object)
         # Gems are inserted as their async tasks finish, so the natural order is
         # nondeterministic completion order. Sort by name once here so every
         # consumer (JSON, SARIF, the baseline diff) gets a stable, diffable order.

--- a/spec/still_active/poison_security_correlator_spec.rb
+++ b/spec/still_active/poison_security_correlator_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/still_active/poison_security_correlator"
+
+RSpec.describe(StillActive::PoisonSecurityCorrelator) do
+  describe ".correlate" do
+    def vuln(cvss3)
+      { id: "GHSA-x", cvss3_score: cvss3, source: "deps.dev" }
+    end
+
+    it "flags a poison cap as security-relevant when the capped dep has a HIGH advisory" do
+      # The real Sentry case: archived Google libs pin a vulnerable protobuf below
+      # the fix. The cap and the vuln were both computed; this connects them.
+      result = {
+        "pypi/google-api-core@1.0.0" => {
+          ecosystem: :pypi,
+          name: "google-api-core",
+          constraints: [{ dependency: "protobuf", requirement: "< 5", majors_behind: 3, kind: :ceiling }],
+        },
+        "pypi/protobuf@4.21.6" => { ecosystem: :pypi, name: "protobuf", vulnerability_count: 1, vulnerabilities: [vuln(8.1)] },
+      }
+      described_class.correlate(result)
+      expect(result["pypi/google-api-core@1.0.0"][:constraints].first[:capped_dep_vulnerable]).to(be(true))
+      expect(result["pypi/google-api-core@1.0.0"][:poison_security_relevant]).to(be(true))
+    end
+
+    it "fails CLOSED on an unscored advisory (a confirmed advisory we can't score could be severe)" do
+      result = {
+        "pypi/capper@1.0.0" => { ecosystem: :pypi, name: "capper", constraints: [{ dependency: "dep", majors_behind: 3 }] },
+        "pypi/dep@1.0.0" => { ecosystem: :pypi, name: "dep", vulnerability_count: 1, vulnerabilities: [vuln(nil)] },
+      }
+      described_class.correlate(result)
+      expect(result["pypi/capper@1.0.0"][:constraints].first[:capped_dep_vulnerable]).to(be(true))
+    end
+
+    it "does NOT flag when the capped dep's only advisory is low/medium (noise, not the stuck-below-a-fix story)" do
+      result = {
+        "pypi/capper@1.0.0" => { ecosystem: :pypi, name: "capper", constraints: [{ dependency: "dep", majors_behind: 3 }] },
+        "pypi/dep@1.0.0" => { ecosystem: :pypi, name: "dep", vulnerability_count: 1, vulnerabilities: [vuln(4.2)] },
+      }
+      described_class.correlate(result)
+      expect(result["pypi/capper@1.0.0"][:constraints].first).not_to(have_key(:capped_dep_vulnerable))
+      expect(result["pypi/capper@1.0.0"]).not_to(have_key(:poison_security_relevant))
+    end
+
+    it "does not flag a cap on a non-vulnerable dep" do
+      result = {
+        "pypi/foo@1.0.0" => { ecosystem: :pypi, name: "foo", constraints: [{ dependency: "bar", majors_behind: 3 }] },
+        "pypi/bar@1.0.0" => { ecosystem: :pypi, name: "bar", vulnerability_count: 0 },
+      }
+      described_class.correlate(result)
+      expect(result["pypi/foo@1.0.0"][:constraints].first).not_to(have_key(:capped_dep_vulnerable))
+    end
+
+    it "ecosystem-qualifies: a vulnerable dep in one ecosystem does not flag a same-named cap in another" do
+      result = {
+        "pypi/foo@1.0.0" => { ecosystem: :pypi, name: "foo", constraints: [{ dependency: "redis", majors_behind: 3 }] },
+        "rubygems/redis@1.0.0" => { ecosystem: :rubygems, name: "redis", vulnerability_count: 1, vulnerabilities: [vuln(9.0)] },
+      }
+      described_class.correlate(result)
+      expect(result["pypi/foo@1.0.0"][:constraints].first).not_to(have_key(:capped_dep_vulnerable))
+    end
+
+    it "works on the native path shape (bare-name keys, no :ecosystem)" do
+      result = {
+        "dormantgem" => { constraints: [{ dependency: "nokogiri", majors_behind: 2 }] },
+        "nokogiri" => { vulnerability_count: 1, vulnerabilities: [vuln(7.5)] },
+      }
+      described_class.correlate(result)
+      expect(result["dormantgem"][:constraints].first[:capped_dep_vulnerable]).to(be(true))
+      expect(result["dormantgem"][:poison_security_relevant]).to(be(true))
+    end
+  end
+end

--- a/spec/still_active/sarif/rules_spec.rb
+++ b/spec/still_active/sarif/rules_spec.rb
@@ -70,7 +70,9 @@ RSpec.describe(StillActive::Sarif::Rules) do
       4.0 => "warning",
       3.9 => "note",
       0.1 => "note",
-      nil => "note",
+      # A confirmed-but-unscored advisory (nil after effective_score) is elevated to
+      # warning, not an informational note -- the SARIF fail-closed (see cvss_to_level).
+      nil => "warning",
     }.each do |score, expected|
       it("maps #{score.inspect} -> #{expected}") do
         expect(described_class.cvss_to_level(score)).to(eq(expected))

--- a/spec/still_active/sarif_helper_spec.rb
+++ b/spec/still_active/sarif_helper_spec.rb
@@ -417,7 +417,7 @@ RSpec.describe(StillActive::SarifHelper) do
       expect(sa003[0].dig("properties", "security-severity")).to(eq("6.0"))
     end
 
-    it("emits no security-severity property when both CVSS scores are nil") do
+    it("elevates a confirmed-but-unscored advisory to warning (not an informational note) and omits security-severity") do
       report_v2 = {
         "vuln_gem" => {
           version_used: "3.0.0",
@@ -425,8 +425,22 @@ RSpec.describe(StillActive::SarifHelper) do
         },
       }
       sa003 = render(result: report_v2).dig("runs", 0, "results", 0)
-      expect(sa003["level"]).to(eq("note"))
+      expect(sa003["level"]).to(eq("warning"))
       expect(sa003["properties"]&.dig("security-severity")).to(be_nil)
+    end
+
+    it("does not export a deps.dev cvss3=0 (CVSS-4-only) advisory as an informational note/0.0") do
+      # Two real HIGH protobuf GHSAs arrive from deps.dev as cvss3_score 0 (its
+      # no-CVSS-3 sentinel); a 0 must not read as low and clear a code-scanning gate.
+      report = {
+        "protobuf" => {
+          version_used: "4.21.6",
+          vulnerabilities: [{ id: "GHSA-8qvm-5x2c-j2w7", title: "DoS", cvss3_score: 0, cvss2_score: nil }],
+        },
+      }
+      sa003 = render(result: report).dig("runs", 0, "results", 0)
+      expect(sa003["level"]).to(eq("warning"))
+      expect(sa003["properties"]&.dig("security-severity")).not_to(eq("0.0"))
     end
   end
 

--- a/spec/still_active/vulnerability_helper_spec.rb
+++ b/spec/still_active/vulnerability_helper_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe(StillActive::VulnerabilityHelper) do
       expect(described_class.highest_severity(vulns)).to(eq("high"))
     end
 
+    it("treats a cvss3 of 0 (deps.dev's CVSS-4-only sentinel) as absent, falling through to a real cvss2") do
+      # A 0 must not masquerade as "low" (0 is truthy in Ruby); it falls through.
+      expect(described_class.highest_severity([{ cvss3_score: 0, cvss2_score: 7.5 }])).to(eq("high"))
+    end
+
+    it("reads a cvss3=0 with no cvss2 as UNSCORED (nil), not low -- so it fails closed on a gate") do
+      vuln = { cvss3_score: 0, cvss2_score: nil }
+      expect(described_class.highest_severity([vuln])).to(be_nil)
+      expect(described_class.unknown_severity?(vuln)).to(be(true))
+      expect(described_class.severity_at_or_above?([vuln], "high")).to(be(true))
+    end
+
     it("prefers cvss3 when both scores are present") do
       vulns = [{ cvss3_score: 9.0, cvss2_score: 5.0 }]
       expect(described_class.highest_severity(vulns)).to(eq("critical"))


### PR DESCRIPTION
Two related changes that came directly out of the "does the moat bite" study + a severity question, and each closes a real gap.

## fix: deps.dev `cvss3=0` (CVSS-4-only) read as low — a verified false-clean
deps.dev only stores CVSS 3.x, so an advisory scored with **CVSS 4.0** comes back as `cvss3Score: 0`. Because `0` is truthy in Ruby, `cvss3 || cvss2` returned it as a real score → `severity_label` → **"low"**. Verified against OSV: two **HIGH** protobuf GHSAs were read as low and **silently cleared `--fail-if-vulnerable=high`** — and the SARIF/CycloneDX exports emitted them as `note`/`0.0`, so a **GitHub code-scanning gate read them as informational too**. False-clean on the exact axis the tool trades on.

A shared `VulnerabilityHelper.effective_score` now treats a `0` as absent (a genuine 0.0 never appears on a published advisory) — falling through to a real cvss2, or reading **unscored → fail-closed**. All three consumers route through it (CLI gate, SARIF, CycloneDX). A confirmed-but-unscored advisory maps to SARIF `warning`, not an informational note.

## feat: security-relevant poison — "an archived dep is pinning you to a vulnerable dependency, below the fix"
The study's strongest, verified moat case was sitting in the data uncomputed: on **Sentry, 7 archived Google client libraries pin a vulnerable `protobuf` 3 majors below the fix**. The caps and protobuf's advisories were both assembled; nothing connected them. `PoisonSecurityCorrelator` does — one whole-tree pass, **no extra fetches** — flagging a cap `capped_dep_vulnerable` / `poison_security_relevant` when the pinned dep carries a **HIGH-or-above (or unscored, fail-closed)** advisory in the same tree.

Only HIGH+ counts — most advisories are low-threat noise (research: the large majority of vulnerable deps are unreachable/low-impact), so a low CVE on the pinned dep isn't the "stuck below the fix" story. Reachability is beyond metadata-only sight and out of scope — this gates on **severity, not exploitability**, and says so. Ecosystem-qualified keys mirror `CeilingReconciler`.

## Verified
Re-dogfood on the real Sentry SBOM: **7 poison findings correctly flagged security-relevant** (each pinning the now-correctly-HIGH protobuf). 1028 specs green, RuboCop clean. Adversarial code-review + silent-failure-hunter both ran; the hunter's HIGH finding (the SARIF/CycloneDX export gap) is fixed in this PR.
