### PR TITLE
feat: surface security-relevant poison (lead with 'pins a vulnerable dep')

### DIFF
--- a/lib/helpers/markdown_helper.rb
+++ b/lib/helpers/markdown_helper.rb
@@ -128,15 +128,25 @@ module StillActive
       # triage-friendly order.
       ranked = flagged.sort_by do |name, data|
         [
+          data[:poison_security_relevant] ? 0 : 1, # security-relevant caps lead
           -ConstraintHelper::SEVERITY.index(data[:poison_severity] || :note),
           -Array(data[:constraints]).map { |c| c[:majors_behind].to_i }.max,
           name.to_s,
         ]
       end
       ranked.each do |name, data|
-        lines << "- **#{data[:poison_severity] || :note}** #{poison_gem_ref(name, data)} caps #{poison_caps(data[:constraints])}"
+        lines << "- **#{data[:poison_severity] || :note}** #{poison_gem_ref(name, data)} caps #{poison_caps(data[:constraints])}#{poison_security_marker(data)}"
       end
       lines.join("\n")
+    end
+
+    # A prominent marker naming the known-vulnerable dependency a security-relevant
+    # cap pins you below the fix for -- the finding to act on first.
+    def poison_security_marker(data)
+      return "" unless data[:poison_security_relevant]
+
+      pinned = Array(data[:constraints]).select { |c| c[:capped_dep_vulnerable] }.map { |c| c[:dependency] }.uniq
+      " ⚠ **pins vulnerable #{pinned.join(", ")}**"
     end
 
     # The language-runtime ceiling: a resolved version whose declared runtime

--- a/lib/helpers/sarif_helper.rb
+++ b/lib/helpers/sarif_helper.rb
@@ -139,10 +139,13 @@ module StillActive
       end
 
       if data[:poison] && !Array(data[:constraints]).empty?
-        # Level tracks the poison tier: critical -> error, warning -> warning,
-        # note -> note. The fingerprint stays (rule_id, gem_name) so a tier change
-        # as the capped dep ships majors doesn't re-alert.
-        out << mark_suppressed(result("SA008", name, poison_message(name, version, data), location, level: poison_level(data)), name, :poison)
+        # Level tracks the poison tier (critical->error, ...); a plain majors-behind
+        # tier change keeps the (rule_id, gem_name) fingerprint so it doesn't re-alert.
+        # But a note->security-relevant escalation (the cap now pins a vulnerable dep)
+        # adds a fingerprint dimension so a past dismissal of the maintenance-tier
+        # finding can't silently mute the security one -- the transition a human must see.
+        state = data[:poison_security_relevant] ? "security" : "maintenance"
+        out << mark_suppressed(result("SA008", name, poison_message(name, version, data), location, level: poison_level(data), fp_extra: state), name, :poison)
       end
 
       if data[:language_ceiling]
@@ -186,6 +189,11 @@ module StillActive
     # and the transitive parent. Note result() fingerprints on (rule_id, gem_name)
     # only, so this volatile detail never re-alerts a finding the user triaged.
     def poison_level(data)
+      # A security-relevant cap (a dormant dep pins a known-vulnerable dependency
+      # below its fix) escalates to error regardless of majors-behind: it's a real
+      # security finding, not the maintenance-tier signal poison usually is.
+      return "error" if data[:poison_security_relevant]
+
       { critical: "error", warning: "warning", note: "note" }.fetch(data[:poison_severity], "warning")
     end
 
@@ -197,7 +205,16 @@ module StillActive
       end
       remaining = top[:total] - top[:shown].length
       caps << "+#{remaining} more" if remaining.positive?
-      "#{name} #{version}: caps #{caps.join("; ")}#{transitive_suffix(data)}."
+      "#{name} #{version}: caps #{caps.join("; ")}#{transitive_suffix(data)}#{poison_security_note(data)}."
+    end
+
+    # Spells out the security escalation for a code-scanning alert: which
+    # known-vulnerable dependency this dormant cap pins you below the fix for.
+    def poison_security_note(data)
+      return "" unless data[:poison_security_relevant]
+
+      pinned = Array(data[:constraints]).select { |c| c[:capped_dep_vulnerable] }.map { |c| c[:dependency] }.uniq
+      " -- pins known-vulnerable #{pinned.join(", ")} below the fix"
     end
 
     # Attaches a SARIF native suppressions[] entry when this finding is covered

--- a/lib/helpers/terminal_helper.rb
+++ b/lib/helpers/terminal_helper.rb
@@ -194,8 +194,20 @@ module StillActive
       path = data[:dependency_path]
       via = data[:direct] == false && path && path.length >= 2 ? " (via #{path.first})" : ""
       # Colour carries the tier: red = act-now (3+ majors behind), yellow = plan,
-      # dim = a minor/FYI cap (1 behind). The row is already red (dormant gem).
-      AnsiHelper.public_send(poison_colour(data[:poison_severity]), "  ↳ poison#{via}: #{poison_receipt(constraints)}")
+      # dim = a minor/FYI cap (1 behind). A security-relevant cap (it pins a
+      # vulnerable dependency below the fix) is always red -- that's the finding to
+      # act on regardless of how many majors behind it happens to be.
+      colour = data[:poison_security_relevant] ? :red : poison_colour(data[:poison_severity])
+      AnsiHelper.public_send(colour, "  ↳ poison#{via}: #{poison_receipt(constraints)}#{poison_security_suffix(data)}")
+    end
+
+    # Names the vulnerable dependency a security-relevant poison cap pins you to --
+    # the actionable "you're stuck below a fix for a known-vulnerable dep" detail.
+    def poison_security_suffix(data)
+      return "" unless data[:poison_security_relevant]
+
+      pinned = Array(data[:constraints]).select { |c| c[:capped_dep_vulnerable] }.map { |c| c[:dependency] }.uniq
+      " ⚠ pins vulnerable #{pinned.join(", ")}"
     end
 
     def poison_colour(severity)

--- a/spec/still_active/markdown_helper_spec.rb
+++ b/spec/still_active/markdown_helper_spec.rb
@@ -373,6 +373,23 @@ RSpec.describe(StillActive::MarkdownHelper) do
       expect(out).to(include("`protected_attributes` caps `activemodel` `< 5.0` (4 majors behind, latest 8.x)"))
     end
 
+    it("marks a security-relevant cap (names the pinned vulnerable dep) and leads with it over a higher-tier plain cap") do
+      result = {
+        "plaingem" => poison_gem(
+          [{ dependency: "activemodel", requirement: "< 5.0", dep_latest: "8.0.1", majors_behind: 4, kind: :ceiling }],
+          { poison_severity: :critical },
+        ),
+        "google-api-core" => poison_gem(
+          [{ dependency: "protobuf", requirement: "< 5", dep_latest: "7.0.0", majors_behind: 3, kind: :ceiling, capped_dep_vulnerable: true }],
+          { poison_severity: :note, poison_security_relevant: true },
+        ),
+      }
+      out = described_class.poison_section(result)
+      expect(out).to(include("⚠ **pins vulnerable protobuf**"))
+      # security-relevant leads, despite being :note vs the plain :critical.
+      expect(out.index("google-api-core")).to(be < out.index("plaingem"))
+    end
+
     it("shows the worst 3 caps + total for a many-cap gem, worst-first with name tie-break") do
       caps = [
         { dependency: "chalk", requirement: "^1", dep_latest: "5.0.0", majors_behind: 4, kind: :ceiling },

--- a/spec/still_active/sarif_helper_spec.rb
+++ b/spec/still_active/sarif_helper_spec.rb
@@ -228,6 +228,18 @@ RSpec.describe(StillActive::SarifHelper) do
       expect(sa008).not_to(have_key("properties"))
     end
 
+    it("escalates a security-relevant cap to error, names the pinned vulnerable dep, and mints a distinct fingerprint") do
+      vuln_cap = cap.merge(dependency: "protobuf", capped_dep_vulnerable: true)
+      data = poison([vuln_cap], { poison_severity: :note, poison_security_relevant: true })
+      sa008 = render(result: data).dig("runs", 0, "results").find { |r| r["ruleId"] == "SA008" }
+      expect(sa008["level"]).to(eq("error")) # security-relevant escalates above the :note tier
+      expect(sa008.dig("message", "text")).to(include("pins known-vulnerable protobuf below the fix"))
+
+      plain = render(result: poison([cap])).dig("runs", 0, "results").find { |r| r["ruleId"] == "SA008" }
+      expect(sa008.dig("partialFingerprints", "primaryLocationLineHash"))
+        .not_to(eq(plain.dig("partialFingerprints", "primaryLocationLineHash")))
+    end
+
     it("fingerprints on gem identity, NOT on majors_behind, so a growing cap is not re-alerted every run") do
       fp = lambda do |behind|
         r = render(result: poison([cap.merge(majors_behind: behind)])).dig("runs", 0, "results").find { |x| x["ruleId"] == "SA008" }

--- a/spec/still_active/terminal_helper_spec.rb
+++ b/spec/still_active/terminal_helper_spec.rb
@@ -319,6 +319,19 @@ RSpec.describe(StillActive::TerminalHelper) do
           .to(include("poison: caps chalk (4 behind), dateformat (3), through2 (3) +2 more"))
       end
 
+      it("names the pinned vulnerable dep and forces red when the cap is security-relevant, even at note tier") do
+        result = {
+          "google-api-core" => poison_gem(
+            [{ dependency: "protobuf", requirement: "< 5", dep_latest: "7.0.0", majors_behind: 3, kind: :ceiling, capped_dep_vulnerable: true }],
+            { poison_severity: :note, poison_security_relevant: true },
+          ),
+        }
+        out = described_class.render(result)
+        expect(out).to(include("⚠ pins vulnerable protobuf"))
+        # red (act-now) despite the :note tier, because it pins a vulnerable dep.
+        expect(out).to(match(/\e\[31m  ↳ poison:.*⚠ pins vulnerable protobuf/))
+      end
+
       it("folds the parent into a transitive poison line and suppresses the generic transitive line") do
         result = {
           "terrapin" => poison_gem(


### PR DESCRIPTION
The security-relevant poison flag (a dormant dep pinning a **vulnerable** dependency below its fix — the moat-bite study's killer case: 7 archived Google libs pinning a vulnerable `protobuf` in Sentry) was computed in #111 but only visible in JSON. A flag nothing displays is half a feature. This makes it **lead**:

- **Terminal:** the poison sub-line is forced **red** and names the pinned vulnerable dep (`⚠ pins vulnerable protobuf`) regardless of majors-behind tier — it's the act-now finding, not a dim note.
- **Markdown:** a prominent `⚠ **pins vulnerable X**` marker, and security-relevant caps **sort first** — leading with the bites, exactly what the study concluded.
- **SARIF:** the poison result **escalates to error** (it's a security finding now, not maintenance-tier), the message spells out which known-vulnerable dependency it pins you below the fix for, and the fingerprint gains a `security` dimension so a note→security escalation **mints a fresh alert** a past dismissal of the maintenance-tier finding can't silently mute.

Native-path renders; the SBOM path stays JSON (where the flag already surfaces). 1038 specs green, RuboCop clean.
