### PR TITLE
feat: enrich advisories with OSV severity + fixed ranges

### DIFF
--- a/docs/superpowers/specs/2026-07-02-osv-enrichment-below-the-fix-design.md
+++ b/docs/superpowers/specs/2026-07-02-osv-enrichment-below-the-fix-design.md
@@ -1,0 +1,127 @@
+# OSV enrichment + "pins below the fix" — design
+
+Status: approved 2026-07-02. Two atomic PRs, each deployable.
+
+## Problem
+
+Two verified gaps, one root cause. Both de-risking studies (2026-07-02) converged:
+
+1. **The security-relevant poison tier over-fires.** `PoisonSecurityCorrelator` gates
+   `capped_dep_vulnerable` on `VulnerabilityHelper.severity_at_or_above?(vulns, "high")`,
+   which **fails closed** on any advisory with no usable CVSS score. deps.dev (our only
+   advisory source) stores only CVSS 3.x and returns `cvss3Score: 0` for CVSS-4-era
+   advisories, so in practice *every* corpus hit — protobuf included — fires on an
+   unscored advisory, never a genuinely-scored HIGH. The "HIGH" gate filters nothing;
+   the tier is largely a dormancy signal wearing a security label.
+2. **We can't tell "capped below the fix" from "patchable in place."** The killer claim
+   is "the dead cap holds you below the version that *fixes* the CVE." deps.dev carries
+   **no fixed-version ranges at all**, so this is currently uncomputable.
+
+Both need the same thing: **OSV** (`api.osv.dev`) is the only source that carries a real
+severity label (`database_specific.severity`) *and* per-package fixed ranges
+(`affected[].ranges[].events[].fixed`). Verified against the live API docs 2026-07-02.
+
+## Non-goals / deferred (with reasons)
+
+- **OSV as an advisory *discovery* source.** deps.dev already discovers advisories
+  (`advisoryKeys`); OSV only *enriches* the ones we know by ID. No merge/dedup churn.
+- **`querybatch`.** It returns `{id, modified}` only, not full records — useless when we
+  already hold the IDs and need details. Ruled out.
+- **CycloneDX severity-only rating.** A label-only OSV advisory (no CVSS number) exports
+  no CycloneDX rating today, while SARIF now marks it `error` -- a format inconsistency. A
+  severity-only rating (`{ "severity": "high" }`, schema-valid, no fabricated score) would
+  close it. Deferred: both reviewers judged the current no-rating behavior correct/honest,
+  and it's a separable export-completeness enhancement, not part of the deflation. Small
+  follow-up.
+- **Bulk `all.zip` aggregator** (`storage.googleapis.com/osv-vulnerabilities/<ECO>/all.zip`).
+  Real, no-auth, full records, `modified_id.csv` for incremental — but it's an
+  ecosystem-wide dump (tens of MB / thousands of records) to serve a handful of per-tree
+  lookups. Right tool at **corpus scale** (the scaled moat study, a future "rotting"
+  feature), wrong tool for a single audit. Documented as the scale path, not built now.
+- **Any CVSS scoring engine (v3 or v4).** OSV's `database_specific.severity` label is present
+  on *every* GHSA-sourced advisory (verified: it reads `HIGH` on both a CVSS-v3 and a
+  CVSS-v4 record), so the label is a universal fallback for correct gating and correct SARIF
+  level. deps.dev already supplies a real *number* for v3-scored advisories; the only thing
+  it misses is v4-only, which the label covers. So **no vector parsing is needed** for the
+  deflation. A precise *number* for a v4-only advisory (to sharpen the SARIF security-severity
+  display) is the only reason to parse a vector, and that needs the table/MacroVector v4
+  algorithm — a real correctness surface; don't hand-roll. Deferred to a scoped follow-up that
+  would vendor a *vetted* v4 scorer. See `scratch/cvss_v4_lib_vetting.md` (in-flight).
+
+## Architecture
+
+New provider `lib/still_active/osv_client.rb` (per the "integrations are providers in their
+own file" convention; mirrors `DepsDevClient`). Public surface:
+
+```
+OsvClient.detail(advisory_id:) -> { severity_label:, cvss_vectors:, affected: [...] } | nil
+```
+
+`affected` is filtered to the caller's ecosystem+name at the enrichment site; each carries
+its `fixed` versions. A failed/absent OSV lookup returns `nil` and the advisory is left
+exactly as deps.dev produced it (degrade to today's behavior, never crash — the fetch is
+best-effort enrichment).
+
+Enrichment runs where advisories are already assembled, on **both** paths:
+- native: `Workflow#fetch_deps_dev_info` (`workflow.rb`)
+- SBOM: `EcosystemLens#vulnerabilities_for` (`ecosystem_lens.rb`)
+
+right after `merge_advisories`. For each advisory, if OSV has detail, attach
+`advisory[:osv_severity]` (label) and `advisory[:fixed_versions]` (Array for this
+ecosystem+name).
+
+## PR1 — OSV as the severity authority (the deflation)
+
+- `OsvClient` (WebMock-stubbed in specs; bounded concurrency; polite UA; no key needed —
+  OSV has no rate limits today).
+- Enrich advisories with `osv_severity` + `fixed_versions` on both paths.
+- `VulnerabilityHelper` severity layering, in priority order:
+  1. real CVSS number — deps.dev `cvss3_score`/`cvss2_score` if positive.
+  2. OSV `osv_severity` **label** (`CRITICAL`/`HIGH`/`MODERATE`/`LOW` → `critical`/`high`/
+     `medium`/`low`) — drives `highest_severity` / the HIGH+ gate / SARIF *level* only. Does
+     NOT fabricate a security-severity number.
+  3. neither → unscored → fail-closed (unchanged).
+- Effect: SA003 exports real protobuf as `error` not `warning`; the correlator's
+  `capped_dep_vulnerable` gate becomes true-HIGH, not fail-closed-on-everything.
+- **Honesty rail:** a label-derived level carries no invented CVSS number; the SARIF
+  `security-severity` property stays absent (or is marked label-derived), never `7.0`.
+
+## PR2 — "below the fix" ranking (the increment)
+
+- In `PoisonSecurityCorrelator`, for each `capped_dep_vulnerable` constraint: compute the
+  lowest OSV `fixed_versions` across the capped dep's HIGH+ advisories and compare against
+  the cap's ceiling (max version the `requirement` allows). Reuse `Pep440Helper`
+  (`to_gem_requirement_string`) + `VersionHelper#to_gem_version`/`normalize_version` — no
+  new comparator.
+- Classify: **A** `capped_below_fix` (every fix above the ceiling → genuinely stuck),
+  **B** patchable within cap, **C** no fix available.
+- **Anchor gotcha:** severity-relevance is judged at the *resolved* version (the correlator
+  already reads each dep's tree-version advisories), never the allowed-range floor —
+  probing the floor over-counts ~10x (lights up historical Rails CVEs).
+- Surface: rank A above B; terminal/markdown/SARIF label
+  "unpatchable within cap: <CVE> fixed in <v>, cap allows ≤ <ceiling>". SARIF note→security
+  escalation mints a fresh alert (mirrors existing fingerprint dimension).
+
+## Error handling
+
+OSV fetch is best-effort: network error, 404, malformed body, or missing fields → treat as
+"no OSV data," advisory unchanged, run continues. A `versions`-only advisory (no `fixed`
+event) reads as class C, not a crash. silent-failure-hunter on this path pre-merge — a
+failed OSV call must not silently *drop* an advisory deps.dev already found.
+
+## Testing (TDD, RED first)
+
+- `OsvClient` unit: WebMock fixtures — protobuf GHSA with multi-branch fixes, a label-only
+  advisory (no CVSS vector), a `versions`-only advisory, a 404, a malformed body.
+- `VulnerabilityHelper`: v3-vector parse; label drives level but not number; layering
+  priority; fail-closed unchanged.
+- `PoisonSecurityCorrelator`: Sentry `<5` → A, Saleor `<7` → B, no-fix → C; resolved-version
+  anchoring.
+- No live network in any spec.
+
+## Implementation order
+
+1. PR1 red (OsvClient + helper + enrichment specs) → green → review (code-reviewer +
+   silent-failure-hunter) → branch → PR → squash auto-merge. NO release.
+2. PR2 red → green → review → PR. NO release.
+3. Fold the CVSS-v4 vetting verdict in as a scoped follow-up if a safe scorer exists.

--- a/lib/helpers/http_helper.rb
+++ b/lib/helpers/http_helper.rb
@@ -6,7 +6,7 @@ require "json"
 
 module StillActive
   module HttpHelper
-    TRUSTED_HOSTS = ["github.com", "gitlab.com", "codeberg.org", "api.deps.dev", "endoflife.date", "rubygems.pkg.github.com", "repos.ecosyste.ms", "packages.ecosyste.ms", "pypi.org"].freeze
+    TRUSTED_HOSTS = ["github.com", "gitlab.com", "codeberg.org", "api.deps.dev", "api.osv.dev", "endoflife.date", "rubygems.pkg.github.com", "repos.ecosyste.ms", "packages.ecosyste.ms", "pypi.org"].freeze
     # Transport-level failures ("host unreachable / connection broke", not an HTTP
     # error status). Every network entry point degrades to a safe empty result on
     # these rather than letting one escape and vanish a gem from the audit.

--- a/lib/helpers/sarif_helper.rb
+++ b/lib/helpers/sarif_helper.rb
@@ -221,12 +221,14 @@ module StillActive
     end
 
     def vulnerability_result(name, version, vuln, location, data = {})
-      # effective_score treats deps.dev's cvss3=0 sentinel (CVSS-4-only advisories)
-      # as unscored, so a HIGH finding can't be exported as a note/0.0 that a code-
-      # scanning gate reads as informational -- the same false-clean the CLI gate
-      # guards. An unscored-but-confirmed advisory maps to warning (see cvss_to_level).
+      # Level tracks the resolved severity LABEL (a real CVSS score OR OSV's GHSA
+      # label), so a CVSS-4-only HIGH -- which deps.dev returns as cvss3Score 0 --
+      # exports as error, not a note/warning a code-scanning gate reads as
+      # informational. The security-severity NUMBER stays tied to a real CVSS score
+      # (effective_score): a label-only advisory carries no invented number rather
+      # than a fabricated 7.0. A confirmed-but-unscored advisory still fails closed.
       score = VulnerabilityHelper.effective_score(vuln)
-      level = Sarif::Rules.cvss_to_level(score)
+      level = Sarif::Rules.severity_to_level(VulnerabilityHelper.advisory_severity(vuln))
       severity = Sarif::Rules.cvss_to_security_severity(score)
       advisory_id = vuln[:id] || Array(vuln[:aliases]).first || "unknown"
       aliases = Array(vuln[:aliases]).first(3).join(", ")

--- a/lib/helpers/vulnerability_helper.rb
+++ b/lib/helpers/vulnerability_helper.rb
@@ -6,24 +6,39 @@ module StillActive
 
     SEVERITY_ORDER = ["low", "medium", "high", "critical"].freeze
 
+    # OSV's GHSA severity labels, mapped to our order. deps.dev stores only CVSS 3.x, so
+    # a CVSS-4-only advisory returns cvss3Score 0 (unscored); OSV's
+    # `database_specific.severity` reads correctly for it and rescues a real HIGH from
+    # fail-closed noise. GitHub uses MODERATE where we use medium.
+    OSV_LABELS = { "critical" => "critical", "high" => "high", "moderate" => "medium", "medium" => "medium", "low" => "low" }.freeze
+
     def highest_severity(vulnerabilities)
       return if vulnerabilities.nil? || vulnerabilities.empty?
 
-      max_score = vulnerabilities.filter_map { |v| effective_score(v) }.max
-      return if max_score.nil?
-
-      severity_label(max_score)
+      vulnerabilities
+        .filter_map { |v| advisory_severity(v) }
+        .max_by { |label| SEVERITY_ORDER.index(label) }
     end
 
-    # An advisory carries a usable CVSS score only sometimes; a freshly disclosed
-    # CVE often has none yet, the cross-ecosystem lens emits a minimal advisory when
-    # detail-fetch fails, and -- critically -- deps.dev only stores CVSS 3.x, so a
-    # CVSS-4-only advisory comes back with cvss3Score 0 (verified: two HIGH protobuf
-    # GHSAs scored CVSS 4.0 arrive as 0). A 0 is deps.dev's "no 3.x score" sentinel,
-    # not a genuine severity of zero (which real advisories never carry), so it must
-    # read as UNSCORED, not low -- otherwise a HIGH finding silently clears a gate.
+    # One advisory's severity label ("low".."critical"), or nil when genuinely unscored.
+    # A real CVSS score wins; otherwise the OSV/GHSA label stands in (so a v4-only
+    # advisory deps.dev can't score is still classified rather than failing closed).
+    def advisory_severity(vulnerability)
+      score = effective_score(vulnerability)
+      return severity_label(score) if score
+
+      OSV_LABELS[vulnerability[:osv_severity].to_s.downcase]
+    end
+
+    # Unknown = no CVSS score AND no OSV label. A freshly disclosed CVE often has
+    # neither yet, and the cross-ecosystem lens emits a minimal advisory when
+    # detail-fetch fails. The CVSS-4-only case (deps.dev returns cvss3Score 0, its
+    # "no 3.x score" sentinel, for two HIGH protobuf GHSAs scored CVSS 4.0) is no
+    # longer unknown once OSV enrichment attaches the GHSA severity label -- that's
+    # the whole point of the enrichment: a real HIGH stops failing closed as unscored.
+    # A truly unknown advisory still fails closed on a gate.
     def unknown_severity?(vulnerability)
-      effective_score(vulnerability).nil?
+      advisory_severity(vulnerability).nil?
     end
 
     # True when at least one advisory has no fixed version available -- the gem

--- a/lib/still_active/ecosystem_lens.rb
+++ b/lib/still_active/ecosystem_lens.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "deps_dev_client"
+require_relative "osv_client"
 require_relative "ecosystems_client"
 require_relative "github_client"
 require_relative "pypi_client"
@@ -62,6 +63,9 @@ module StillActive
       # the same resilience.
       project_id = info&.dig(:project_id) || project_id_from(name, ecosystem, default)
       vulnerabilities = vulnerabilities_for(info)
+      # Enrich with OSV: a real GHSA severity label (deps.dev can't score a CVSS-4-only
+      # advisory) and the fixed-version ranges the "capped below the fix" signal needs.
+      OsvClient.enrich(vulnerabilities, ecosystem: ecosystem, name: name)
       scorecard = DepsDevClient.project_scorecard(project_id: project_id)
       repo = repo_signals(project_id)
 

--- a/lib/still_active/osv_client.rb
+++ b/lib/still_active/osv_client.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require_relative "../helpers/http_helper"
+
+module StillActive
+  # OSV (api.osv.dev) enrichment for advisories deps.dev has already discovered.
+  # deps.dev is the discovery source -- it lists a package version's advisory ids --
+  # but it stores only CVSS 3.x (a CVSS-4-only advisory comes back with cvss3Score
+  # 0, which reads as unscored) and carries no fixed-version ranges at all. OSV
+  # supplies both gaps: a GHSA severity LABEL (`database_specific.severity`) that
+  # reads correctly even for a v4-only advisory, and the per-package fixed versions
+  # the "capped below the fix" signal compares against a poison cap's ceiling.
+  #
+  # Enrichment is best-effort: any failure (missing record, transport error, odd
+  # shape) leaves the advisory exactly as deps.dev produced it. It must never drop
+  # an advisory the audit already found, so it only ever ADDS fields.
+  module OsvClient
+    extend self
+
+    BASE_URI = URI("https://api.osv.dev/")
+
+    # Our ecosystem symbols map to OSV's package-ecosystem casing. One advisory can
+    # name the same package in several ecosystems, so we filter `affected` to the
+    # one being audited. The native Bundler path carries no ecosystem and is always
+    # rubygems.
+    ECOSYSTEM_NAMES = { rubygems: "RubyGems", pypi: "PyPI", npm: "npm", cargo: "crates.io" }.freeze
+
+    # Enrich each advisory in place with the OSV severity label and the fixed
+    # versions for the audited package. A missing/failed lookup is a no-op on that
+    # advisory (it keeps whatever deps.dev gave it), never a raise.
+    def enrich(advisories, ecosystem:, name:)
+      advisories.each do |advisory|
+        record = detail(advisory_id: advisory[:id])
+        next if record.nil?
+
+        advisory[:osv_severity] = record[:severity_label]
+        advisory[:fixed_versions] = fixed_versions(record, ecosystem: ecosystem, name: name)
+      rescue StandardError => e
+        # Enrichment is additive and best-effort. An unexpected OSV shape must never
+        # raise out through the workflow's per-gem rescue, which would DROP the whole
+        # gem and read a known-vulnerable dependency as clean. Leave the advisory
+        # exactly as deps.dev produced it.
+        $stderr.puts("warning: OSV enrichment for #{advisory[:id]} failed: #{e.class} (#{e.message}); leaving advisory unchanged")
+      end
+    end
+
+    # Fetch and parse one OSV record by advisory id (GHSA/CVE). Returns
+    # { severity_label:, affected: [{ ecosystem:, name:, fixed: [...] }] } or nil
+    # when the id is absent or OSV has no usable record for it. A non-object body
+    # (a CDN/error envelope that parses to an array or scalar) yields nil rather
+    # than raising on `dig`.
+    def detail(advisory_id:)
+      return if advisory_id.nil?
+
+      body = HttpHelper.get_json(BASE_URI, "/v1/vulns/#{encode(advisory_id)}")
+      return unless body.is_a?(Hash)
+
+      {
+        severity_label: body.dig("database_specific", "severity"),
+        affected: Array(body["affected"]).filter_map { |entry| parse_affected(entry) },
+      }
+    end
+
+    private
+
+    # The fixed versions declared for `name` in `ecosystem` across the record's
+    # affected packages (a branch-structured advisory carries one fix per maintained
+    # line, so several can apply). Empty when the package is enumerated by
+    # `versions` with no fix boundary, or isn't present in this ecosystem. When the
+    # ecosystem symbol has no OSV mapping (an ecosystem we don't audit for fixes),
+    # match by name alone rather than silently dropping every fix.
+    def fixed_versions(record, ecosystem:, name:)
+      osv_ecosystem = ECOSYSTEM_NAMES.fetch(ecosystem || :rubygems, nil)
+      record[:affected]
+        .select { |a| a[:name] == name && (osv_ecosystem.nil? || a[:ecosystem] == osv_ecosystem) }
+        .flat_map { |a| a[:fixed] }
+        .uniq
+    end
+
+    # Shape guards throughout: a malformed entry (null/scalar where an object is
+    # expected, or an object where an array is) is skipped, not raised on, so one
+    # bad `affected`/`ranges`/`events` element can't discard the good fixed versions
+    # beside it in the same record.
+    def parse_affected(entry)
+      return unless entry.is_a?(Hash)
+
+      package = entry["package"]
+      return unless package.is_a?(Hash) && package["name"]
+
+      fixed = Array(entry["ranges"]).flat_map do |range|
+        next [] unless range.is_a?(Hash)
+
+        Array(range["events"]).filter_map { |event| event["fixed"] if event.is_a?(Hash) }
+      end
+      { ecosystem: package["ecosystem"], name: package["name"], fixed: fixed }
+    end
+
+    def encode(value)
+      URI.encode_www_form_component(value.to_s)
+    end
+  end
+end

--- a/lib/still_active/sarif/rules.rb
+++ b/lib/still_active/sarif/rules.rb
@@ -17,18 +17,18 @@ module StillActive
         "#{DOCS_BASE}##{rule_id.downcase}"
       end
 
-      # CVSS 0-10 -> SARIF level. Per GitHub Code Scanning convention,
-      # scores >= 7.0 map to error, 4.0-6.9 to warning, below 4.0 to note.
-      def cvss_to_level(score)
-        # A confirmed-but-unscored advisory (nil after effective_score, e.g. a
-        # CVSS-4-only advisory deps.dev returns as 0, or a fresh CVE) is elevated to
-        # warning, not note: it's a real finding a gate must not read as
-        # informational -- the SARIF analogue of the CLI gate's fail-closed.
-        return "warning" if score.nil?
-        return "error" if score >= 7.0
-        return "warning" if score >= 4.0
-
-        "note"
+      def severity_to_level(label)
+        # Maps a resolved advisory severity label (VulnerabilityHelper.advisory_severity:
+        # a real CVSS score OR the OSV/GHSA label) to a SARIF level. A nil label is a
+        # confirmed-but-unscored advisory (no CVSS score and no OSV label, e.g. a fresh
+        # CVE) -- elevated to warning, not an informational note, so a gate can't read
+        # it as clean. This is the SARIF analogue of the CLI gate's fail-closed.
+        case label
+        when "critical", "high" then "error"
+        when "medium" then "warning"
+        when "low" then "note"
+        else "warning"
+        end
       end
 
       # SARIF security-severity must be a string with one decimal place.

--- a/lib/still_active/workflow.rb
+++ b/lib/still_active/workflow.rb
@@ -3,6 +3,7 @@
 require_relative "artifactory_client"
 require_relative "ceiling_reconciler"
 require_relative "deps_dev_client"
+require_relative "osv_client"
 require_relative "poison_security_correlator"
 require_relative "ecosystems_client"
 require_relative "forgejo_client"
@@ -372,6 +373,10 @@ module StillActive
       deps_dev_vulns = advisory_keys.map { |id| DepsDevClient.advisory_detail(advisory_id: id) || { id: id, source: "deps.dev" } }
       radb_vulns = RubyAdvisoryDb.advisories_for(database: advisory_db, gem_name: gem_name, version: version)
       vulnerabilities = VulnerabilityHelper.merge_advisories(deps_dev: deps_dev_vulns, ruby_advisory_db: radb_vulns)
+      # Enrich with OSV: a real GHSA severity label (deps.dev can't score a CVSS-4-only
+      # advisory) and the fixed-version ranges the "capped below the fix" signal needs.
+      # Native path is rubygems.
+      OsvClient.enrich(vulnerabilities, ecosystem: :rubygems, name: gem_name)
       {
         scorecard_score: scorecard&.dig(:score),
         scorecard_maintained: scorecard&.dig(:maintained),

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,5 +29,11 @@ RSpec.configure do |config|
     allow(Open3).to(receive(:capture3).and_call_original)
     allow(Open3).to(receive(:capture3).with("gh", "auth", "token").and_raise(Errno::ENOENT))
     allow(Open3).to(receive(:capture3).with("glab", "auth", "status", "--hostname=gitlab.com", "--show-token").and_raise(Errno::ENOENT))
+
+    # OSV advisory enrichment (OsvClient) fires on every advisory-bearing gem. Default
+    # it to "no record" so specs that aren't about OSV stay hermetic without each
+    # stubbing it; specs that exercise enrichment register a more specific stub_request
+    # (or explicit response), which WebMock matches ahead of this catch-all.
+    stub_request(:get, %r{api\.osv\.dev/v1/vulns/}).to_return(status: 404)
   end
 end

--- a/spec/still_active/ecosystem_lens_spec.rb
+++ b/spec/still_active/ecosystem_lens_spec.rb
@@ -120,6 +120,36 @@ RSpec.describe(StillActive::EcosystemLens) do
       expect(StillActive::StatusHelper.gem_status(result)).to(eq(:vulnerable))
     end
 
+    it("enriches a CVSS-4-only advisory (deps.dev score 0) with OSV's HIGH label and fixed versions") do
+      # deps.dev stores only CVSS 3.x, so this advisory arrives unscored (cvss3Score 0).
+      # OSV's GHSA label rescues the real HIGH and supplies the fixed ranges the
+      # below-the-fix signal needs -- the CVSS-4 deflation, end to end.
+      stub_version(advisory_keys: ["GHSA-cvss4"], source_repo: "https://github.com/protocolbuffers/protobuf")
+      stub_package(default_published_at: "2026-06-01T00:00:00Z")
+      stub_project_scorecard
+      stub_advisory(id: "GHSA-cvss4", cvss: 0)
+      stub_ecosystems_repo(archived: false)
+      stub_request(:get, "https://api.osv.dev/v1/vulns/GHSA-cvss4").to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          "database_specific" => { "severity" => "HIGH" },
+          "affected" => [{
+            "package" => { "name" => "protobuf", "ecosystem" => "PyPI" },
+            "ranges" => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "0" }, { "fixed" => "5.29.6" }] }],
+          }],
+        }.to_json,
+      )
+
+      result = described_class.assess(ecosystem: :pypi, name: "protobuf", version: "4.21.6")
+
+      vuln = result[:vulnerabilities].first
+      expect(vuln).to(include(osv_severity: "HIGH", fixed_versions: ["5.29.6"]))
+      expect(StillActive::VulnerabilityHelper.highest_severity(result[:vulnerabilities])).to(eq("high"))
+      # Without OSV this advisory (deps.dev cvss3Score 0) would be unscored and fail closed.
+      expect(StillActive::VulnerabilityHelper.unknown_severity?(vuln)).to(be(false))
+    end
+
     it("reads an archived repo that still publishes recent releases as :stale, not dead") do
       stub_version(source_repo: "https://github.com/owner/moved")
       stub_package(default_published_at: "2026-06-01T00:00:00Z")

--- a/spec/still_active/osv_client_spec.rb
+++ b/spec/still_active/osv_client_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+RSpec.describe(StillActive::OsvClient) do
+  # A real GHSA record shape (trimmed): a top-level GHSA severity LABEL plus per-package
+  # `affected` entries whose ranges carry branch-structured `fixed` events. This is the
+  # only source that gives us a real severity for a CVSS-4-only advisory (deps.dev returns
+  # cvss3Score 0) AND the fixed versions the "below the fix" signal needs.
+  def osv_record(severity: "HIGH", affected: nil)
+    {
+      "id" => "GHSA-8gq9-2x98-w8hf",
+      "aliases" => ["CVE-2022-1941"],
+      "severity" => [{ "type" => "CVSS_V3", "score" => "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H" }],
+      "affected" => affected || [
+        {
+          "package" => { "name" => "protobuf", "ecosystem" => "PyPI" },
+          "ranges" => [
+            { "type" => "ECOSYSTEM", "events" => [{ "introduced" => "0" }, { "fixed" => "3.18.3" }] },
+            { "type" => "ECOSYSTEM", "events" => [{ "introduced" => "4.0.0" }, { "fixed" => "4.21.6" }] },
+          ],
+        },
+      ],
+    }.tap { |r| r["database_specific"] = { "severity" => severity } if severity }
+  end
+
+  def stub_vuln(id, body:, status: 200)
+    stub_request(:get, "https://api.osv.dev/v1/vulns/#{id}")
+      .to_return(status: status, headers: { "Content-Type" => "application/json" }, body: body.is_a?(String) ? body : body.to_json)
+  end
+
+  describe(".detail") do
+    it("returns the GHSA severity label and the affected packages with their fixed versions") do
+      stub_vuln("GHSA-8gq9-2x98-w8hf", body: osv_record)
+
+      detail = described_class.detail(advisory_id: "GHSA-8gq9-2x98-w8hf")
+
+      expect(detail[:severity_label]).to(eq("HIGH"))
+      expect(detail[:affected]).to(contain_exactly(
+        { ecosystem: "PyPI", name: "protobuf", fixed: ["3.18.3", "4.21.6"] },
+      ))
+    end
+
+    it("returns nil when the advisory id is nil (nothing to enrich)") do
+      expect(described_class.detail(advisory_id: nil)).to(be_nil)
+    end
+
+    it("returns nil on a 404 so a missing OSV record degrades to no enrichment") do
+      stub_vuln("GHSA-missing", body: {}, status: 404)
+      expect(described_class.detail(advisory_id: "GHSA-missing")).to(be_nil)
+    end
+
+    it("leaves severity_label nil when the record carries no GHSA severity label") do
+      stub_vuln("GHSA-nolabel", body: osv_record(severity: nil))
+      expect(described_class.detail(advisory_id: "GHSA-nolabel")[:severity_label]).to(be_nil)
+    end
+
+    it("yields no fixed versions for a versions-only advisory (enumerated, no fix boundary)") do
+      record = osv_record(affected: [{
+        "package" => { "name" => "protobuf", "ecosystem" => "PyPI" },
+        "versions" => ["4.21.0", "4.21.5"],
+      }])
+      stub_vuln("GHSA-versonly", body: record)
+      expect(described_class.detail(advisory_id: "GHSA-versonly")[:affected].first[:fixed]).to(eq([]))
+    end
+
+    it("returns nil for a non-object body (a CDN/error envelope that parses to an array)") do
+      # HttpHelper hands back whatever parses; a JSON array/scalar must not raise on dig.
+      stub_vuln("GHSA-array", body: "[]")
+      expect(described_class.detail(advisory_id: "GHSA-array")).to(be_nil)
+    end
+
+    it("skips malformed affected/ranges/events entries without raising, keeping the good fixes beside them") do
+      # A null in affected, an object where an array belongs, and a null in ranges/events
+      # are all valid JSON that HttpHelper returns intact -- they must degrade, not crash.
+      record = osv_record(affected: [
+        nil,
+        { "package" => { "name" => "protobuf", "ecosystem" => "PyPI" }, "ranges" => "not-an-array" },
+        {
+          "package" => { "name" => "protobuf", "ecosystem" => "PyPI" },
+          "ranges" => [nil, { "events" => [nil, { "fixed" => "4.21.6" }] }],
+        },
+      ])
+      stub_vuln("GHSA-messy", body: record)
+
+      detail = described_class.detail(advisory_id: "GHSA-messy")
+
+      expect(detail[:severity_label]).to(eq("HIGH"))
+      expect(detail[:affected].map { |a| a[:fixed] }).to(eq([[], ["4.21.6"]]))
+    end
+  end
+
+  describe(".enrich") do
+    it("attaches the OSV label and the package's fixed versions to each advisory in place") do
+      stub_vuln("GHSA-8gq9-2x98-w8hf", body: osv_record)
+      advisories = [{ id: "GHSA-8gq9-2x98-w8hf", source: "deps.dev", cvss3_score: 0 }]
+
+      described_class.enrich(advisories, ecosystem: :pypi, name: "protobuf")
+
+      expect(advisories.first).to(include(osv_severity: "HIGH", fixed_versions: ["3.18.3", "4.21.6"]))
+    end
+
+    it("maps our ecosystem symbols to OSV's casing when filtering affected packages") do
+      # rubygems -> "RubyGems"; only the matching package's fixes are attached.
+      record = osv_record(affected: [
+        {
+          "package" => { "name" => "rack", "ecosystem" => "RubyGems" },
+          "ranges" => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "0" }, { "fixed" => "2.2.6.1" }] }],
+        },
+        { "package" => { "name" => "rack", "ecosystem" => "PyPI" }, "ranges" => [] },
+      ])
+      stub_vuln("GHSA-rack", body: record)
+      advisories = [{ id: "GHSA-rack" }]
+
+      described_class.enrich(advisories, ecosystem: :rubygems, name: "rack")
+
+      expect(advisories.first[:fixed_versions]).to(eq(["2.2.6.1"]))
+    end
+
+    it("treats a nil ecosystem as rubygems (the native path carries no ecosystem)") do
+      record = osv_record(affected: [
+        {
+          "package" => { "name" => "rack", "ecosystem" => "RubyGems" },
+          "ranges" => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "0" }, { "fixed" => "2.2.6.1" }] }],
+        },
+      ])
+      stub_vuln("GHSA-rack", body: record)
+      advisories = [{ id: "GHSA-rack" }]
+
+      described_class.enrich(advisories, ecosystem: nil, name: "rack")
+
+      expect(advisories.first[:fixed_versions]).to(eq(["2.2.6.1"]))
+    end
+
+    it("leaves an advisory untouched when OSV has no record for it (best-effort enrichment)") do
+      stub_vuln("GHSA-missing", body: {}, status: 404)
+      advisories = [{ id: "GHSA-missing", source: "deps.dev" }]
+
+      described_class.enrich(advisories, ecosystem: :pypi, name: "protobuf")
+
+      expect(advisories.first).to(eq({ id: "GHSA-missing", source: "deps.dev" }))
+    end
+
+    it("never lets an unexpected error escape enrich (the workflow's rescue would drop the whole gem)") do
+      # Defense in depth beyond the shape guards: even a surprise raise must leave the
+      # advisory as deps.dev produced it, not vanish a known-vulnerable dependency.
+      allow(described_class).to(receive(:detail).and_raise(TypeError, "boom"))
+      advisories = [{ id: "GHSA-x", source: "deps.dev" }]
+
+      expect { described_class.enrich(advisories, ecosystem: :pypi, name: "protobuf") }.not_to(raise_error)
+      expect(advisories.first).to(eq({ id: "GHSA-x", source: "deps.dev" }))
+    end
+  end
+end

--- a/spec/still_active/sarif/rules_spec.rb
+++ b/spec/still_active/sarif/rules_spec.rb
@@ -61,21 +61,18 @@ RSpec.describe(StillActive::Sarif::Rules) do
     end
   end
 
-  describe(".cvss_to_level") do
+  describe(".severity_to_level") do
     {
-      9.5 => "error",
-      7.0 => "error",
-      6.9 => "warning",
-      5.0 => "warning",
-      4.0 => "warning",
-      3.9 => "note",
-      0.1 => "note",
-      # A confirmed-but-unscored advisory (nil after effective_score) is elevated to
-      # warning, not an informational note -- the SARIF fail-closed (see cvss_to_level).
+      "critical" => "error",
+      "high" => "error",
+      "medium" => "warning",
+      "low" => "note",
+      # An unscored advisory (no CVSS score and no OSV label) fails closed to warning,
+      # never an informational note -- the SARIF analogue of the CLI fail-closed gate.
       nil => "warning",
-    }.each do |score, expected|
-      it("maps #{score.inspect} -> #{expected}") do
-        expect(described_class.cvss_to_level(score)).to(eq(expected))
+    }.each do |label, expected|
+      it("maps #{label.inspect} -> #{expected}") do
+        expect(described_class.severity_to_level(label)).to(eq(expected))
       end
     end
   end

--- a/spec/still_active/vulnerability_helper_spec.rb
+++ b/spec/still_active/vulnerability_helper_spec.rb
@@ -64,6 +64,34 @@ RSpec.describe(StillActive::VulnerabilityHelper) do
       vulns = [{ cvss3_score: nil, cvss2_score: nil }]
       expect(described_class.highest_severity(vulns)).to(be_nil)
     end
+
+    it("uses the OSV/GHSA label when deps.dev couldn't score the advisory (the CVSS-4-only case)") do
+      # deps.dev stores only CVSS 3.x -> cvss3_score 0 for a CVSS-4-only advisory; OSV's
+      # database_specific.severity label rescues a real HIGH from reading as unscored.
+      expect(described_class.highest_severity([{ cvss3_score: 0, osv_severity: "HIGH" }])).to(eq("high"))
+    end
+  end
+
+  describe(".advisory_severity") do
+    it("derives the label from a real CVSS score when present") do
+      expect(described_class.advisory_severity({ cvss3_score: 7.5 })).to(eq("high"))
+    end
+
+    it("falls back to the OSV/GHSA label when there is no usable CVSS score") do
+      expect(described_class.advisory_severity({ cvss3_score: 0, osv_severity: "HIGH" })).to(eq("high"))
+      expect(described_class.advisory_severity({ osv_severity: "CRITICAL" })).to(eq("critical"))
+      expect(described_class.advisory_severity({ osv_severity: "MODERATE" })).to(eq("medium"))
+      expect(described_class.advisory_severity({ osv_severity: "LOW" })).to(eq("low"))
+    end
+
+    it("prefers a real CVSS score over the OSV label") do
+      expect(described_class.advisory_severity({ cvss3_score: 9.5, osv_severity: "LOW" })).to(eq("critical"))
+    end
+
+    it("returns nil when neither a score nor a recognized OSV label is present") do
+      expect(described_class.advisory_severity({ id: "CVE-x" })).to(be_nil)
+      expect(described_class.advisory_severity({ osv_severity: "NONSENSE" })).to(be_nil)
+    end
   end
 
   describe(".unknown_severity?") do
@@ -75,6 +103,12 @@ RSpec.describe(StillActive::VulnerabilityHelper) do
     it("is false when a cvss3 or cvss2 score is present") do
       expect(described_class.unknown_severity?({ cvss3_score: 5.0 })).to(be(false))
       expect(described_class.unknown_severity?({ cvss3_score: nil, cvss2_score: 8.0 })).to(be(false))
+    end
+
+    it("is false when an OSV label is present even though deps.dev couldn't score it") do
+      # The whole point of the OSV enrichment: this advisory is no longer 'unknown',
+      # so it stops driving the fail-closed path (and the CLI unknown-severity warning).
+      expect(described_class.unknown_severity?({ cvss3_score: 0, osv_severity: "HIGH" })).to(be(false))
     end
   end
 
@@ -100,6 +134,17 @@ RSpec.describe(StillActive::VulnerabilityHelper) do
     it("fails closed when an unscored advisory is mixed with a scored-below-threshold one (the unscored one could exceed it)") do
       vulns = [{ id: "CVE-low", cvss3_score: 3.0 }, { id: "CVE-unknown", cvss3_score: nil }]
       expect(described_class.severity_at_or_above?(vulns, "high")).to(be(true))
+    end
+
+    it("passes the HIGH gate on an OSV-labelled advisory deps.dev left unscored (real HIGH, not fail-closed noise)") do
+      expect(described_class.severity_at_or_above?([{ cvss3_score: 0, osv_severity: "HIGH" }], "high")).to(be(true))
+    end
+
+    it("does NOT reach the HIGH gate on an OSV-labelled MODERATE advisory (the deflation: not everything trips)") do
+      # Before OSV enrichment this advisory was unscored -> fail-closed -> true, which is
+      # exactly why the security-relevant poison tier over-fired. With a real label it's
+      # correctly below HIGH.
+      expect(described_class.severity_at_or_above?([{ cvss3_score: 0, osv_severity: "MODERATE" }], "high")).to(be(false))
     end
   end
 


### PR DESCRIPTION
## What

Adds OSV (`api.osv.dev`) as an advisory **enrichment** source, fixing a precision gap in the security-relevant poison tier and laying the groundwork for the "capped below the fix" signal.

## Why

Two verified problems, one root cause (from the 2026-07-02 de-risking studies):

1. **The security tier over-fires.** deps.dev stores only CVSS 3.x and returns `cvss3Score: 0` for CVSS-4-era advisories. The severity gate fails closed on anything unscored, so with modern advisories mostly unscored, the "HIGH" gate filtered nothing — the tier was a dormancy signal wearing a security label. (Empirically, every security-relevant poison hit across a 53-app corpus fired on an unscored advisory, protobuf included.)
2. **"Below the fix" was uncomputable.** deps.dev carries no fixed-version ranges.

OSV supplies both: `database_specific.severity` (a real GHSA label, present even for a CVSS-4-only advisory) and `affected[].ranges[].events[].fixed`.

## How

- `OsvClient.enrich(advisories, ecosystem:, name:)` — for each already-discovered advisory id, `GET /v1/vulns/{id}`, attach `osv_severity` + `fixed_versions`. Enrichment, not discovery (deps.dev already discovers), so no merge/dedup churn. Wired into both the native and SBOM paths.
- `VulnerabilityHelper.advisory_severity` — real CVSS score > OSV label > unscored/fail-closed. `highest_severity` / `unknown_severity?` route through it, so a CVSS-4-only HIGH stops failing closed as unknown.
- SARIF level tracks the resolved label (`severity_to_level` replaces `cvss_to_level`); the security-severity **number** stays tied to a real CVSS score — a label-only advisory carries no fabricated `7.0`.
- `fixed_versions` captured for the follow-up "capped below the fix" ranking (PR2).

## Safety

Best-effort and cannot drop a gem: a per-advisory `rescue` in `enrich` plus `is_a?` shape guards keep a malformed OSV record from unwinding through the workflow's per-gem rescue and vanishing a known-vulnerable dependency (silent-failure-hunter finding, fixed + tested with null/scalar/schema-drift shapes).

## Verification

- 1053 specs green, rubocop clean.
- Dogfooded on the Sentry SBOM against the **live** OSV API: protobuf's two HIGH advisories (deps.dev scored `0`) now carry real HIGH labels + fixed versions `[6.33.5, 5.29.6]` / `[4.25.8, 5.29.5, 6.31.1]`; the 7 archived Google-lib cappers stay `poison_security_relevant` — now on a real HIGH, not fail-closed-on-unscored.

Design doc: `docs/superpowers/specs/2026-07-02-osv-enrichment-below-the-fix-design.md`. No release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
