### PR TITLE
feat: rank poison caps that hold you below the security fix

### DIFF
--- a/lib/helpers/constraint_helper.rb
+++ b/lib/helpers/constraint_helper.rb
@@ -101,6 +101,29 @@ module StillActive
       SEVERITY.index(severity) >= SEVERITY.index(threshold)
     end
 
+    # True when `version` sits at or below the highest major the cap allows -- i.e.
+    # you could upgrade the capped dep to it WITHOUT breaking the cap. The ceiling
+    # major is recovered from the poison finding itself (dep_latest minus
+    # majors_behind), at the same major precision the poison signal already uses, so
+    # a fix that lands OUTSIDE the cap ("below the fix") is detected without
+    # re-parsing the raw requirement and its pre/dev-release quirks (`< 5.0.0dev`).
+    #
+    # Precision is MAJOR-level by design, and that errs deliberately toward reachable:
+    # a within-major cap (`~> 4.2.1`, `< 5.5`) reads a same-major fix (4.9.0, 5.29.6)
+    # as reachable even though the cap forbids it. So a genuinely-stuck within-major
+    # cap is UNDER-reported (downgraded to the still-visible "vulnerable" tier), never
+    # falsely promoted -- when this DOES return false for every fix, the below-the-fix
+    # claim is sound (every fix is in a strictly higher major than the cap allows).
+    # Unparseable/absent inputs read false (never claims reachable when we can't tell).
+    def reachable_within_cap?(finding, version)
+      fix_major = major(version)
+      latest_major = major(finding[:dep_latest])
+      behind = finding[:majors_behind]
+      return false if fix_major.nil? || latest_major.nil? || behind.nil?
+
+      fix_major <= latest_major - behind
+    end
+
     # The poison condition: a below-latest ceiling or exact pin. A permissive
     # constraint, or a cap at/above the dep's latest major, is not a pill.
     def poison_ceiling?(requirement:, dep_latest:)

--- a/lib/helpers/markdown_helper.rb
+++ b/lib/helpers/markdown_helper.rb
@@ -128,7 +128,7 @@ module StillActive
       # triage-friendly order.
       ranked = flagged.sort_by do |name, data|
         [
-          data[:poison_security_relevant] ? 0 : 1, # security-relevant caps lead
+          poison_rank(data), # below-the-fix leads, then security-relevant, then the rest
           -ConstraintHelper::SEVERITY.index(data[:poison_severity] || :note),
           -Array(data[:constraints]).map { |c| c[:majors_behind].to_i }.max,
           name.to_s,
@@ -140,13 +140,31 @@ module StillActive
       lines.join("\n")
     end
 
+    # Ranks poison findings for the report: a cap that holds you BELOW THE FIX first
+    # (unpatchable without replacing the capper), then a merely security-relevant cap
+    # (vulnerable but patchable in place), then everything else.
+    def poison_rank(data)
+      return 0 if data[:poison_below_fix]
+      return 1 if data[:poison_security_relevant]
+
+      2
+    end
+
     # A prominent marker naming the known-vulnerable dependency a security-relevant
-    # cap pins you below the fix for -- the finding to act on first.
+    # cap pins you to. Leads with the stronger BELOW-THE-FIX claim (the CVE and its
+    # nearest fix, a version the cap forbids) when it applies, else the weaker
+    # "vulnerable but patchable" form.
     def poison_security_marker(data)
       return "" unless data[:poison_security_relevant]
 
-      pinned = Array(data[:constraints]).select { |c| c[:capped_dep_vulnerable] }.map { |c| c[:dependency] }.uniq
-      " ⚠ **pins vulnerable #{pinned.join(", ")}**"
+      below = Array(data[:constraints]).select { |c| c[:capped_below_fix] }
+      if below.any?
+        receipts = below.map { |c| "#{c[:dependency]} below the fix (#{c[:below_fix_advisory]} fixed in #{c[:below_fix_fixed_in]})" }.uniq
+        " ⚠ **pins #{receipts.join("; ")}**"
+      else
+        pinned = Array(data[:constraints]).select { |c| c[:capped_dep_vulnerable] }.map { |c| c[:dependency] }.uniq
+        " ⚠ **pins vulnerable #{pinned.join(", ")}**"
+      end
     end
 
     # The language-runtime ceiling: a resolved version whose declared runtime

--- a/lib/helpers/sarif_helper.rb
+++ b/lib/helpers/sarif_helper.rb
@@ -141,10 +141,16 @@ module StillActive
       if data[:poison] && !Array(data[:constraints]).empty?
         # Level tracks the poison tier (critical->error, ...); a plain majors-behind
         # tier change keeps the (rule_id, gem_name) fingerprint so it doesn't re-alert.
-        # But a note->security-relevant escalation (the cap now pins a vulnerable dep)
-        # adds a fingerprint dimension so a past dismissal of the maintenance-tier
-        # finding can't silently mute the security one -- the transition a human must see.
-        state = data[:poison_security_relevant] ? "security" : "maintenance"
+        # But an escalation up the tiers (maintenance -> security-relevant -> below the
+        # fix) adds a fingerprint dimension so a past dismissal of a weaker tier can't
+        # silently mute the stronger one -- the transition a human must see.
+        state = if data[:poison_below_fix]
+          "below_fix"
+        elsif data[:poison_security_relevant]
+          "security"
+        else
+          "maintenance"
+        end
         out << mark_suppressed(result("SA008", name, poison_message(name, version, data), location, level: poison_level(data), fp_extra: state), name, :poison)
       end
 
@@ -208,13 +214,23 @@ module StillActive
       "#{name} #{version}: caps #{caps.join("; ")}#{transitive_suffix(data)}#{poison_security_note(data)}."
     end
 
-    # Spells out the security escalation for a code-scanning alert: which
-    # known-vulnerable dependency this dormant cap pins you below the fix for.
+    # Spells out the security escalation for a code-scanning alert. Only claims
+    # "below the fix" (with the CVE and its nearest fix, a version the cap forbids)
+    # when that is actually established. Otherwise we say only that the dep is
+    # known-vulnerable, WITHOUT asserting patchability: this branch also covers a
+    # HIGH advisory with no released fix at all (class C), which is not patchable in
+    # place, so an "(patchable in place)" claim here would be false on the worst case.
     def poison_security_note(data)
       return "" unless data[:poison_security_relevant]
 
-      pinned = Array(data[:constraints]).select { |c| c[:capped_dep_vulnerable] }.map { |c| c[:dependency] }.uniq
-      " -- pins known-vulnerable #{pinned.join(", ")} below the fix"
+      below = Array(data[:constraints]).select { |c| c[:capped_below_fix] }
+      if below.any?
+        receipts = below.map { |c| "#{c[:dependency]} below the fix (#{c[:below_fix_advisory]} fixed in #{c[:below_fix_fixed_in]}, outside the cap)" }.uniq
+        " -- pins #{receipts.join("; ")}"
+      else
+        pinned = Array(data[:constraints]).select { |c| c[:capped_dep_vulnerable] }.map { |c| c[:dependency] }.uniq
+        " -- pins known-vulnerable #{pinned.join(", ")}"
+      end
     end
 
     # Attaches a SARIF native suppressions[] entry when this finding is covered

--- a/lib/helpers/terminal_helper.rb
+++ b/lib/helpers/terminal_helper.rb
@@ -201,13 +201,22 @@ module StillActive
       AnsiHelper.public_send(colour, "  ↳ poison#{via}: #{poison_receipt(constraints)}#{poison_security_suffix(data)}")
     end
 
-    # Names the vulnerable dependency a security-relevant poison cap pins you to --
-    # the actionable "you're stuck below a fix for a known-vulnerable dep" detail.
+    # Names the vulnerable dependency a security-relevant poison cap pins you to. When
+    # the cap holds you BELOW THE FIX (every patched version is a major it forbids) we
+    # lead with that stronger, enforced claim and name the CVE and its nearest fix --
+    # "you cannot patch this without replacing the dormant capper". Otherwise the
+    # weaker "pins vulnerable X" (the dep is vulnerable, but patchable in place).
     def poison_security_suffix(data)
       return "" unless data[:poison_security_relevant]
 
-      pinned = Array(data[:constraints]).select { |c| c[:capped_dep_vulnerable] }.map { |c| c[:dependency] }.uniq
-      " ⚠ pins vulnerable #{pinned.join(", ")}"
+      below = Array(data[:constraints]).select { |c| c[:capped_below_fix] }
+      if below.any?
+        receipts = below.map { |c| "#{c[:dependency]} below the fix (#{c[:below_fix_advisory]} fixed in #{c[:below_fix_fixed_in]})" }.uniq
+        " ⚠ pins #{receipts.join("; ")}"
+      else
+        pinned = Array(data[:constraints]).select { |c| c[:capped_dep_vulnerable] }.map { |c| c[:dependency] }.uniq
+        " ⚠ pins vulnerable #{pinned.join(", ")}"
+      end
     end
 
     def poison_colour(severity)

--- a/lib/still_active/osv_client.rb
+++ b/lib/still_active/osv_client.rb
@@ -23,7 +23,18 @@ module StillActive
     # name the same package in several ecosystems, so we filter `affected` to the
     # one being audited. The native Bundler path carries no ecosystem and is always
     # rubygems.
-    ECOSYSTEM_NAMES = { rubygems: "RubyGems", pypi: "PyPI", npm: "npm", cargo: "crates.io" }.freeze
+    # Every ecosystem SbomReader/deps.dev resolve, mapped to OSV's package-ecosystem
+    # casing (verified against live OSV records). Anything unmapped falls back to
+    # name-only fix filtering rather than dropping fixes.
+    ECOSYSTEM_NAMES = {
+      rubygems: "RubyGems",
+      pypi: "PyPI",
+      npm: "npm",
+      cargo: "crates.io",
+      maven: "Maven",
+      go: "Go",
+      nuget: "NuGet",
+    }.freeze
 
     # Enrich each advisory in place with the OSV severity label and the fixed
     # versions for the audited package. A missing/failed lookup is a no-op on that

--- a/lib/still_active/poison_security_correlator.rb
+++ b/lib/still_active/poison_security_correlator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "../helpers/vulnerability_helper"
+require_relative "../helpers/constraint_helper"
 
 module StillActive
   # Whole-tree correlation, run once after the fan-out: a poison cap is far more
@@ -25,6 +26,11 @@ module StillActive
     # and deliberately out of scope -- this gates on severity, not exploitability.
     SECURITY_THRESHOLD = "high"
 
+    # The severity labels that let an advisory establish "below the fix". Only a
+    # confirmed HIGH+ advisory with a known fix can: an unscored advisory (which the
+    # capped_dep_vulnerable gate accepts fail-closed) has no reliable fix analysis.
+    BELOW_FIX_LABELS = ["high", "critical"].freeze
+
     def correlate(result_object)
       # Ecosystem-qualified map of each tree package's advisories. A capped dep
       # resolves in its capper's ecosystem, so match "ecosystem/name" on both
@@ -44,11 +50,54 @@ module StillActive
         constraints.each do |constraint|
           vulns = advisories["#{eco}/#{constraint[:dependency]}"]
           next if vulns.nil?
+          next unless VulnerabilityHelper.severity_at_or_above?(vulns, SECURITY_THRESHOLD)
 
-          constraint[:capped_dep_vulnerable] = true if VulnerabilityHelper.severity_at_or_above?(vulns, SECURITY_THRESHOLD)
+          constraint[:capped_dep_vulnerable] = true
+          mark_below_fix(constraint, vulns)
         end
         data[:poison_security_relevant] = true if constraints.any? { |c| c[:capped_dep_vulnerable] }
+        data[:poison_below_fix] = true if constraints.any? { |c| c[:capped_below_fix] }
       end
+    end
+
+    private
+
+    # The sharper claim on a security-relevant cap: does it hold you BELOW THE FIX?
+    # A HIGH+ advisory with a known fix establishes it only when EVERY fixed version
+    # lands outside the cap (a major it forbids) -- you cannot patch the CVE without
+    # replacing the dormant capper. The receipt names the advisory and its nearest
+    # fix (the lowest fixed version, all of which are outside the cap).
+    def mark_below_fix(constraint, vulns)
+      stuck = vulns.select do |vuln|
+        fixes = Array(vuln[:fixed_versions])
+        next false if fixes.empty?
+        next false unless BELOW_FIX_LABELS.include?(VulnerabilityHelper.advisory_severity(vuln))
+
+        fixes.none? { |fix| ConstraintHelper.reachable_within_cap?(constraint, fix) }
+      end
+      return if stuck.empty?
+
+      receipt = stuck.min_by { |vuln| gem_version(nearest_fix(vuln)) }
+      constraint[:capped_below_fix] = true
+      constraint[:below_fix_advisory] = receipt[:id]
+      constraint[:below_fix_fixed_in] = nearest_fix(receipt)
+    end
+
+    # The lowest fixed version, for the "fixed in X" receipt. A parseable version
+    # always beats an unparseable one (PyPI epoch `1!2.3.4`, or garbage), so the
+    # receipt never names an odd string when a clean fix is present; only when EVERY
+    # fix is unparseable does it fall back to one of those.
+    def nearest_fix(vuln)
+      Array(vuln[:fixed_versions]).min_by { |fix| [Gem::Version.correct?(fix.to_s) ? 0 : 1, gem_version(fix)] }
+    end
+
+    # A version key that sorts fix strings without raising; an unparseable version
+    # collapses to 0 (only reached as a tiebreak among all-unparseable fixes, since
+    # nearest_fix prefers parseable ones).
+    def gem_version(version)
+      Gem::Version.new(version.to_s)
+    rescue ArgumentError
+      Gem::Version.new("0")
     end
   end
 end

--- a/spec/still_active/constraint_helper_spec.rb
+++ b/spec/still_active/constraint_helper_spec.rb
@@ -222,4 +222,27 @@ RSpec.describe(StillActive::ConstraintHelper) do
       expect(described_class.poison_ceiling?(requirement: "~> 8.0", dep_latest: "8.2.0")).to(be(false)) # at latest
     end
   end
+
+  describe(".reachable_within_cap?") do
+    # The real Sentry case: protobuf latest ~7.x, cap `< 5` (3 majors behind), so the
+    # highest major the cap allows is 4. A fix in major 4 is reachable; a fix in 5+ is
+    # "below the fix" -- unpatchable without replacing the capper.
+    let(:finding) { { dep_latest: "7.35.1", majors_behind: 3 } }
+
+    it("is true for a fix at or below the cap's ceiling major") do
+      expect(described_class.reachable_within_cap?(finding, "4.25.8")).to(be(true))
+      expect(described_class.reachable_within_cap?(finding, "3.20.3")).to(be(true))
+    end
+
+    it("is false for a fix in a major the cap forbids (below the fix)") do
+      expect(described_class.reachable_within_cap?(finding, "5.29.6")).to(be(false))
+      expect(described_class.reachable_within_cap?(finding, "6.33.5")).to(be(false))
+    end
+
+    it("reads false on unparseable or absent inputs (never claims a fix is reachable when unsure)") do
+      expect(described_class.reachable_within_cap?(finding, "not-a-version")).to(be(false))
+      expect(described_class.reachable_within_cap?({ dep_latest: nil, majors_behind: 3 }, "4.0.0")).to(be(false))
+      expect(described_class.reachable_within_cap?({ dep_latest: "7.0.0", majors_behind: nil }, "4.0.0")).to(be(false))
+    end
+  end
 end

--- a/spec/still_active/markdown_helper_spec.rb
+++ b/spec/still_active/markdown_helper_spec.rb
@@ -390,6 +390,33 @@ RSpec.describe(StillActive::MarkdownHelper) do
       expect(out.index("google-api-core")).to(be < out.index("plaingem"))
     end
 
+    it("leads with a below-the-fix cap (CVE + nearest fix) ahead of a merely-vulnerable one") do
+      result = {
+        "patchable-capper" => poison_gem(
+          [{ dependency: "jwt", requirement: "< 3", dep_latest: "5.0.0", majors_behind: 2, kind: :ceiling, capped_dep_vulnerable: true }],
+          { poison_severity: :critical, poison_security_relevant: true },
+        ),
+        "google-api-core" => poison_gem(
+          [{
+            dependency: "protobuf",
+            requirement: "< 5",
+            dep_latest: "7.0.0",
+            majors_behind: 3,
+            kind: :ceiling,
+            capped_dep_vulnerable: true,
+            capped_below_fix: true,
+            below_fix_advisory: "GHSA-7gcm-g887-7qv7",
+            below_fix_fixed_in: "5.29.6",
+          }],
+          { poison_severity: :note, poison_security_relevant: true, poison_below_fix: true },
+        ),
+      }
+      out = described_class.poison_section(result)
+      expect(out).to(include("⚠ **pins protobuf below the fix (GHSA-7gcm-g887-7qv7 fixed in 5.29.6)**"))
+      # below-the-fix leads, even over a :critical merely-vulnerable cap.
+      expect(out.index("google-api-core")).to(be < out.index("patchable-capper"))
+    end
+
     it("shows the worst 3 caps + total for a many-cap gem, worst-first with name tie-break") do
       caps = [
         { dependency: "chalk", requirement: "^1", dep_latest: "5.0.0", majors_behind: 4, kind: :ceiling },

--- a/spec/still_active/osv_client_spec.rb
+++ b/spec/still_active/osv_client_spec.rb
@@ -115,6 +115,29 @@ RSpec.describe(StillActive::OsvClient) do
       expect(advisories.first[:fixed_versions]).to(eq(["2.2.6.1"]))
     end
 
+    it("maps every ecosystem still_active resolves to OSV's casing (maven/go/nuget too, for fix-data parity)") do
+      # deps.dev/SbomReader resolve 7 systems; OSV names three of them Maven/Go/NuGet.
+      # Without these, fix-version filtering for those ecosystems falls back to loose
+      # name-only matching. Verified casing against live OSV records.
+      {
+        maven: "Maven", go: "Go", nuget: "NuGet",
+      }.each do |eco, osv_name|
+        record = osv_record(affected: [
+          {
+            "package" => { "name" => "widget", "ecosystem" => osv_name },
+            "ranges" => [{ "type" => "ECOSYSTEM", "events" => [{ "introduced" => "0" }, { "fixed" => "1.2.3" }] }],
+          },
+          { "package" => { "name" => "widget", "ecosystem" => "PyPI" }, "ranges" => [] },
+        ])
+        stub_vuln("GHSA-#{eco}", body: record)
+        advisories = [{ id: "GHSA-#{eco}" }]
+
+        described_class.enrich(advisories, ecosystem: eco, name: "widget")
+
+        expect(advisories.first[:fixed_versions]).to(eq(["1.2.3"]))
+      end
+    end
+
     it("treats a nil ecosystem as rubygems (the native path carries no ecosystem)") do
       record = osv_record(affected: [
         {

--- a/spec/still_active/poison_security_correlator_spec.rb
+++ b/spec/still_active/poison_security_correlator_spec.rb
@@ -71,4 +71,76 @@ RSpec.describe(StillActive::PoisonSecurityCorrelator) do
       expect(result["dormantgem"][:poison_security_relevant]).to(be(true))
     end
   end
+
+  describe ".correlate below the fix" do
+    # Sentry: google-api-core caps protobuf `< 5` (3 majors behind, latest ~7). Whether
+    # the cap holds you BELOW THE FIX depends on where the CVE's fix lands.
+    def sentry_result(fixed_versions, advisory: { id: "CVE-2026-0994", cvss3_score: 8.1 })
+      {
+        "pypi/google-api-core@1.0.0" => {
+          ecosystem: :pypi,
+          name: "google-api-core",
+          constraints: [{ dependency: "protobuf", requirement: "< 5", dep_latest: "7.35.1", majors_behind: 3, kind: :ceiling }],
+        },
+        "pypi/protobuf@4.21.6" => {
+          ecosystem: :pypi,
+          name: "protobuf",
+          vulnerability_count: 1,
+          vulnerabilities: [advisory.merge(fixed_versions: fixed_versions, source: "deps.dev")],
+        },
+      }
+    end
+
+    it "marks a cap below the fix when every fix is outside the cap (class A: unpatchable in place)" do
+      result = sentry_result(["6.33.5", "5.29.6"])
+      described_class.correlate(result)
+      cap = result["pypi/google-api-core@1.0.0"]
+      constraint = cap[:constraints].first
+      expect(constraint[:capped_below_fix]).to(be(true))
+      expect(constraint[:below_fix_advisory]).to(eq("CVE-2026-0994"))
+      expect(constraint[:below_fix_fixed_in]).to(eq("5.29.6")) # nearest fix outside the cap
+      expect(cap[:poison_below_fix]).to(be(true))
+    end
+
+    it "does NOT mark below the fix when a fix is reachable within the cap (class B: patchable in place)" do
+      result = sentry_result(["4.25.8", "5.29.5"]) # 4.25.8 satisfies `< 5`
+      described_class.correlate(result)
+      cap = result["pypi/google-api-core@1.0.0"]
+      expect(cap[:constraints].first[:capped_dep_vulnerable]).to(be(true))
+      expect(cap[:constraints].first).not_to(have_key(:capped_below_fix))
+      expect(cap).not_to(have_key(:poison_below_fix))
+    end
+
+    it "does NOT establish below the fix from an advisory with no known fix (class C)" do
+      result = sentry_result([])
+      described_class.correlate(result)
+      cap = result["pypi/google-api-core@1.0.0"]
+      expect(cap[:constraints].first[:capped_dep_vulnerable]).to(be(true))
+      expect(cap[:constraints].first).not_to(have_key(:capped_below_fix))
+    end
+
+    it "does NOT establish below the fix from an UNSCORED advisory (no reliable fix analysis)" do
+      result = sentry_result(["5.29.6"], advisory: { id: "CVE-x", cvss3_score: nil })
+      described_class.correlate(result)
+      cap = result["pypi/google-api-core@1.0.0"]
+      expect(cap[:constraints].first[:capped_dep_vulnerable]).to(be(true)) # fail-closed still flags
+      expect(cap[:constraints].first).not_to(have_key(:capped_below_fix))  # but below-fix needs a real score
+    end
+
+    it "uses the OSV label to score a CVSS-4-only advisory (deps.dev 0) for below-the-fix (the flagship)" do
+      result = sentry_result(["5.29.6"], advisory: { id: "CVE-2026-0994", cvss3_score: 0, osv_severity: "HIGH" })
+      described_class.correlate(result)
+      expect(result["pypi/google-api-core@1.0.0"][:constraints].first[:capped_below_fix]).to(be(true))
+    end
+
+    it "names a clean fix in the receipt, never an epoch/garbage version when a parseable one exists" do
+      # OSV fix strings are usually clean, but a PyPI epoch (7!2.3.4, Gem-unparseable)
+      # must not be chosen as the displayed 'fixed in' over a real version. All three
+      # fixes are outside the `< 5` cap (majors 7/6/5), so below-fix fires; the receipt
+      # picks the lowest PARSEABLE one.
+      result = sentry_result(["7!2.3.4", "6.33.5", "5.29.6"])
+      described_class.correlate(result)
+      expect(result["pypi/google-api-core@1.0.0"][:constraints].first[:below_fix_fixed_in]).to(eq("5.29.6"))
+    end
+  end
 end

--- a/spec/still_active/sarif_helper_spec.rb
+++ b/spec/still_active/sarif_helper_spec.rb
@@ -228,16 +228,40 @@ RSpec.describe(StillActive::SarifHelper) do
       expect(sa008).not_to(have_key("properties"))
     end
 
-    it("escalates a security-relevant cap to error, names the pinned vulnerable dep, and mints a distinct fingerprint") do
+    it("escalates a security-relevant (patchable) cap to error, names the pinned vulnerable dep, and mints a distinct fingerprint") do
       vuln_cap = cap.merge(dependency: "protobuf", capped_dep_vulnerable: true)
       data = poison([vuln_cap], { poison_severity: :note, poison_security_relevant: true })
       sa008 = render(result: data).dig("runs", 0, "results").find { |r| r["ruleId"] == "SA008" }
       expect(sa008["level"]).to(eq("error")) # security-relevant escalates above the :note tier
-      expect(sa008.dig("message", "text")).to(include("pins known-vulnerable protobuf below the fix"))
+      # No below-fix data: claim only that it's vulnerable, without asserting
+      # patchability (this branch also covers a no-fix advisory, which isn't patchable).
+      expect(sa008.dig("message", "text")).to(include("pins known-vulnerable protobuf"))
+      expect(sa008.dig("message", "text")).not_to(include("patchable in place"))
 
       plain = render(result: poison([cap])).dig("runs", 0, "results").find { |r| r["ruleId"] == "SA008" }
       expect(sa008.dig("partialFingerprints", "primaryLocationLineHash"))
         .not_to(eq(plain.dig("partialFingerprints", "primaryLocationLineHash")))
+    end
+
+    it("names the CVE and its nearest fix, and mints a fresh fingerprint, when a cap holds you BELOW THE FIX") do
+      below_cap = cap.merge(
+        dependency: "protobuf",
+        capped_dep_vulnerable: true,
+        capped_below_fix: true,
+        below_fix_advisory: "GHSA-7gcm-g887-7qv7",
+        below_fix_fixed_in: "5.29.6",
+      )
+      data = poison([below_cap], { poison_severity: :note, poison_security_relevant: true, poison_below_fix: true })
+      sa008 = render(result: data).dig("runs", 0, "results").find { |r| r["ruleId"] == "SA008" }
+      expect(sa008["level"]).to(eq("error"))
+      expect(sa008.dig("message", "text")).to(include("protobuf below the fix (GHSA-7gcm-g887-7qv7 fixed in 5.29.6, outside the cap)"))
+
+      # A security-relevant (patchable) finding escalating to below-the-fix mints a NEW
+      # alert, so a past dismissal of the weaker tier can't mute the stronger one.
+      patchable = poison([cap.merge(dependency: "protobuf", capped_dep_vulnerable: true)], { poison_severity: :note, poison_security_relevant: true })
+      patchable_fp = render(result: patchable).dig("runs", 0, "results").find { |r| r["ruleId"] == "SA008" }
+      expect(sa008.dig("partialFingerprints", "primaryLocationLineHash"))
+        .not_to(eq(patchable_fp.dig("partialFingerprints", "primaryLocationLineHash")))
     end
 
     it("fingerprints on gem identity, NOT on majors_behind, so a growing cap is not re-alerted every run") do

--- a/spec/still_active/terminal_helper_spec.rb
+++ b/spec/still_active/terminal_helper_spec.rb
@@ -332,6 +332,27 @@ RSpec.describe(StillActive::TerminalHelper) do
         expect(out).to(match(/\e\[31m  ↳ poison:.*⚠ pins vulnerable protobuf/))
       end
 
+      it("leads with the CVE and its nearest fix when the cap holds you BELOW THE FIX") do
+        result = {
+          "google-api-core" => poison_gem(
+            [{
+              dependency: "protobuf",
+              requirement: "< 5",
+              dep_latest: "7.0.0",
+              majors_behind: 3,
+              kind: :ceiling,
+              capped_dep_vulnerable: true,
+              capped_below_fix: true,
+              below_fix_advisory: "GHSA-7gcm-g887-7qv7",
+              below_fix_fixed_in: "5.29.6",
+            }],
+            { poison_severity: :note, poison_security_relevant: true, poison_below_fix: true },
+          ),
+        }
+        out = described_class.render(result)
+        expect(out).to(include("⚠ pins protobuf below the fix (GHSA-7gcm-g887-7qv7 fixed in 5.29.6)"))
+      end
+
       it("folds the parent into a transitive poison line and suppresses the generic transitive line") do
         result = {
           "terrapin" => poison_gem(


### PR DESCRIPTION
## What

Turns the OSV-enriched "this cap pins a vulnerable dep" signal (PR #115) into the sharper, enforced claim: **does the dead dependency's cap hold you *below the version that fixes* the CVE?**

## Why

A HIGH+ advisory whose every fixed version lands in a major the cap *forbids* is **below the fix** — you cannot patch the CVE without replacing the dormant capper. One whose fix is reachable within the cap is patchable in place. Surfacing the former *is* the demotion of the latter (the moat-bite study's core insight: the demotion of scary-but-patchable caps is as valuable as the promotion of the genuinely-stuck ones).

## How

- **`PoisonSecurityCorrelator`** classifies each security-relevant cap (class A below-the-fix / B patchable / C no-fix) and records a receipt on class A (`capped_below_fix`, `below_fix_advisory`, `below_fix_fixed_in` = nearest fix). Only a real HIGH+ scored advisory with known fixes can establish it — an unscored (fail-closed) or scored-low advisory cannot.
- **`ConstraintHelper#reachable_within_cap?`** recovers the cap's ceiling major from the finding itself (`major(dep_latest) - majors_behind`), reusing the existing major precision rather than re-parsing the raw requirement and its pre/dev-release quirks (`< 5.0.0dev`). Precision is major-level *by design*, erring toward "reachable": a within-major cap (`~> 4.2.1`) under-reports rather than over-claims — when class A *does* fire, every fix is in a strictly higher major, so the strong claim is sound.
- **Three renderers** (terminal / markdown / SARIF) lead with below-the-fix (naming the CVE and the version the cap forbids) and rank it above a merely-vulnerable cap. SARIF adds a `below_fix` fingerprint tier so a security → below-fix escalation mints a fresh alert; its non-below-fix note claims only "known-vulnerable" (no false "patchable in place", which would misdescribe a no-fix advisory).
- **OSV ecosystem map completed** (maven / go / nuget) so fixed-version filtering is precise for every ecosystem still_active resolves, not just the four it had.

## Verification

- 1069 specs green, rubocop clean. Three review gates (reviewer, silent-failure-hunter, simplifier); two silent-failure findings fixed (class-C over-claim wording; receipt now prefers a parseable fix over an epoch/garbage string).
- Dogfooded on the Sentry SBOM against live OSV: all 7 archived Google-lib cappers flag protobuf **below the fix** (`GHSA-7gcm-g887-7qv7` / CVE-2026-0994, fixed in 5.29.6, outside the `< 5` cap), while the patchable CVE-2025-4565 (fixed at 4.25.8, within cap) correctly does **not**.

Rendered terminal line:
```
↳ poison (via sentry-sdk): caps protobuf < 5.0.0dev (3 majors behind, latest 7.x)
  ⚠ pins protobuf below the fix (GHSA-7gcm-g887-7qv7 fixed in 5.29.6)
```

Design doc: `docs/superpowers/specs/2026-07-02-osv-enrichment-below-the-fix-design.md`. No release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
