### PR TITLE
fix: surface deps.dev CVE aliases (the API returns strings, not objects)

### DIFF
--- a/lib/still_active/deps_dev_client.rb
+++ b/lib/still_active/deps_dev_client.rb
@@ -107,7 +107,9 @@ module StillActive
         id: body.dig("advisoryKey", "id"),
         url: body["url"],
         title: body["title"],
-        aliases: body["aliases"]&.filter_map { |a| a["id"] } || [],
+        # deps.dev's v3alpha returns aliases as bare id strings (["CVE-..."]);
+        # tolerate the legacy object shape ({"id":...}) too since it's an alpha API.
+        aliases: Array(body["aliases"]).filter_map { |a| a.is_a?(Hash) ? a["id"] : a },
         cvss3_score: body["cvss3Score"],
         cvss3_vector: body["cvss3Vector"],
         cvss2_score: body["cvss2Score"],

--- a/spec/still_active/deps_dev_client_spec.rb
+++ b/spec/still_active/deps_dev_client_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe(StillActive::DepsDevClient) do
         "advisoryKey" => { "id" => "GHSA-test-1234" },
         "url" => "https://github.com/advisories/GHSA-test-1234",
         "title" => "Test vulnerability",
-        "aliases" => [{ "id" => "CVE-2024-1234" }],
+        "aliases" => ["CVE-2024-1234"],
         "cvss3Score" => 9.8,
         "cvss3Vector" => "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
       }
@@ -178,16 +178,32 @@ RSpec.describe(StillActive::DepsDevClient) do
       ))
     end
 
-    it("drops alias entries with no id, so aliases stays a clean string array") do
+    it("surfaces deps.dev's real string-array aliases (the live v3alpha API returns [\"CVE-...\"], not objects)") do
+      # Verified against api.deps.dev: aliases is an array of bare id strings. The
+      # previous object-shape stubs never matched reality, so every CVE alias was
+      # silently dropped and findings arrived with an empty aliases list.
       body = {
-        "advisoryKey" => { "id" => "GHSA-nullalias" },
-        "aliases" => [{ "id" => "CVE-2024-9" }, { "foo" => "bar" }, {}],
+        "advisoryKey" => { "id" => "GHSA-real-shape" },
+        "aliases" => ["CVE-2026-54906", "GHSA-xj5v-6v4g-jfw6"],
       }
       stub_request(:get, %r{api\.deps\.dev/v3alpha/advisories/}).to_return(
         status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" },
       )
 
-      expect(described_class.advisory_detail(advisory_id: "GHSA-nullalias")[:aliases]).to(eq(["CVE-2024-9"]))
+      expect(described_class.advisory_detail(advisory_id: "GHSA-real-shape")[:aliases])
+        .to(eq(["CVE-2026-54906", "GHSA-xj5v-6v4g-jfw6"]))
+    end
+
+    it("still tolerates the legacy object shape defensively (alpha API could regress)") do
+      body = {
+        "advisoryKey" => { "id" => "GHSA-nullalias" },
+        "aliases" => [{ "id" => "CVE-2024-9" }, { "foo" => "bar" }, {}, "CVE-2024-10"],
+      }
+      stub_request(:get, %r{api\.deps\.dev/v3alpha/advisories/}).to_return(
+        status: 200, body: body.to_json, headers: { "Content-Type" => "application/json" },
+      )
+
+      expect(described_class.advisory_detail(advisory_id: "GHSA-nullalias")[:aliases]).to(eq(["CVE-2024-9", "CVE-2024-10"]))
     end
 
     it("extracts cvss2_score when present") do


### PR DESCRIPTION
## What

`DepsDevClient.advisory_detail` was silently dropping every CVE alias. Advisories shipped with `aliases: []`, so consumers (and an LLM generating a risk report from `--json`) could cite the GHSA id but never the **CVE** the reader actually recognizes.

## Root cause

The code extracted each alias with `a["id"]`, assuming `body["aliases"]` was an array of objects. But the live deps.dev v3alpha API returns aliases as an array of **bare id strings** — `["CVE-2026-54906"]` — verified against the real API across several advisories. `"CVE-..."["id"]` is `nil`, so `filter_map` dropped everything.

The existing specs mocked the object shape the API never returns, so the suite stayed green while the feature was broken in production (tested the mock, not reality).

## Fix

Parse defensively — `Array(body["aliases"]).filter_map { |a| a.is_a?(Hash) ? a["id"] : a }` — keeping strings and still tolerating the legacy `{"id":...}` shape (alpha API). Specs corrected to the real string shape, plus a mixed-shape defensive test.

Lives at the shared `DepsDevClient` layer, so it reaches both the native and the cross-ecosystem `--sbom` paths.

## Verification

- TDD: RED (real string shape → `[]`) → GREEN.
- Confirmed against the live API: `GHSA-6wx8-w4f5-wwcr` now surfaces `["CVE-2026-54906"]` (was `[]`).
- Full suite + rubocop green.
