### PR TITLE
feat: read production vs dev/test scope from the SBOM (cross-ecosystem)

### DIFF
--- a/lib/still_active/sbom_reader.rb
+++ b/lib/still_active/sbom_reader.rb
@@ -53,19 +53,46 @@ module StillActive
       components = doc.is_a?(Hash) ? doc["components"] : nil
       return Result.new(dependencies: [], unassessable: []) unless components.is_a?(Array)
 
+      # Only trust the prod/dev split when the generator actually marks it
+      # somewhere (scope, or a dev property). syft-style SBOMs mark nothing, so an
+      # unmarked component is genuinely unknown -- never assume it's production.
+      # Scoped to library components: scope/properties are legal on any component
+      # type (application/file/...), and a dev signal on one of those is unrelated
+      # to whether the dependency library components are marked.
+      marks_dev = components.any? { |c| c.is_a?(Hash) && c["type"] == "library" && dev_signal?(c) }
+
       deps = []
       unassessable = []
       components.each do |component|
         kind, entry = classify(component)
+        entry[:production] = !dev_signal?(component) if kind == :dependency && marks_dev
         deps << entry if kind == :dependency
         unassessable << entry if kind == :unassessable
       end
+      # uniq collapses a package that a generator lists more than once (e.g. Syft's
+      # per-location entries); `production` is derived from each component's own
+      # signal, so duplicates of the same name+version dedup cleanly unless a
+      # generator marks the copies inconsistently (malformed; not observed).
       Result.new(dependencies: deps.uniq, unassessable: unassessable.uniq)
     rescue JSON::ParserError
       Result.new(dependencies: [], unassessable: [])
     end
 
     private
+
+    # Whether a component is marked dev/test-only. CycloneDX `scope` (excluded =
+    # not part of the product, optional = not needed at runtime) is the standard;
+    # tools that don't set scope may instead emit a property (cyclonedx-npm's
+    # `cdx:npm:package:development=true`). Absent both, this is false -- the caller
+    # only trusts a false when the document marks dev somewhere.
+    def dev_signal?(component)
+      scope = component["scope"]
+      return true if scope == "excluded" || scope == "optional"
+
+      Array(component["properties"]).any? do |p|
+        p.is_a?(Hash) && p["value"] == "true" && p["name"].to_s.match?(/(\A|:)dev(elopment)?\z/)
+      end
+    end
 
     # [:dependency, {...}] | [:unassessable, {...}] | nil (non-package noise).
     def classify(component)

--- a/spec/still_active/sbom_reader_spec.rb
+++ b/spec/still_active/sbom_reader_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe(StillActive::SbomReader) do
 
   let(:fixture) { "spec/fixtures/sbom/sample.cdx.json" }
 
+  def sbom(*components) = { "bomFormat" => "CycloneDX", "components" => components }.to_json
+
   it("extracts only the mappable library components (drops file/application, github, generic, null-purl)") do
     names = deps.map { |d| [d[:ecosystem], d[:name]] }
     expect(names).to(contain_exactly(
@@ -73,8 +75,6 @@ RSpec.describe(StillActive::SbomReader) do
   end
 
   describe("edge cases") do
-    def sbom(*components) = { "bomFormat" => "CycloneDX", "components" => components }.to_json
-
     it("classifies a package from a non-public repository_url as private (never substitutes public-registry data)") do
       # A repository_url qualifier means a non-default (private/alternative)
       # registry per the purl spec. We still never dial the URL -- we use its
@@ -123,6 +123,53 @@ RSpec.describe(StillActive::SbomReader) do
 
     it("skips an unmapped ecosystem (e.g. cocoapods/conan/swift)") do
       expect(described_class.read_string(sbom({ "type" => "library", "purl" => "pkg:cocoapods/Alamofire@5.0.0" }))).to(eq([]))
+    end
+  end
+
+  # Production vs dev/test separation. The signal is only trustworthy when the
+  # generator marks it (CycloneDX `scope: excluded/optional`, or a tool property
+  # like `cdx:npm:package:development`). syft-style SBOMs mark nothing, so we must
+  # NOT assume unmarked == production: `production` is set only when the document
+  # carries a dev signal somewhere, and left absent (unknown) otherwise.
+  describe("dev/prod scope") do
+    def lib(name, extra = {})
+      { "type" => "library", "name" => name, "purl" => "pkg:npm/#{name}@1.0.0" }.merge(extra)
+    end
+
+    it("marks a scope:excluded component as not production and unmarked siblings as production") do
+      deps = described_class.read_string(sbom(lib("jest", "scope" => "excluded"), lib("lodash")))
+      expect(deps.find { |d| d[:name] == "jest" }[:production]).to(be(false))
+      expect(deps.find { |d| d[:name] == "lodash" }[:production]).to(be(true))
+    end
+
+    it("reads the cyclonedx-npm development property as not production") do
+      body = sbom(
+        lib("jest", "properties" => [{ "name" => "cdx:npm:package:development", "value" => "true" }]),
+        lib("lodash"),
+      )
+      deps = described_class.read_string(body)
+      expect(deps.find { |d| d[:name] == "jest" }[:production]).to(be(false))
+      expect(deps.find { |d| d[:name] == "lodash" }[:production]).to(be(true))
+    end
+
+    it("treats scope:optional as not production, scope:required as production") do
+      deps = described_class.read_string(sbom(lib("opt", "scope" => "optional"), lib("req", "scope" => "required")))
+      expect(deps.find { |d| d[:name] == "opt" }[:production]).to(be(false))
+      expect(deps.find { |d| d[:name] == "req" }[:production]).to(be(true))
+    end
+
+    it("leaves production unknown (key absent) when the SBOM marks nothing (e.g. syft)") do
+      dep = described_class.read_string(sbom(lib("lodash"))).first
+      expect(dep).not_to(have_key(:production))
+    end
+
+    it("ignores dev signals on NON-library components (an excluded app/file must not flip every dep to production)") do
+      # scope/properties are legal on any component type; a self-`application`
+      # marked excluded must not be read as "this SBOM marks dev" and silently
+      # promote every unmarked library to production.
+      body = sbom({ "type" => "application", "name" => "self", "scope" => "excluded" }, lib("lodash"))
+      dep = described_class.read_string(body).find { |d| d[:name] == "lodash" }
+      expect(dep).not_to(have_key(:production))
     end
   end
 end


### PR DESCRIPTION
## What

`SbomReader` now extracts a **production vs dev/test** signal per dependency, cross-ecosystem, so a downstream report can separate production risk from test-only debt (the PoC's #1 CTO-value gap).

## Why it was missing

Neither input carried it: the Ruby lockfile has no groups, and a **syft** SBOM drops dev deps *unlabeled* (verified — it excludes `jest`, sets no `scope`). The signal lives in the SBOM only when the generator marks it: the CycloneDX standard uses `component.scope` (`excluded`/`optional`), and `@cyclonedx/cyclonedx-npm` emits a `cdx:npm:package:development=true` property (verified: `jest` labelled dev, `lodash` not).

## How

- `dev_signal?` reads `scope: excluded/optional` **or** a `*:development` property.
- **Document-aware:** `production` is set only when the SBOM marks dev *somewhere*. So an unmarked component is honestly **unknown** (key absent) — never falsely assumed production (the syft case). Where a generator marks dev, unmarked components are production, per the CycloneDX `required` default.
- Added only when determinable, so existing exact-match reader tests are untouched.

## Verification

- TDD (scope:excluded, dev property, scope:optional/required, unknown-when-unmarked).
- Verified against a real `@cyclonedx/cyclonedx-npm` SBOM: `jest → production:false`, `lodash → production:true`.
- Full suite + rubocop green.

Read side only; threading `production` into the emitted output is the immediate follow-up PR.
