### PR TITLE
fix: ignore downgrade fixes so multi-range advisories don't hide a stuck cap

### DIFF
--- a/lib/still_active/poison_security_correlator.rb
+++ b/lib/still_active/poison_security_correlator.rb
@@ -32,14 +32,17 @@ module StillActive
     BELOW_FIX_LABELS = ["high", "critical"].freeze
 
     def correlate(result_object)
-      # Ecosystem-qualified map of each tree package's advisories. A capped dep
-      # resolves in its capper's ecosystem, so match "ecosystem/name" on both
-      # sides; native results carry no :ecosystem (nil on both) and still match.
+      # Ecosystem-qualified map of each tree package's advisories AND the version
+      # it's pinned at. A capped dep resolves in its capper's ecosystem, so match
+      # "ecosystem/name" on both sides; native results carry no :ecosystem (nil on
+      # both) and still match. The used version is kept so "below the fix" ignores
+      # fixes that land BELOW it: an OSV advisory lists a fix per affected range, and
+      # a fix for an older line is a downgrade, not a patch for the version in hand.
       advisories = result_object.each_with_object({}) do |(key, data), map|
         next unless data[:vulnerability_count].to_i.positive?
 
         name = data[:name] || key
-        map["#{data[:ecosystem]}/#{name}"] = data[:vulnerabilities] || []
+        map["#{data[:ecosystem]}/#{name}"] = { vulns: data[:vulnerabilities] || [], used_version: data[:version_used] }
       end
 
       result_object.each_value do |data|
@@ -48,12 +51,14 @@ module StillActive
 
         eco = data[:ecosystem]
         constraints.each do |constraint|
-          vulns = advisories["#{eco}/#{constraint[:dependency]}"]
-          next if vulns.nil?
+          entry = advisories["#{eco}/#{constraint[:dependency]}"]
+          next if entry.nil?
+
+          vulns = entry[:vulns]
           next unless VulnerabilityHelper.severity_at_or_above?(vulns, SECURITY_THRESHOLD)
 
           constraint[:capped_dep_vulnerable] = true
-          mark_below_fix(constraint, vulns)
+          mark_below_fix(constraint, vulns, entry[:used_version])
         end
         data[:poison_security_relevant] = true if constraints.any? { |c| c[:capped_dep_vulnerable] }
         data[:poison_below_fix] = true if constraints.any? { |c| c[:capped_below_fix] }
@@ -67,9 +72,9 @@ module StillActive
     # lands outside the cap (a major it forbids) -- you cannot patch the CVE without
     # replacing the dormant capper. The receipt names the advisory and its nearest
     # fix (the lowest fixed version, all of which are outside the cap).
-    def mark_below_fix(constraint, vulns)
+    def mark_below_fix(constraint, vulns, used_version)
       stuck = vulns.select do |vuln|
-        fixes = Array(vuln[:fixed_versions])
+        fixes = applicable_fixes(vuln, used_version)
         next false if fixes.empty?
         next false unless BELOW_FIX_LABELS.include?(VulnerabilityHelper.advisory_severity(vuln))
 
@@ -77,18 +82,31 @@ module StillActive
       end
       return if stuck.empty?
 
-      receipt = stuck.min_by { |vuln| gem_version(nearest_fix(vuln)) }
+      receipt = stuck.min_by { |vuln| gem_version(nearest_fix(vuln, used_version)) }
       constraint[:capped_below_fix] = true
       constraint[:below_fix_advisory] = receipt[:id]
-      constraint[:below_fix_fixed_in] = nearest_fix(receipt)
+      constraint[:below_fix_fixed_in] = nearest_fix(receipt, used_version)
     end
 
-    # The lowest fixed version, for the "fixed in X" receipt. A parseable version
-    # always beats an unparseable one (PyPI epoch `1!2.3.4`, or garbage), so the
-    # receipt never names an odd string when a clean fix is present; only when EVERY
-    # fix is unparseable does it fall back to one of those.
-    def nearest_fix(vuln)
-      Array(vuln[:fixed_versions]).min_by { |fix| [Gem::Version.correct?(fix.to_s) ? 0 : 1, gem_version(fix)] }
+    # An advisory lists a fixed version per affected range; only fixes ABOVE the
+    # version in hand are real remediation. A fix at or below it belongs to an older
+    # release line (a downgrade), so it neither patches this version nor counts as
+    # "reachable within the cap". With no known used version (older data), all fixes
+    # are kept -- the pre-existing behaviour, never fewer findings than before.
+    def applicable_fixes(vuln, used_version)
+      fixes = Array(vuln[:fixed_versions])
+      return fixes if used_version.nil? || !Gem::Version.correct?(used_version.to_s)
+
+      used = gem_version(used_version)
+      fixes.select { |fix| !Gem::Version.correct?(fix.to_s) || gem_version(fix) > used }
+    end
+
+    # The lowest applicable fixed version, for the "fixed in X" receipt. A parseable
+    # version always beats an unparseable one (PyPI epoch `1!2.3.4`, or garbage), so
+    # the receipt never names an odd string when a clean fix is present; only when
+    # EVERY fix is unparseable does it fall back to one of those.
+    def nearest_fix(vuln, used_version)
+      applicable_fixes(vuln, used_version).min_by { |fix| [Gem::Version.correct?(fix.to_s) ? 0 : 1, gem_version(fix)] }
     end
 
     # A version key that sorts fix strings without raising; an unparseable version

--- a/spec/still_active/poison_security_correlator_spec.rb
+++ b/spec/still_active/poison_security_correlator_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe(StillActive::PoisonSecurityCorrelator) do
         "pypi/protobuf@4.21.6" => {
           ecosystem: :pypi,
           name: "protobuf",
+          version_used: "4.21.6",
           vulnerability_count: 1,
           vulnerabilities: [advisory.merge(fixed_versions: fixed_versions, source: "deps.dev")],
         },
@@ -131,6 +132,27 @@ RSpec.describe(StillActive::PoisonSecurityCorrelator) do
       result = sentry_result(["5.29.6"], advisory: { id: "CVE-2026-0994", cvss3_score: 0, osv_severity: "HIGH" })
       described_class.correlate(result)
       expect(result["pypi/google-api-core@1.0.0"][:constraints].first[:capped_below_fix]).to(be(true))
+    end
+
+    it "ignores a downgrade fix from another release line (multi-range advisory), so a real below-the-fix cap still fires" do
+      # OSV lists a fix per affected range: the used 4.21.6 is fixed by 5.29.6, but an
+      # OLDER line (< 4) was fixed at 3.19.6. A downgrade to 3.19.6 does not patch
+      # 4.21.6 -- it's a different, lower branch -- yet it sits within the `< 5` cap.
+      # Reading it as "patchable in place" would false-negative a genuine stuck cap.
+      result = sentry_result(["3.19.6", "5.29.6"])
+      described_class.correlate(result)
+      constraint = result["pypi/google-api-core@1.0.0"][:constraints].first
+      expect(constraint[:capped_below_fix]).to(be(true))
+      expect(constraint[:below_fix_fixed_in]).to(eq("5.29.6")) # the applicable fix, never the downgrade
+    end
+
+    it "names the applicable fix in the receipt, not a lower-line downgrade" do
+      # Both 5.29.6 and 6.33.5 are outside the cap and above the used 4.21.6, but a
+      # 3.19.6 fix for an older line must never be chosen as 'fixed in': it's below
+      # the version we're on, so naming it would tell the user to downgrade.
+      result = sentry_result(["3.19.6", "6.33.5", "5.29.6"])
+      described_class.correlate(result)
+      expect(result["pypi/google-api-core@1.0.0"][:constraints].first[:below_fix_fixed_in]).to(eq("5.29.6"))
     end
 
     it "names a clean fix in the receipt, never an epoch/garbage version when a parseable one exists" do


### PR DESCRIPTION
## What

The "below the fix" security signal now ignores fixed versions that sit **below** the version in hand, so a multi-range advisory can't hide (or misdescribe) a genuinely stuck poison cap.

## Why

The signal asks: does a dormant package's constraint hold a dependency below the version that patches a HIGH+ advisory? An OSV advisory lists a fixed version **per affected range**, so a CVE affecting the pinned version (e.g. `protobuf 4.21.6`, fixed `5.29.6`) can also carry a fix for an **older** release line (`3.19.6`). The old code fed the global-minimum fixed version into the cap check, with two failure modes:

- **False negative on the decision** — `3.19.6` satisfies a `< 5` cap, so it read as "patchable in place" and suppressed a genuinely stuck cap. But downgrading to `3.19.6` doesn't patch `4.21.6`; it's a different, lower branch.
- **Misleading receipt** — `below_fix_fixed_in` could name `3.19.6`, telling the user to downgrade instead of pointing at the real fix.

This is in the **live pypi/rubygems path**, independent of the npm/cargo extension it was found alongside.

## How

Thread the capped dep's `version_used` through the advisories map and add `applicable_fixes(vuln, used_version)`, which keeps only fixes strictly above it — a downgrade is never a remediation. When the used version is unknown or unparseable, **all** fixes are kept, so this never yields fewer findings than before (backward-safe).

## Provenance & verification

Surfaced while PoC-validating (against real deps.dev/OSV data) whether the below-the-fix signal can extend to npm/cargo. The `qs@6.7.0` advisory `GHSA-hrpp-h998-j3pp` was the receipt: its `fixed_versions` include `6.2.4`, a downgrade relative to `6.7.0`.

Verified by unit tests covering the exact multi-range scenarios (downgrade-inside-cap still fires; receipt names the applicable fix, never the downgrade; nil/epoch fallbacks preserved), plus adversarial review confirming the nil-used-version path never produces fewer findings than before. Honest limit: not exercised by a live run — the trigger (a specific multi-range OSV advisory under a dormant capper) isn't reliably reproducible on demand, so coverage is the unit tests + review, not an end-to-end invocation. Full suite (1094 examples) + rubocop green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
