### PR TITLE
feat: extend below-the-fix to npm/cargo (patch-precision + tree-copy guard)

### DIFF
--- a/lib/still_active/ecosystem_lens.rb
+++ b/lib/still_active/ecosystem_lens.rb
@@ -140,17 +140,33 @@ module StillActive
       RuntimeCeilingHelper.analyze(requirement: latest_requirement, support_window: python_range).nil?
     end
 
-    # Poison-pill enrichment for the cross-ecosystem path, mirroring the native
-    # Bundler path: gated on dormancy so a maintained package is never flagged,
-    # each finding carrying its receipt. Resolves a capped dep's latest via
-    # deps.dev in the SAME ecosystem (a runtime dep of an npm package is npm).
+    # Constraint enrichment for the cross-ecosystem path, gated on dormancy so a
+    # maintained package is never flagged. Two shapes by ecosystem:
+    #
+    # FLAT (rubygems/pypi): the poison-pill signal as-is -- a below-latest cap holds
+    # the whole tree hostage, so it renders directly (`constraints` + `poison`).
+    #
+    # NESTED (npm/cargo): the pure below-latest cap is subtree-local noise (nested
+    # copies, caret default), so no poison here. Instead keep every declared dep as a
+    # security CANDIDATE (`capped_deps`); the correlator, which alone sees the tree's
+    # resolved versions and advisories, promotes only the ones that pin a vulnerable
+    # copy below its fix. Candidates are NOT filtered to below-latest-major (npm/cargo
+    # fixes are mostly same-major patch bumps that filter would miss) and need no
+    # dep_latest fetch (the wall test is patch-precise on the requirement itself).
     def attach_constraints(gem_data, ecosystem:, name:, version:, cache:)
       registry = ECOSYSTEM_REGISTRIES[ecosystem]
       return if registry.nil?
-      return unless FLAT_RESOLUTION_ECOSYSTEMS.include?(ecosystem)
       return unless [:critical, :archived].include?(ActivityHelper.activity_level(gem_data))
 
       declared = EcosystemsClient.declared_dependencies(name: name, version: version, registry: registry)
+      if FLAT_RESOLUTION_ECOSYSTEMS.include?(ecosystem)
+        attach_flat_poison(gem_data, ecosystem, declared, cache)
+      else
+        attach_nested_candidates(gem_data, declared)
+      end
+    end
+
+    def attach_flat_poison(gem_data, ecosystem, declared, cache)
       findings = ConstraintHelper.poison_findings(declared) do |dep_name|
         latest_version_for(ecosystem, dep_name, cache)
       end
@@ -159,6 +175,15 @@ module StillActive
       gem_data[:constraints] = findings
       gem_data[:poison] = findings.any? { |finding| finding[:kind] == :ceiling }
       gem_data[:poison_severity] = ConstraintHelper.worst_severity(findings) if gem_data[:poison]
+    end
+
+    def attach_nested_candidates(gem_data, declared)
+      candidates = declared.filter_map do |dep|
+        next if dep[:package_name].to_s.empty? || dep[:requirements].to_s.empty?
+
+        { dependency: dep[:package_name], requirement: dep[:requirements] }
+      end
+      gem_data[:capped_deps] = candidates unless candidates.empty?
     end
 
     # A capped dep's current latest version in `ecosystem`, via deps.dev's default

--- a/lib/still_active/poison_security_correlator.rb
+++ b/lib/still_active/poison_security_correlator.rb
@@ -2,6 +2,7 @@
 
 require_relative "../helpers/vulnerability_helper"
 require_relative "../helpers/constraint_helper"
+require_relative "../helpers/semver_satisfaction"
 
 module StillActive
   # Whole-tree correlation, run once after the fan-out: a poison cap is far more
@@ -32,40 +33,141 @@ module StillActive
     BELOW_FIX_LABELS = ["high", "critical"].freeze
 
     def correlate(result_object)
-      # Ecosystem-qualified map of each tree package's advisories AND the version
-      # it's pinned at. A capped dep resolves in its capper's ecosystem, so match
-      # "ecosystem/name" on both sides; native results carry no :ecosystem (nil on
-      # both) and still match. The used version is kept so "below the fix" ignores
-      # fixes that land BELOW it: an OSV advisory lists a fix per affected range, and
-      # a fix for an older line is a downgrade, not a patch for the version in hand.
-      advisories = result_object.each_with_object({}) do |(key, data), map|
-        next unless data[:vulnerability_count].to_i.positive?
-
-        name = data[:name] || key
-        map["#{data[:ecosystem]}/#{name}"] = { vulns: data[:vulnerabilities] || [], used_version: data[:version_used] }
-      end
+      advisories = flat_advisories(result_object)
+      copies = copy_index(result_object)
 
       result_object.each_value do |data|
+        # FLAT (rubygems/pypi): mark below-fix on the poison caps already attached.
+        mark_flat_constraints(data, advisories)
+        # NESTED (npm/cargo): promote a genuine below-fix candidate into :constraints.
+        promote_nested_below_fix(data, copies) if data[:capped_deps]
+
         constraints = data[:constraints]
         next if constraints.nil? || constraints.empty?
 
-        eco = data[:ecosystem]
-        constraints.each do |constraint|
-          entry = advisories["#{eco}/#{constraint[:dependency]}"]
-          next if entry.nil?
-
-          vulns = entry[:vulns]
-          next unless VulnerabilityHelper.severity_at_or_above?(vulns, SECURITY_THRESHOLD)
-
-          constraint[:capped_dep_vulnerable] = true
-          mark_below_fix(constraint, vulns, entry[:used_version])
-        end
         data[:poison_security_relevant] = true if constraints.any? { |c| c[:capped_dep_vulnerable] }
         data[:poison_below_fix] = true if constraints.any? { |c| c[:capped_below_fix] }
       end
     end
 
     private
+
+    # Ecosystem-qualified map of each tree package's advisories AND the version it's
+    # pinned at, for the FLAT path (one resolved version per name). A capped dep
+    # resolves in its capper's ecosystem, so match "ecosystem/name" on both sides;
+    # native results carry no :ecosystem (nil on both) and still match. The used
+    # version is kept so "below the fix" ignores fixes that land BELOW it: an OSV
+    # advisory lists a fix per affected range, and a fix for an older line is a
+    # downgrade, not a patch for the version in hand.
+    def flat_advisories(result_object)
+      result_object.each_with_object({}) do |(key, data), map|
+        next unless data[:vulnerability_count].to_i.positive?
+
+        name = data[:name] || key
+        map["#{data[:ecosystem]}/#{name}"] = { vulns: data[:vulnerabilities] || [], used_version: data[:version_used] }
+      end
+    end
+
+    # Every RESOLVED copy of each package, keyed "ecosystem/name", for the NESTED
+    # path: npm nests versions and cargo coexists majors, so one name maps to several
+    # copies. The full set (vulnerable AND not) is what the condition-5 soundness
+    # guard needs -- "is there a SAFE copy within the cap" can't be answered from the
+    # vulnerable copies alone.
+    def copy_index(result_object)
+      result_object.each_with_object({}) do |(key, data), map|
+        name = data[:name] || key
+        (map["#{data[:ecosystem]}/#{name}"] ||= []) << { version: data[:version_used], vulns: data[:vulnerabilities] || [] }
+      end
+    end
+
+    def mark_flat_constraints(data, advisories)
+      constraints = data[:constraints]
+      return if constraints.nil? || constraints.empty?
+
+      eco = data[:ecosystem]
+      constraints.each do |constraint|
+        entry = advisories["#{eco}/#{constraint[:dependency]}"]
+        next if entry.nil?
+
+        vulns = entry[:vulns]
+        next unless VulnerabilityHelper.severity_at_or_above?(vulns, SECURITY_THRESHOLD)
+
+        constraint[:capped_dep_vulnerable] = true
+        mark_below_fix(constraint, vulns, entry[:used_version])
+      end
+    end
+
+    # NESTED below-the-fix (npm/cargo). The pure poison cap is suppressed for these
+    # ecosystems (caret default + nested copies over-claim), so a candidate is
+    # promoted ONLY when it genuinely holds a vulnerable copy below its fix, checked
+    # at PATCH precision. When one is, it takes the same shape the flat path renders,
+    # and :poison is set here (the only npm/cargo poison there is is a below-fix).
+    def promote_nested_below_fix(data, copies)
+      eco = data[:ecosystem]
+      # Consume the candidates: they are an internal work-list, never serialized.
+      promoted = data.delete(:capped_deps).filter_map do |candidate|
+        dep_copies = copies["#{eco}/#{candidate[:dependency]}"] || []
+        nested_below_fix(eco, candidate[:dependency], candidate[:requirement], dep_copies)
+      end
+      return if promoted.empty?
+
+      data[:constraints] = promoted
+      data[:poison] = true
+      data[:poison_severity] = :critical
+    end
+
+    # A below-fix finding for one capped dep, or nil. The claim holds only when
+    # EVERY resolved copy the constraint governs is vulnerable to the same HIGH+
+    # advisory (condition 5: no safe in-constraint copy to resolve to), AND no fix
+    # of that advisory satisfies the constraint (the wall, at patch precision). A
+    # patched copy sitting OUTSIDE the constraint elsewhere in the tree is irrelevant
+    # -- it can't lift the copy this capper pins -- so it never enters this view.
+    def nested_below_fix(ecosystem, dependency, requirement, dep_copies)
+      in_constraint = dep_copies.select { |copy| satisfies?(requirement, copy[:version], ecosystem) }
+      return if in_constraint.empty?
+
+      oldest = in_constraint.map { |copy| copy[:version] }.min_by { |version| gem_version(version) }
+      stuck = candidate_advisories(in_constraint).select do |advisory|
+        walls?(requirement, advisory, ecosystem, oldest) && every_copy_affected?(in_constraint, advisory)
+      end
+      return if stuck.empty?
+
+      receipt = stuck.min_by { |advisory| gem_version(nearest_fix(advisory, oldest)) }
+      {
+        dependency: dependency,
+        requirement: requirement,
+        capped_dep_vulnerable: true,
+        capped_below_fix: true,
+        below_fix_advisory: receipt[:id],
+        below_fix_fixed_in: nearest_fix(receipt, oldest),
+      }
+    end
+
+    def satisfies?(requirement, version, ecosystem)
+      SemverSatisfaction.evaluate(requirement: requirement, version: version, ecosystem: ecosystem) == true
+    end
+
+    # HIGH+ advisories with a known fix, deduped by id, across the in-constraint copies.
+    def candidate_advisories(copies)
+      copies.flat_map { |copy| copy[:vulns] }
+        .select { |vuln| BELOW_FIX_LABELS.include?(VulnerabilityHelper.advisory_severity(vuln)) && Array(vuln[:fixed_versions]).any? }
+        .uniq { |vuln| vuln[:id] }
+    end
+
+    # The wall: NO applicable fix satisfies the constraint at patch precision. Every
+    # fix must be a DEFINITE non-match (evaluate == false); an undecidable fix (nil,
+    # unparseable) blocks the claim rather than counting as unreachable, so we never
+    # fabricate a wall from input we couldn't parse.
+    def walls?(requirement, advisory, ecosystem, oldest_affected)
+      fixes = applicable_fixes(advisory, oldest_affected)
+      fixes.any? && fixes.all? { |fix| SemverSatisfaction.evaluate(requirement: requirement, version: fix, ecosystem: ecosystem) == false }
+    end
+
+    # Condition 5: every governed copy is vulnerable to THIS advisory (none is a safe
+    # version you could resolve to within the cap).
+    def every_copy_affected?(copies, advisory)
+      copies.all? { |copy| copy[:vulns].any? { |vuln| vuln[:id] == advisory[:id] } }
+    end
 
     # The sharper claim on a security-relevant cap: does it hold you BELOW THE FIX?
     # A HIGH+ advisory with a known fix establishes it only when EVERY fixed version

--- a/spec/still_active/ecosystem_lens_spec.rb
+++ b/spec/still_active/ecosystem_lens_spec.rb
@@ -287,18 +287,32 @@ RSpec.describe(StillActive::EcosystemLens) do
       ]))
     end
 
-    it("suppresses poison on subtree-local ecosystems (npm/cargo): a transitive cap pins a duplicate copy, it does not hold the tree hostage") do
-      # npm nests versions and cargo coexists majors, so a below-latest cap is
-      # subtree-local, not a tree-wide block; the blocking case (peerDependencies)
-      # isn't visible in ecosyste.ms data. Suppress rather than over-claim.
+    it("keeps a dormant npm/cargo package's declared deps as security CANDIDATES, not rendered poison") do
+      # npm nests versions and cargo coexists majors, so the pure below-latest cap is
+      # subtree-local noise (caret is the default): the `poison`/`constraints` signal
+      # stays suppressed. But we keep every declared dep as a `capped_deps` CANDIDATE
+      # for the security below-the-fix path -- the correlator alone sees the tree's
+      # resolved versions + advisories and promotes only the ones pinning a vulnerable
+      # copy below its fix. No dep_latest fetch here: the wall test is patch-precise.
       stub_latest("oldpkg" => "2017-01-01T00:00:00Z")
       allow(StillActive::EcosystemsClient).to(receive(:declared_dependencies))
+        .and_return([{ package_name: "vulndep", requirements: "^1.2.0" }])
 
       [:npm, :cargo].each do |eco|
         result = described_class.assess(ecosystem: eco, name: "oldpkg", version: "1.0.0")
         expect(result).not_to(have_key(:poison))
         expect(result).not_to(have_key(:constraints))
+        expect(result[:capped_deps]).to(eq([{ dependency: "vulndep", requirement: "^1.2.0" }]))
       end
+    end
+
+    it("does not fetch or attach candidates for a MAINTAINED npm package (dormancy-gated)") do
+      stub_latest("fresh" => "2026-05-01T00:00:00Z")
+      allow(StillActive::EcosystemsClient).to(receive(:declared_dependencies))
+
+      result = described_class.assess(ecosystem: :npm, name: "fresh", version: "1.0.0")
+
+      expect(result).not_to(have_key(:capped_deps))
       expect(StillActive::EcosystemsClient).not_to(have_received(:declared_dependencies))
     end
 

--- a/spec/still_active/poison_security_correlator_spec.rb
+++ b/spec/still_active/poison_security_correlator_spec.rb
@@ -165,4 +165,145 @@ RSpec.describe(StillActive::PoisonSecurityCorrelator) do
       expect(result["pypi/google-api-core@1.0.0"][:constraints].first[:below_fix_fixed_in]).to(eq("5.29.6"))
     end
   end
+
+  describe ".correlate npm/cargo below the fix (nested, patch-precision)" do
+    def high(id, fixed_versions)
+      { id: id, cvss3_score: 8.1, fixed_versions: fixed_versions, source: "osv" }
+    end
+
+    # A dormant npm capper declaring `requirement` on `dep`, plus one tree entry per
+    # resolved copy of `dep` (each with its own version-specific advisories). Mirrors
+    # what SbomWorkflow assembles: keys ecosystem/name@version, capped_deps candidates
+    # attached by the lens, resolved copies as sibling entries.
+    def nested_result(requirement:, copies:, eco: :npm)
+      result = {
+        "#{eco}/capper@1.0.0" => {
+          ecosystem: eco,
+          name: "capper",
+          capped_deps: [{ dependency: "dep", requirement: requirement }],
+        },
+      }
+      copies.each do |version, vulns|
+        result["#{eco}/dep@#{version}"] = {
+          ecosystem: eco,
+          name: "dep",
+          version_used: version,
+          vulnerability_count: vulns.length,
+          vulnerabilities: vulns,
+        }
+      end
+      result
+    end
+
+    it "flags a same-major patch wall a coexisting patched copy does NOT clear (the braces case)" do
+      # capper caps dep `^2.3.1`; the tree carries the vulnerable 2.3.2 AND a patched
+      # 3.0.3 elsewhere. The patched copy is OUTSIDE the caret, so it can't lift 2.3.2;
+      # the tree still ships the vulnerable copy. A coexistence filter would wrongly
+      # suppress this -- patch-precision + the in-constraint view is what gets it right.
+      result = nested_result(requirement: "^2.3.1", copies: [
+        ["2.3.2", [high("GHSA-braces", ["3.0.3"])]],
+        ["3.0.3", []],
+      ])
+      described_class.correlate(result)
+
+      capper = result["npm/capper@1.0.0"]
+      expect(capper[:poison]).to(be(true))
+      expect(capper[:poison_below_fix]).to(be(true))
+      constraint = capper[:constraints].first
+      expect(constraint).to(include(dependency: "dep", capped_below_fix: true, below_fix_advisory: "GHSA-braces", below_fix_fixed_in: "3.0.3"))
+    end
+
+    it "suppresses the flag when a SAFE in-constraint copy exists (condition 5)" do
+      # capper caps dep `^1.0.0`; the tree carries a vulnerable 1.7.0 but ALSO a safe
+      # 1.2.0 that satisfies the same constraint. You are not stuck: resolving to 1.2.0
+      # is possible within the cap, so the capper doesn't force a vulnerable version.
+      result = nested_result(requirement: "^1.0.0", copies: [
+        ["1.2.0", []],
+        ["1.7.0", [high("GHSA-y", ["2.0.0"])]],
+      ])
+      described_class.correlate(result)
+
+      capper = result["npm/capper@1.0.0"]
+      expect(capper).not_to(have_key(:poison))
+      expect(capper).not_to(have_key(:constraints))
+    end
+
+    it "does NOT flag when a fix is reachable within the constraint at patch precision" do
+      # Fix 1.5.0 satisfies `^1.0.0`, so the CVE is patchable in place without touching
+      # the capper -- not below the fix. (Major precision would agree here; the point is
+      # the patch-precision path returns the right answer.)
+      result = nested_result(requirement: "^1.0.0", copies: [
+        ["1.2.0", [high("GHSA-z", ["1.5.0"])]],
+      ])
+      described_class.correlate(result)
+
+      capper = result["npm/capper@1.0.0"]
+      expect(capper).not_to(have_key(:poison))
+      expect(capper).not_to(have_key(:constraints))
+    end
+
+    it "flags a same-major patch wall major precision would MISS (tilde caps below a patch fix)" do
+      # `~1.2.0` = [1.2.0, 1.3.0); the fix 1.3.0 is a same-major patch bump OUTSIDE it.
+      # The old major-precision reachable check reads 1.3.0 as reachable (same major) and
+      # misses this; patch precision catches it -- the case the PoC said dominates npm.
+      result = nested_result(requirement: "~1.2.0", copies: [
+        ["1.2.5", [high("GHSA-tilde", ["1.3.0"])]],
+      ])
+      described_class.correlate(result)
+
+      capper = result["npm/capper@1.0.0"]
+      expect(capper[:poison_below_fix]).to(be(true))
+      expect(capper[:constraints].first).to(include(below_fix_advisory: "GHSA-tilde", below_fix_fixed_in: "1.3.0"))
+    end
+
+    it "applies the cargo bare-version caret when deciding reachability" do
+      # cargo `0.10.38` is a caret [0.10.38, 0.11.0). Fix 0.11.0 is outside -> below fix.
+      result = nested_result(eco: :cargo, requirement: "0.10.38", copies: [
+        ["0.10.39", [high("RUSTSEC-x", ["0.11.0"])]],
+      ])
+      described_class.correlate(result)
+
+      expect(result["cargo/capper@1.0.0"][:poison_below_fix]).to(be(true))
+      expect(result["cargo/capper@1.0.0"][:constraints].first[:below_fix_fixed_in]).to(eq("0.11.0"))
+    end
+
+    it "does not flag on a low/medium advisory (only HIGH+ establishes below-the-fix)" do
+      result = nested_result(requirement: "^1.0.0", copies: [
+        ["1.2.0", [{ id: "GHSA-low", cvss3_score: 4.2, fixed_versions: ["2.0.0"], source: "osv" }]],
+      ])
+      described_class.correlate(result)
+
+      expect(result["npm/capper@1.0.0"]).not_to(have_key(:poison))
+    end
+
+    it "stays silent when the constraint is unparseable (never a false wall)" do
+      result = nested_result(requirement: "not-a-range", copies: [
+        ["1.2.0", [high("GHSA-x", ["2.0.0"])]],
+      ])
+      described_class.correlate(result)
+
+      expect(result["npm/capper@1.0.0"]).not_to(have_key(:poison))
+    end
+
+    it "does not flag when the advisory has no known fix (no wall to establish)" do
+      result = nested_result(requirement: "^1.0.0", copies: [
+        ["1.2.0", [high("GHSA-nofix", [])]],
+      ])
+      described_class.correlate(result)
+
+      expect(result["npm/capper@1.0.0"]).not_to(have_key(:poison))
+    end
+
+    it "consumes the internal :capped_deps work-list so it never leaks into the JSON output" do
+      # capped_deps is an internal candidate list; whether or not it promotes, it must
+      # be gone after correlation (emit_sbom_json serializes the raw data hash).
+      flagged = nested_result(requirement: "^2.3.1", copies: [["2.3.2", [high("GHSA-x", ["3.0.3"])]]])
+      unflagged = nested_result(requirement: "^1.0.0", copies: [["1.2.0", []]])
+      described_class.correlate(flagged)
+      described_class.correlate(unflagged)
+
+      expect(flagged["npm/capper@1.0.0"]).not_to(have_key(:capped_deps))
+      expect(unflagged["npm/capper@1.0.0"]).not_to(have_key(:capped_deps))
+    end
+  end
 end

--- a/spec/still_active/poison_security_correlator_spec.rb
+++ b/spec/still_active/poison_security_correlator_spec.rb
@@ -294,6 +294,20 @@ RSpec.describe(StillActive::PoisonSecurityCorrelator) do
       expect(result["npm/capper@1.0.0"]).not_to(have_key(:poison))
     end
 
+    it "does not fabricate a flag on a cargo PARTIAL-bare cap when a safe higher copy satisfies it" do
+      # Regression for the partial-bare caret: cargo `1.2` = ^1.2 = [1.2.0, 2.0.0), so
+      # the safe 1.9.0 both satisfies the constraint and is a reachable fix. A shim that
+      # read `1.2` as the narrow 1.2.x would drop 1.9.0, wall it, and fabricate a
+      # below-fix. The correct caret + condition 5 keep it silent.
+      result = nested_result(eco: :cargo, requirement: "1.2", copies: [
+        ["1.2.1", [high("RUSTSEC-y", ["1.9.0"])]],
+        ["1.9.0", []],
+      ])
+      described_class.correlate(result)
+
+      expect(result["cargo/capper@1.0.0"]).not_to(have_key(:poison))
+    end
+
     it "consumes the internal :capped_deps work-list so it never leaks into the JSON output" do
       # capped_deps is an internal candidate list; whether or not it promotes, it must
       # be gone after correlation (emit_sbom_json serializes the raw data hash).


### PR DESCRIPTION
## What

Extends the **below-the-fix** security signal (a dormant package pins a dependency below the version that patches a HIGH+ advisory) to **npm and cargo**. Until now it was flat-ecosystem-only (rubygems/pypi). Builds on the semver primitive from #123 (merged).

## Why npm/cargo needed more than the flat path

A PoC against real deps.dev/OSV data showed two gaps:
- **Patch precision.** npm/cargo CVE fixes are overwhelmingly *same-major patch bumps* (`~1.2.0` → `1.3.0`), which the flat path's major-level reachability check is blind to. The PoC found the flat logic near-inert on npm/cargo.
- **Multi-copy trees.** Nested resolution keeps several versions of one dep, so a below-latest cap can be *subtree-local* rather than a tree-wide block. The naive "coexistence filter" (suppress if a patched copy exists anywhere) *false-negatives* — a patched copy elsewhere can't lift the copy a dormant parent actually pins.

## How

- **`ecosystem_lens`** — for a dormant npm/cargo package, attach every declared dep as a private `capped_deps` **candidate** (no `poison`; the pure below-latest cap is caret-default noise there). No `dep_latest` fetch — the wall test is patch-precise on the requirement itself.
- **`poison_security_correlator`** — builds a multi-copy index (all resolved versions per `ecosystem/name`) and *promotes* a candidate to a rendered below-fix finding only when **both**:
  1. **Wall** — no applicable fix of a HIGH+ advisory satisfies the constraint at patch precision (`SemverSatisfaction`), and
  2. **Condition 5** — *every* resolved copy the constraint governs is vulnerable (a safe in-constraint copy elsewhere means you're not stuck).

  A patched copy *outside* the constraint is irrelevant and never enters the view — that's the coexistence-filter false-negative, avoided. The private `capped_deps` work-list is consumed (deleted) so it never serializes.

The flat **rubygems/pypi path is unchanged**: a single resolved copy makes condition 5 a no-op, and the wall stays major-precision on PEP 440 / Gem grammar (which `SemverSatisfaction` doesn't model).

## Verification

**Real end-to-end** (`bundle exec still_active --sbom`): archived `request@2.88.2` pins `form-data ~2.3.2`, flagged below the fix for **GHSA-fjxv-7rqg-78g4 (CRITICAL, CVE-2025-7783)**, `fixed_in: 2.5.4` — the applicable 2.x-line fix, not the higher-line 3.0.4/4.0.4 (multi-range handling).

An adversarial review caught a false-positive path (a cargo partial-bare `1.2` cap misread as the narrow `1.2.x`); fixed in #123 and pinned here by a correlator regression test. Unit tests cover the braces coexistence TP, the condition-5 safe-copy suppression, wall-reachable suppression, the tilde same-major patch wall major precision misses, undecidable input, and no-fix / low-severity cases. Full suite (1123) + rubocop green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
