### PR TITLE
fix: post-validation hardening (unresolved versions, git-URL parsing, CLI errors)

### DIFF
--- a/lib/helpers/status_helper.rb
+++ b/lib/helpers/status_helper.rb
@@ -24,6 +24,14 @@ module StillActive
     # Returns :dead, :vulnerable, :archived, :legacy, :stale, :ok, or :unknown.
     def gem_status(gem_data)
       vulnerable = gem_data[:vulnerability_count].to_i.positive?
+
+      # A pinned version the registry can't resolve (yanked, typo, or nonexistent)
+      # has no version-specific data to judge, so package-level health must not read
+      # it as :ok. Absence of data is :unknown, never a false all-clear. Guarded on
+      # `!vulnerable` so a detected advisory always wins, in case a future source
+      # ever attaches one to an otherwise-unresolved version.
+      return :unknown if gem_data[:version_unresolved] && !vulnerable
+
       level = ActivityHelper.activity_level(gem_data)
 
       if vulnerable

--- a/lib/still_active/cli.rb
+++ b/lib/still_active/cli.rb
@@ -32,7 +32,15 @@ module StillActive
       # win over it: CLI flag > env var > config file > default.
       config_data = ConfigFile.load
       ConfigFile.apply(StillActive.config, config_data).each { |warning| $stderr.puts("warning: #{warning}") }
-      options = Options.new.parse!(args)
+      options = begin
+        Options.new.parse!(args)
+      rescue ArgumentError, OptionParser::ParseError => e
+        # Bad CLI input (conflicting flags, a missing file, an unknown flag, a bad
+        # enum value) is a user error: print it and exit 2, matching the SBOM/baseline
+        # paths, rather than letting the raise bubble into a Ruby backtrace.
+        $stderr.puts("error: #{e.message}")
+        exit(2)
+      end
       # After CLI flags resolve, nudge (don't auto-inherit) an un-imported
       # bundler-audit ignore list when the vulnerability gate is on.
       hint = ConfigFile.import_hint(config_data)

--- a/lib/still_active/deps_dev_client.rb
+++ b/lib/still_active/deps_dev_client.rb
@@ -135,7 +135,17 @@ module StillActive
       url = body.dig("links")&.find { |l| l["label"] == "SOURCE_REPO" }&.dig("url")
       return if url.nil?
 
-      host, *segments = url.sub(%r{\Ahttps?://}, "").split("/")
+      # deps.dev returns SOURCE_REPO in many shapes: `https://`, but also `git://`,
+      # `git+https://`, `git+ssh://git@...`, `ssh://git@...`. Strip the `git+` prefix,
+      # any `scheme://`, and ssh userinfo (`git@`) so what remains is host/owner/repo.
+      # Left unnormalized, a git-scheme URL mis-parses (host becomes `git:`), which
+      # 400s the projects lookup and drops the repo signals.
+      cleaned = url.strip.delete_prefix("git+").sub(%r{\A[a-z][a-z0-9+.-]*://}i, "").sub(%r{\A[^/@]+@}, "")
+      # scp-style git remotes separate host from path with a colon (`host:owner/repo`)
+      # rather than a slash. Convert it so the split yields host/owner/repo, but leave
+      # a real port (`host:443/...`) alone -- a colon before a digit isn't a path.
+      cleaned = cleaned.sub(%r{\A([^/:]+):(?=\D)}, '\1/')
+      host, *segments = cleaned.split("/")
       segments = repo_path_segments(host, segments)
       return if host.nil? || segments.empty?
 

--- a/lib/still_active/ecosystem_lens.rb
+++ b/lib/still_active/ecosystem_lens.rb
@@ -55,12 +55,22 @@ module StillActive
     def assess(ecosystem:, name:, version:, constraint_cache: {}, python_range: nil)
       info = DepsDevClient.version_info(gem_name: name, version: version, system: ecosystem)
       default = DepsDevClient.default_version_info(name: name, system: ecosystem)
+      # Retry the version lookup once when it came back empty but the package DID
+      # resolve: HttpHelper collapses a genuine 404 and a transient network blip to
+      # the same nil, and a healthy version must not be mis-flagged as unresolved
+      # (below) on a one-off miss. A real 404 stays nil; a blip recovers the data.
+      info ||= DepsDevClient.version_info(gem_name: name, version: version, system: ecosystem) if default
       # Recover the repo from the default version when the exact locked version
       # isn't indexed (yanked/normalization mismatch): otherwise its project link
       # vanishes and a still-fresh package date would read a false :ok with
       # archived/scorecard silently dropped. The native Bundler path resolves the
       # repo independently of deps.dev's per-version record; this gives the lens
       # the same resilience.
+      # The pinned version isn't indexed by deps.dev (info nil) while the package IS
+      # (default present, so the feed is up): the version is yanked/nonexistent, not a
+      # transient miss. Flag it so status reads :unknown rather than letting the still-
+      # fresh PACKAGE date report a nonexistent version as :ok.
+      version_unresolved = info.nil? && !default.nil?
       project_id = info&.dig(:project_id) || project_id_from(name, ecosystem, default)
       vulnerabilities = vulnerabilities_for(info)
       # Enrich with OSV: a real GHSA severity label (deps.dev can't score a CVSS-4-only
@@ -92,6 +102,7 @@ module StillActive
         vulnerability_count: vulnerabilities.length,
         vulnerabilities: vulnerabilities,
       }
+      gem_data[:version_unresolved] = true if version_unresolved
       attach_constraints(gem_data, ecosystem: ecosystem, name: name, version: version, cache: constraint_cache)
       attach_language_ceiling(gem_data, ecosystem: ecosystem, name: name, version: version, latest_version: default&.dig(:version), python_range: python_range)
       gem_data

--- a/spec/still_active/cli_spec.rb
+++ b/spec/still_active/cli_spec.rb
@@ -637,9 +637,10 @@ RSpec.describe(StillActive::CLI) do
       end
     end
 
-    it("rejects an unsupported spec version") do
+    it("exits 2 with a friendly error on an unsupported spec version (not a backtrace)") do
+      allow($stderr).to(receive(:puts))
       expect { cli.run(["--gems=rack", "--cyclonedx", "--cyclonedx-version=2.0"]) }
-        .to(raise_error(ArgumentError, /1\.6.*1\.7/))
+        .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(2)) })
     end
   end
 
@@ -1047,14 +1048,15 @@ RSpec.describe(StillActive::CLI) do
       ))
     end
 
-    it("rejects combining --sbom with --gems") do
+    it("exits 2 with a friendly error when combining --sbom with --gems (not a backtrace)") do
+      allow($stderr).to(receive(:puts))
       expect { cli.run(["--sbom=sbom.json", "--gems=rails"]) }
-        .to(raise_error(ArgumentError, /only one of/))
+        .to(raise_error(SystemExit) { |e| expect(e.status).to(eq(2)) })
     end
 
-    it("errors when the SBOM file does not exist") do
+    it("exits 2 with a friendly error when the SBOM file does not exist (not a backtrace)") do
       expect { cli.run(["--sbom=/no/such/sbom.json"]) }
-        .to(raise_error(ArgumentError, /SBOM file not found/))
+        .to(output(/error: SBOM file not found/).to_stderr.and(raise_error(SystemExit) { |e| expect(e.status).to(eq(2)) }))
     end
 
     it("exits 2 on a present-but-unparseable SBOM instead of reporting a silent empty audit") do

--- a/spec/still_active/deps_dev_client_spec.rb
+++ b/spec/still_active/deps_dev_client_spec.rb
@@ -334,6 +334,29 @@ RSpec.describe(StillActive::DepsDevClient) do
       expect(project_id("https://github.com/rails/rails.git")).to(eq("github.com/rails/rails"))
     end
 
+    it("normalizes a git:// scheme URL (deps.dev returns these for many npm packages)") do
+      # Left unstripped, `git://github.com/gruntjs/grunt.git` mis-parses to
+      # `git:/github.com/gruntjs`, which then 400s the deps.dev projects lookup (noise)
+      # and drops the repo signals. Normalizing recovers the clean id and the data.
+      expect(project_id("git://github.com/gruntjs/grunt.git")).to(eq("github.com/gruntjs/grunt"))
+    end
+
+    it("normalizes git+https and git+ssh scheme URLs") do
+      expect(project_id("git+https://github.com/owner/repo.git")).to(eq("github.com/owner/repo"))
+      expect(project_id("git+ssh://git@github.com/owner/repo.git")).to(eq("github.com/owner/repo"))
+    end
+
+    it("strips ssh userinfo before the host") do
+      expect(project_id("ssh://git@github.com/owner/repo.git")).to(eq("github.com/owner/repo"))
+    end
+
+    it("handles the scp-style git remote (host:owner/repo), but not a port") do
+      expect(project_id("git@github.com:owner/repo.git")).to(eq("github.com/owner/repo"))
+      expect(project_id("git+ssh://git@github.com:owner/repo.git")).to(eq("github.com/owner/repo"))
+      # a real port after the host is not a path separator
+      expect(project_id("https://gitlab.example.com:8443/group/project")).to(eq("gitlab.example.com:8443/group/project"))
+    end
+
     it("returns nil when there is no SOURCE_REPO link") do
       expect(described_class.send(:extract_project_id, { "links" => [] })).to(be_nil)
     end

--- a/spec/still_active/ecosystem_lens_spec.rb
+++ b/spec/still_active/ecosystem_lens_spec.rb
@@ -106,6 +106,21 @@ RSpec.describe(StillActive::EcosystemLens) do
       expect(StillActive::StatusHelper.gem_status(result)).to(eq(:legacy))
     end
 
+    it("flags a pinned version deps.dev can't resolve, so a nonexistent version reads :unknown not :ok") do
+      # The version endpoint 404s (version doesn't exist) but the package endpoint
+      # resolves (fresh package). Without the flag, package-level health would report
+      # this nonexistent version as :ok -- a confident wrong answer.
+      stub_request(:get, %r{api\.deps\.dev/v3alpha/systems/[^/]+/packages/.+/versions/.+}).to_return(status: 404)
+      stub_package(default_published_at: "2026-05-01T00:00:00Z")
+      stub_project_scorecard
+      stub_ecosystems_repo(archived: false)
+
+      result = described_class.assess(ecosystem: :pypi, name: "requests", version: "999.999.999")
+
+      expect(result[:version_unresolved]).to(be(true))
+      expect(StillActive::StatusHelper.gem_status(result)).to(eq(:unknown))
+    end
+
     it("surfaces a vulnerability at the locked version and counts it") do
       stub_version(advisory_keys: ["GHSA-xxxx"], source_repo: "https://github.com/owner/leaky")
       stub_package(default_published_at: "2026-06-01T00:00:00Z")

--- a/spec/still_active/status_helper_spec.rb
+++ b/spec/still_active/status_helper_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe(StillActive::StatusHelper) do
       expect(described_class.gem_status(data)).to(eq(:vulnerable))
     end
 
+    it("is :unknown when the pinned version doesn't resolve (never :ok on a nonexistent/yanked version)") do
+      # A pinned version the registry has no record of can't be assessed: package-level
+      # health must not read a nonexistent version as :ok. Absence of data stays :unknown.
+      data = { version_unresolved: true, latest_version_release_date: recent, vulnerability_count: 0 }
+      expect(described_class.gem_status(data)).to(eq(:unknown))
+    end
+
     it("is :dead for a dormant gem with an unpatched vulnerability (no one is fixing it)") do
       data = { latest_version_release_date: ancient, vulnerability_count: 1 }
       expect(described_class.gem_status(data)).to(eq(:dead))


### PR DESCRIPTION
## What

Four independent robustness/correctness fixes surfaced by a **real-world validation sweep** (npm, pypi, cargo, go, maven, nuget, native Ruby — ~600 real assessments via `syft` over real `npm`/`cargo`/`pip` resolutions).

## The fixes

| Issue | Before | After |
|-------|--------|-------|
| **Unresolved pinned version** | `requests@999.999.999` → `status: ok` (rode the fresh package date) | `:unknown` — absence of data is never a false all-clear |
| **git-scheme SOURCE_REPO URLs** | `git://…`/`git+ssh…`/scp mis-parsed → `git:/github.com/gruntjs`; **1098 stderr `HTTP 400` warnings** on one tree + dropped repo signals | normalized → resolves cleanly; **0 warnings** and archived/scorecard *recovered* |
| **Bad CLI input** | `--sbom=<missing>` / conflicting flags → Ruby **backtrace** | `error: …` + exit 2, matching every other bad-input path |

Details:
- **`version_unresolved`** (`ecosystem_lens` + `status_helper`): set when the version lookup is empty but the package resolves. A **single retry** distinguishes a genuine 404 from a transient miss (HttpHelper collapses both to nil), and the status guard **yields to a detected advisory** so a real vuln always wins.
- **git-URL normalization** (`deps_dev_client`): strips `git+`, any `scheme://`, ssh userinfo, and converts the scp-style `host:owner/repo` colon (leaving a real port alone). Recovers data *and* silences the noise.
- **CLI rescue** (`cli`): `rescue ArgumentError, OptionParser::ParseError` around option parsing → `error:` + exit 2. Tightly scoped to the parse call.

## Validation context

This batch is the hardening pass from the sweep that validated the npm/cargo below-the-fix moat. That signal came back **clean: 16 firings across the real trees, 100% true positives, zero false positives** (npm 11/11, cargo 5/5 — baited hard with caret-default + coexisting-majors trees; pypi conservative). The "dormant/archived *package*" gate does the FP-prevention work (`sails`: 17 vulnerable + 105 dormant packages → 0 firings).

## Review

code-reviewer + silent-failure-hunter + simplifier. Both correctness reviewers' findings applied: the transient-vs-404 retry, the scp-URL shape, and the explicit "advisory wins over unresolved" guard. Full suite (1129) + rubocop green; every claim above verified against real `--sbom` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
