### PR TITLE
fix: make the published JSON Schema match real output (it rejected any vuln)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Usage: still_active [options]
         --gitlab-token=TOKEN         GitLab personal access token for API calls
         --artifactory-token=TOKEN    Artifactory token for private gem registry API calls
         --artifactory-host=HOST      Artifactory host allowed to receive the global token (e.g. my-org.jfrog.io)
+        --ecosystems-email=EMAIL     Contact email to join the ecosyste.ms polite pool (higher rate limit)
         --simultaneous-requests=QTY  Number of simultaneous requests made
         --safe-range-end=YEARS       maximum years since last release considered safe, no warning (default 1.5)
         --warning-range-end=YEARS    maximum years since last release that triggers a warning, beyond this is critical (default 3)
@@ -280,7 +281,7 @@ jobs:
         with: { sarif_file: still_active.sarif.json }
 ```
 
-Rule reference (SA001–SA008) and how to suppress: see [`docs/rules.md`](docs/rules.md).
+Rule reference (SA001–SA009) and how to suppress: see [`docs/rules.md`](docs/rules.md).
 
 ### Baseline diff (PR review)
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -78,6 +78,12 @@ A digest so a consumer reads the headline posture without iterating every gem. C
 | `version_yanked` | bool \| absent | `true` if `version_used` has been yanked. |
 | `license` | string \| nil | SPDX license identifier(s) for `version_used`, comma-joined when more than one. `nil` when unknown (e.g. git/path sources). |
 | `libyear` | float \| nil | Years between `version_used` and `latest_version`. |
+| `poison` | bool \| absent | `true` when a dormant gem caps a dependency below its latest major (a below-latest ceiling). See SA008. |
+| `poison_severity` | string \| absent | `note` / `warning` / `critical`, scaling with majors-behind. |
+| `poison_security_relevant` | bool \| absent | `true` when a capped dependency is itself known-vulnerable in the tree. |
+| `poison_below_fix` | bool \| absent | `true` when the cap holds a vulnerable dependency below its security fix (the strongest poison case). |
+| `constraints` | array \| absent | The poison caps: each `{ dependency, requirement, dep_latest, majors_behind, kind }`, plus `capped_dep_vulnerable` / `capped_below_fix` / `below_fix_advisory` / `below_fix_fixed_in` when security-relevant. |
+| `language_ceiling` | object \| absent | The runtime (Ruby) EOL ceiling a pinned gem forces. See SA009. |
 
 ### Vulnerability fields
 
@@ -91,6 +97,12 @@ A digest so a consumer reads the headline posture without iterating every gem. C
 | `cvss3_vector` | string \| nil | CVSS v3 vector string. (Always `nil` for `ruby-advisory-db`-only advisories — bundler-audit exposes no vector.) |
 | `cvss2_score` | float \| nil | CVSS v2 fallback for older advisories. |
 | `source` | string | Which source reported the advisory: `"deps.dev"`, `"ruby-advisory-db"`, or `"merged"` (both). `ruby-advisory-db` entries appear only when `bundler-audit` is installed with a current advisory checkout. |
+| `osv_severity` | string \| nil | OSV/GHSA qualitative label (`HIGH`, etc.), used when deps.dev can't score a CVSS-4-only advisory. |
+| `osv_cvss_score` | float \| nil | CVSS base score from OSV enrichment. |
+| `cvss_version` | string \| nil | CVSS version of the scored vector (e.g. `3.1`, `4.0`). |
+| `cvss_vector` | string \| nil | The scored CVSS vector string. |
+| `fixed_versions` | array | Versions that patch the advisory (empty when none is published). |
+| `no_fix_available` | bool | `true` when no fixed version exists — you can't upgrade out of it. |
 
 ## Ruby fields
 

--- a/docs/still_active.schema.json
+++ b/docs/still_active.schema.json
@@ -82,7 +82,7 @@
         "vulnerabilities": { "type": "array", "items": { "$ref": "#/$defs/vulnerability" } },
         "alternatives": { "type": "array", "items": { "type": "string" } },
         "ruby_gems_url": { "type": "string" },
-        "up_to_date": { "type": "boolean" },
+        "up_to_date": { "type": ["boolean", "null"] },
         "version_used_release_date": { "type": ["string", "null"], "format": "date-time" },
         "version_yanked": { "type": "boolean" },
         "license": { "type": ["string", "null"] },
@@ -90,6 +90,7 @@
         "poison": { "type": "boolean" },
         "poison_severity": { "type": "string", "enum": ["note", "warning", "critical"] },
         "poison_security_relevant": { "type": "boolean" },
+        "poison_below_fix": { "type": "boolean", "description": "True when a cap holds a vulnerable dependency below its security fix (the strongest poison case)." },
         "constraints": { "type": "array", "items": { "$ref": "#/$defs/constraint" } },
         "language_ceiling": { "$ref": "#/$defs/language_ceiling" }
       }
@@ -104,7 +105,10 @@
         "dep_latest": { "type": ["string", "null"] },
         "majors_behind": { "type": "integer", "minimum": 0 },
         "kind": { "type": "string", "enum": ["ceiling", "exact_pin", "permissive"] },
-        "capped_dep_vulnerable": { "type": "boolean" }
+        "capped_dep_vulnerable": { "type": "boolean" },
+        "capped_below_fix": { "type": "boolean", "description": "True when every fix for the capped dep's advisory lies outside this cap: you can't patch without replacing the dormant capper." },
+        "below_fix_advisory": { "type": "string", "description": "The advisory id the cap holds you below the fix for." },
+        "below_fix_fixed_in": { "type": "string", "description": "The nearest fixed version, which the cap forbids." }
       }
     },
     "language_ceiling": {
@@ -136,7 +140,13 @@
         "cvss3_score": { "type": ["number", "null"] },
         "cvss3_vector": { "type": ["string", "null"] },
         "cvss2_score": { "type": ["number", "null"] },
-        "source": { "type": "string", "enum": ["deps.dev", "ruby-advisory-db", "merged"] }
+        "source": { "type": "string", "enum": ["deps.dev", "ruby-advisory-db", "merged"] },
+        "osv_severity": { "type": ["string", "null"], "description": "OSV/GHSA qualitative severity label (e.g. HIGH), used when deps.dev can't score a CVSS-4-only advisory." },
+        "osv_cvss_score": { "type": ["number", "null"] },
+        "cvss_version": { "type": ["string", "null"], "description": "CVSS version of the scored vector (e.g. 3.1, 4.0)." },
+        "cvss_vector": { "type": ["string", "null"] },
+        "fixed_versions": { "type": "array", "items": { "type": "string" }, "description": "Versions that patch the advisory (from OSV ranges); empty when no fix is published." },
+        "no_fix_available": { "type": "boolean", "description": "True when the advisory has no published fixed version, so you can't upgrade out of it." }
       }
     },
     "ruby": {

--- a/spec/still_active/cli_spec.rb
+++ b/spec/still_active/cli_spec.rb
@@ -259,16 +259,22 @@ RSpec.describe(StillActive::CLI) do
           last_commit_date: recent_date,
           vulnerability_count: 1,
           alternatives: ["foo"],
-          vulnerabilities: [{ id: "CVE-2024-1", url: "https://example/x", title: "t", aliases: ["GHSA-x"], cvss3_score: 7.5, cvss3_vector: "AV:N", cvss2_score: nil, source: "merged" }],
+          # A fully OSV-enriched advisory: these keys are added in place by OsvClient
+          # and emitted verbatim, so the schema must validate them (else real output
+          # with any vulnerability fails its own published contract).
+          vulnerabilities: [{ id: "CVE-2024-1", url: "https://example/x", title: "t", aliases: ["GHSA-x"], cvss3_score: 7.5, cvss3_vector: "AV:N", cvss2_score: nil, source: "merged", osv_severity: "MODERATE", osv_cvss_score: nil, cvss_version: "3.0", cvss_vector: "CVSS:3.0/AV:N/AC:L", fixed_versions: ["2.0.6", "1.6.11"], no_fix_available: false }],
         },
         # A poison-pill gem and a language-ceiling gem, so the published schema is
-        # actually validated against those compatibility-signal shapes.
+        # actually validated against those compatibility-signal shapes -- including
+        # the security below-the-fix keys the correlator sets.
         "protected_attributes" => {
           source_type: :rubygems,
           direct: true,
           poison: true,
           poison_severity: :critical,
-          constraints: [{ dependency: "activemodel", requirement: "< 5.0", dep_latest: "8.0.1", majors_behind: 4, kind: :ceiling }],
+          poison_security_relevant: true,
+          poison_below_fix: true,
+          constraints: [{ dependency: "activemodel", requirement: "< 5.0", dep_latest: "8.0.1", majors_behind: 4, kind: :ceiling, capped_dep_vulnerable: true, capped_below_fix: true, below_fix_advisory: "CVE-2024-9", below_fix_fixed_in: "5.0.0" }],
         },
         "cfpropertylist" => {
           source_type: :rubygems,


### PR DESCRIPTION
## What

Make the published JSON Schema (`docs/still_active.schema.json`) match real `--json` output, and fix the doc drift a freshness audit surfaced.

## The real bug

The schema **rejected real output whenever a vulnerability was present.** `OsvClient` enriches each advisory in place with `osv_severity`, `osv_cvss_score`, `cvss_version`, `cvss_vector`, `fixed_versions`, `no_fix_available`, and the CLI emits them verbatim — but the `vulnerability` object is `additionalProperties: false` and listed none of them. The contract test passed only because its fixture hand-built a *minimal* advisory. `up_to_date` was also `boolean`-only while the native path emits `null` when it can't determine.

Confirmed by validating a real vulnerable-gem run (`rack@2.0.0`) against the published schema — it failed on six forbidden keys + the nullable `up_to_date`; **now passes.**

## Fixes

- **Schema:** add the OSV enrichment keys to `vulnerability`; add the below-the-fix keys (`capped_below_fix` / `below_fix_advisory` / `below_fix_fixed_in`) to `constraint`; add `poison_below_fix` to `gem`; make `up_to_date` nullable.
- **Contract test:** enrich the fixture with the real OSV keys + a below-the-fix poison, so this drift **can't recur silently** (the test now validates realistic output).
- **schema.md prose:** add the missing `poison` / `constraints` / `language_ceiling` and vuln-enrichment field rows.
- **README:** `SA001–SA008` → `SA001–SA009` (SA009 shipped); add `--ecosystems-email` to the help snapshot.

Full suite (1130) + rubocop green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
