### PR TITLE
fix: two v3 release blockers (malformed-purl crash, false-clean on alias drift)

### DIFF
--- a/lib/helpers/vulnerability_helper.rb
+++ b/lib/helpers/vulnerability_helper.rb
@@ -101,7 +101,11 @@ module StillActive
     private
 
     def identifiers(advisory)
-      [advisory[:id], *advisory[:aliases]].compact
+      # Coerce to strings: advisory ids/aliases are strings, but deps.dev's ALPHA API
+      # could drift and hand back a non-string alias, and a mixed array makes the
+      # union's `.sort` (in combine!) raise -- which escapes to the per-gem rescue that
+      # strips ALL the gem's signals, reading a known-vulnerable gem as clean.
+      [advisory[:id], *advisory[:aliases]].compact.map(&:to_s)
     end
 
     # Folds a ruby-advisory-db advisory into a matching deps.dev advisory in place:

--- a/lib/still_active/deps_dev_client.rb
+++ b/lib/still_active/deps_dev_client.rb
@@ -109,7 +109,7 @@ module StillActive
         title: body["title"],
         # deps.dev's v3alpha returns aliases as bare id strings (["CVE-..."]);
         # tolerate the legacy object shape ({"id":...}) too since it's an alpha API.
-        aliases: Array(body["aliases"]).filter_map { |a| a.is_a?(Hash) ? a["id"] : a },
+        aliases: Array(body["aliases"]).filter_map { |a| normalize_alias(a) },
         cvss3_score: body["cvss3Score"],
         cvss3_vector: body["cvss3Vector"],
         cvss2_score: body["cvss2Score"],
@@ -118,6 +118,27 @@ module StillActive
     end
 
     private
+
+    # Coerce an advisory alias to a string id. A BARE non-string alias is deps.dev
+    # ALPHA-API schema drift: coerce it (a non-string alias makes the advisory-merge
+    # sort raise, which strips a gem of ALL its signals and reads a vulnerable gem
+    # clean) but warn once so the drift surfaces rather than passing invisibly, the
+    # same "loud on schema drift" stance as the advisory-count canary.
+    def normalize_alias(raw)
+      return raw["id"]&.to_s if raw.is_a?(Hash)
+      return raw if raw.is_a?(String) || raw.nil?
+
+      warn_alias_drift(raw)
+      raw.to_s
+    end
+
+    # Warn once per run (not per alias), matching CvssHelper's warn-once stance.
+    def warn_alias_drift(raw)
+      return if @alias_drift_warned
+
+      @alias_drift_warned = true
+      $stderr.puts("warning: deps.dev returned a non-string advisory alias (#{raw.class}); the ALPHA API schema may have drifted")
+    end
 
     # The OpenSSF "Maintained" check score (0-10), or nil when it's absent. A
     # malformed (non-array) `checks` payload also yields nil rather than raising:

--- a/lib/still_active/sbom_reader.rb
+++ b/lib/still_active/sbom_reader.rb
@@ -152,7 +152,12 @@ module StillActive
       else
         [:unassessable, { ecosystem: type, name: name, reason: :unsupported_ecosystem }]
       end
-    rescue PackageURL::InvalidPackageURL
+    rescue ArgumentError
+      # InvalidPackageURL is a subclass of ArgumentError, but PackageURL.parse also
+      # raises a BARE ArgumentError on an empty name-after-namespace (`pkg:npm/@1.0.0`)
+      # or bad percent-encoding, both common in real Syft/Trivy output. Catch both so
+      # one malformed component degrades to unassessable, never a backtrace that drops
+      # every other dependency's verdict (SbomReader's documented "never raises").
       [:unassessable, { ecosystem: nil, name: name, reason: :malformed_purl }]
     end
 

--- a/spec/still_active/sbom_reader_spec.rb
+++ b/spec/still_active/sbom_reader_spec.rb
@@ -52,6 +52,24 @@ RSpec.describe(StillActive::SbomReader) do
     expect { expect(described_class.read_string("not json")).to(eq([])) }.not_to(raise_error)
   end
 
+  it("surfaces a malformed PURL as unassessable instead of backtracing the whole audit") do
+    # PackageURL.parse raises a BARE ArgumentError (not only InvalidPackageURL) on an
+    # empty name-after-namespace (`pkg:npm/@1.0.0`) or bad percent-encoding (`%zz`),
+    # both common in real Syft/Trivy output. One bad component must not crash and drop
+    # every other dependency's verdict.
+    body = {
+      components: [
+        { type: "library", name: "good", purl: "pkg:npm/lodash@4.17.21" },
+        { type: "library", name: "bad", purl: "pkg:npm/@1.0.0" },
+        { type: "library", name: "bad2", purl: "pkg:npm/%zz@1.0.0" },
+      ],
+    }.to_json
+    result = nil
+    expect { result = described_class.parse_string(body) }.not_to(raise_error)
+    expect(result.dependencies.map { |d| d[:name] }).to(eq(["lodash"]))
+    expect(result.unassessable.map { |u| u[:reason] }).to(all(eq(:malformed_purl)))
+  end
+
   describe(".parse — surfacing unassessable components (never silently drop a real dep)") do
     subject(:result) { described_class.parse(fixture) }
 

--- a/spec/still_active/vulnerability_helper_spec.rb
+++ b/spec/still_active/vulnerability_helper_spec.rb
@@ -187,6 +187,17 @@ RSpec.describe(StillActive::VulnerabilityHelper) do
       expect(described_class.merge_advisories(deps_dev: deps_dev, ruby_advisory_db: [])).to(eq(deps_dev))
     end
 
+    it("coerces a non-string alias so deps.dev alpha-API drift can't crash the merge and strip a real advisory") do
+      # A numeric alias slipping through would make combine!'s `.sort` raise, escaping
+      # to the per-gem rescue that strips ALL signals -- a known-vulnerable gem then
+      # reads clean. The worst failure mode, so the union coerces to strings.
+      deps_dev = [{ id: "CVE-1", aliases: [2, "GHSA-x"], cvss3_score: 9.0, source: "deps.dev" }]
+      radb = [{ id: "CVE-1", aliases: ["GHSA-x"], source: "ruby-advisory-db" }]
+      merged = nil
+      expect { merged = described_class.merge_advisories(deps_dev: deps_dev, ruby_advisory_db: radb) }.not_to(raise_error)
+      expect(merged.first[:aliases]).to(all(be_a(String)))
+    end
+
     it("returns ruby-advisory-db advisories when deps.dev is empty") do
       radb = [{ id: "GHSA-bbb", aliases: [], cvss3_score: 5.0, source: "ruby-advisory-db" }]
       expect(described_class.merge_advisories(deps_dev: [], ruby_advisory_db: radb)).to(eq(radb))


### PR DESCRIPTION
## What

Two crashes in the newest code that a **pre-3.0 release audit** flagged as must-fix — either would force a 3.0.1 the first time real input hit it.

## The blockers

1. **A single malformed PURL crashed the entire `--sbom` audit.** `SbomReader` rescued only `PackageURL::InvalidPackageURL`, but `PackageURL.parse` also raises a **bare `ArgumentError`** on an empty name-after-namespace (`pkg:npm/@1.0.0`) or bad percent-encoding (`pkg:npm/%zz@1.0.0`) — both common in real Syft/Trivy output. That backtraced and dropped every other dependency's verdict, breaking the module's "never raises" contract and reintroducing the exact crash the hardening batch removed. **Fix:** widen the rescue so a bad component degrades to `unassessable` (surfaced with a reason), never a stack trace.

2. **A non-string advisory alias read a vulnerable gem as clean.** A drifted alias from deps.dev's ALPHA API made the advisory-merge's `.sort` raise, escaping to the per-gem rescue that strips **all** the gem's signals — so a known-vulnerable gem cleared every gate. **Fix:** coerce ids/aliases to strings in the union, and **warn once** at ingestion so the schema drift surfaces (matching the advisory-count canary's loud-on-drift stance) instead of passing invisibly.

## Posture

Both move the failure the right way: crash → surfaced `unassessable`; silent-strip → coerced-and-warned. Verified end-to-end (a mixed good/malformed SBOM assesses the good deps and lists the bad). Reviewed by silent-failure-hunter (scoped, surface-not-suppress) + simplifier. Full suite (1134) + rubocop green.

Clears the **NO-GO** from the 3.0 release-readiness audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
