### PR TITLE
test: automate the drift + robustness checks (conformance, fuzz, consistency, coverage, changelog gate)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,41 @@
+name: Changelog
+
+# A PR that changes lib/ must add a CHANGELOG entry, so the release notes can't
+# silently fall behind the code (they had drifted ~44 commits before 3.0). Pure
+# refactors and internal-only changes are exempt via the `skip-changelog` label;
+# dependency bumps and docs-only PRs are exempt automatically.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  changelog:
+    name: Require a CHANGELOG entry for code changes
+    runs-on: ubuntu-latest
+    if: >-
+      !contains(github.event.pull_request.labels.*.name, 'skip-changelog') &&
+      !contains(github.event.pull_request.labels.*.name, 'dependencies') &&
+      !contains(github.event.pull_request.labels.*.name, 'documentation')
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Check that lib changes come with a CHANGELOG entry
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          changed="$(git diff --name-only "$BASE" "$HEAD")"
+          if echo "$changed" | grep -qE '^lib/'; then
+            if ! echo "$changed" | grep -qxF 'CHANGELOG.md'; then
+              echo "::error::This PR changes lib/ but does not update CHANGELOG.md."
+              echo "Add an entry under ## [Unreleased], or apply the 'skip-changelog' label for a pure refactor / internal-only change."
+              exit 1
+            fi
+          fi
+          echo "Changelog check passed."

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -29,6 +29,10 @@ jobs:
         bundler-cache: true
     - name: Execute the tests
       run: bundle exec rspec
+      env:
+        # Measure coverage and enforce the floor on one version only, so the
+        # branch-coverage floor can't flake on cross-version differences.
+        COVERAGE: ${{ matrix.ruby == '3.4' && '1' || '' }}
 
   floors:
     name: Dependency floors (min versions)

--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,6 @@ gemspec
 
 gem "rake", ">= 13.0"
 gem "rspec", ">= 4.0.0.beta1"
+gem "simplecov", "~> 1.0.0.rc5", require: false
 gem "vcr"
 gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,7 @@ GEM
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     semantic_range (3.1.1)
+    simplecov (1.0.0.rc5)
     simpleidn (0.2.3)
     stringio (3.2.0)
     thor (1.5.0)
@@ -177,6 +178,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rspec
   rubocop-shopify
+  simplecov (~> 1.0.0.rc5)
   still_active!
   vcr
   webmock
@@ -245,6 +247,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   sawyer (0.9.3) sha256=0d0f19298408047037638639fe62f4794483fb04320269169bd41af2bdcf5e41
   semantic_range (3.1.1) sha256=508333196ef0c7ba33e79579d4df7eb0a41080595e6a655c2515b03d634ec4a9
+  simplecov (1.0.0.rc5) sha256=069108264a60335ebaa014a963b595e15d21541067019659c87bc4e9d6b18743
   simpleidn (0.2.3) sha256=08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29
   still_active (2.0.0)
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# Coverage is opt-in (COVERAGE=1) so a normal local run isn't slowed; CI sets it.
+# Must start before still_active loads so every file is instrumented. The floor is a
+# regression ratchet (fail if coverage drops), not a target to chase.
+if ENV["COVERAGE"] == "1"
+  require "simplecov"
+  SimpleCov.start do
+    add_filter "/spec/"
+    enable_coverage :branch
+    # Measured 96.3% line / 87.3% branch; floor sits a few points below as a
+    # regression ratchet, loose enough not to flake on a legitimate change.
+    minimum_coverage line: 92, branch: 82
+  end
+end
+
 require "still_active"
 require "vcr"
 require "webmock/rspec"

--- a/spec/still_active/cli_spec.rb
+++ b/spec/still_active/cli_spec.rb
@@ -224,90 +224,205 @@ RSpec.describe(StillActive::CLI) do
       expect(payload.dig("ruby", "release_date")).to(eq("2026-01-02T01:04:05Z"))
     end
 
-    it("emits JSON that validates against the published JSON Schema and carries a summary digest") do
+    # #128 shipped a schema that rejected any real --json output carrying a
+    # vulnerability: OSV enrichment adds keys the strict `additionalProperties:
+    # false` schema didn't list, and the old contract test passed only because its
+    # fixture was minimal. The guard against that class of drift is a fixture that
+    # is EXHAUSTIVE -- it must exercise every field the emitters can produce, so
+    # validating it makes any emitted-but-unschema'd key fail. The tests below both
+    # validate that exhaustive output and prove the fixture is actually exhaustive
+    # (schema property <=> emitted key, in both directions).
+    describe("published JSON Schema conformance (exhaustive)") do
       require "json_schemer"
-      schema_path = File.expand_path("../../docs/still_active.schema.json", __dir__)
-      rich = {
-        "rails" => {
-          source_type: :rubygems,
-          direct: true,
-          version_used: "7.0.0",
-          latest_version: "7.1.0",
-          # Real Time objects, as the Workflow produces; the JSON layer must
-          # normalize them to ISO8601 UTC strings (don't pre-stringify here).
-          latest_version_release_date: Time.new(2026, 1, 1, 0, 0, 0, "+00:00"),
-          latest_pre_release_version: nil,
-          latest_pre_release_version_release_date: nil,
-          repository_url: "https://github.com/rails/rails",
-          last_commit_date: recent_date,
-          archived: false,
-          scorecard_score: 8.5,
-          vulnerability_count: 0,
-          vulnerabilities: [],
-          ruby_gems_url: "https://rubygems.org/gems/rails",
-          up_to_date: false,
-          version_used_release_date: Time.new(2025, 1, 1, 0, 0, 0, "+00:00"),
-          version_yanked: false,
-          license: "MIT",
-          libyear: 1.2,
-          unreleased_commits: 17,
-        },
-        "rack" => {
-          source_type: :rubygems,
-          direct: false,
-          dependency_path: ["rails", "actionpack", "rack"],
-          last_commit_date: recent_date,
-          vulnerability_count: 1,
-          alternatives: ["foo"],
-          # A fully OSV-enriched advisory: these keys are added in place by OsvClient
-          # and emitted verbatim, so the schema must validate them (else real output
-          # with any vulnerability fails its own published contract).
-          vulnerabilities: [{ id: "CVE-2024-1", url: "https://example/x", title: "t", aliases: ["GHSA-x"], cvss3_score: 7.5, cvss3_vector: "AV:N", cvss2_score: nil, source: "merged", osv_severity: "MODERATE", osv_cvss_score: nil, cvss_version: "3.0", cvss_vector: "CVSS:3.0/AV:N/AC:L", fixed_versions: ["2.0.6", "1.6.11"], no_fix_available: false }],
-        },
-        # A poison-pill gem and a language-ceiling gem, so the published schema is
-        # actually validated against those compatibility-signal shapes -- including
-        # the security below-the-fix keys the correlator sets.
-        "protected_attributes" => {
-          source_type: :rubygems,
-          direct: true,
-          poison: true,
-          poison_severity: :critical,
-          poison_security_relevant: true,
-          poison_below_fix: true,
-          constraints: [{ dependency: "activemodel", requirement: "< 5.0", dep_latest: "8.0.1", majors_behind: 4, kind: :ceiling, capped_dep_vulnerable: true, capped_below_fix: true, below_fix_advisory: "CVE-2024-9", below_fix_fixed_in: "5.0.0" }],
-        },
-        "cfpropertylist" => {
-          source_type: :rubygems,
-          direct: true,
-          version_used: "3.0.9",
-          latest_version: "4.0.0",
-          language_ceiling: {
-            runtime: "Ruby",
-            requirement: "< 3.2",
-            eol_forced: true,
-            severity: :critical,
-            ceiling_version: "3.1",
-            ceiling_eol_date: Time.new(2025, 3, 31, 0, 0, 0, "+00:00"),
-            oldest_supported: "3.3",
-            latest_stable: "4.0.5",
-            fixed_by_upgrade: true,
+
+      # Plain methods (not `let`) to stay under RSpec/MultipleMemoizedHelpers; the
+      # file reads are cheap and run a handful of times.
+      def schema_path = File.expand_path("../../docs/still_active.schema.json", __dir__)
+      def schema_md_path = File.expand_path("../../docs/schema.md", __dir__)
+      def schema = JSON.parse(File.read(schema_path))
+
+      # Ruby freshness carrying every `ruby` schema field.
+      def exhaustive_ruby
+        {
+          version: "3.4.0",
+          release_date: Time.new(2025, 1, 1, 0, 0, 0, "+00:00"),
+          eol_date: Time.new(2028, 1, 1, 0, 0, 0, "+00:00"),
+          eol: false,
+          latest_version: "3.4.1",
+          latest_release_date: Time.new(2026, 1, 1, 0, 0, 0, "+00:00"),
+          libyear: 0.1,
+        }
+      end
+
+      # A bot context carrying every `pr_context` field (bot, bumps, and a bump's
+      # gem/from/to).
+      def exhaustive_pr_context
+        { bot: "dependabot", bumps: [{ gem: "rack", from: "2.0.0", to: "2.0.6" }] }
+      end
+
+      # A result that exercises EVERY per-gem / vulnerability / constraint /
+      # language_ceiling field the schema defines, spread across four gems. Values
+      # are real Time objects where the emitters produce them (the JSON layer
+      # normalizes those to ISO8601 UTC strings). Field provenance is cross-checked
+      # against the code that emits each key: workflow.rb (scorecard_maintained),
+      # osv_client.rb (osv_severity/osv_cvss_score/cvss_version/cvss_vector/
+      # fixed_versions), vulnerability_helper.rb (no_fix_available via merge),
+      # poison_security_correlator.rb (poison_security_relevant/poison_below_fix and
+      # the constraint below-fix keys) and ceiling_reconciler.rb (upgrade_blocked).
+      def exhaustive_result
+        {
+          "rails" => {
+            source_type: :rubygems,
+            direct: true,
+            version_used: "7.0.0",
+            latest_version: "7.1.0",
+            latest_version_release_date: Time.new(2026, 1, 1, 0, 0, 0, "+00:00"),
+            latest_pre_release_version: "7.2.0.beta1",
+            latest_pre_release_version_release_date: Time.new(2026, 2, 1, 0, 0, 0, "+00:00"),
+            repository_url: "https://github.com/rails/rails",
+            last_commit_date: recent_date,
+            archived: false,
+            scorecard_score: 8.5,
+            # deps.dev's Maintained sub-check, attached alongside scorecard_score;
+            # absent from the pre-#128 fixture, so the schema's own field went
+            # unvalidated by real output.
+            scorecard_maintained: 7.0,
+            vulnerability_count: 0,
+            vulnerabilities: [],
+            ruby_gems_url: "https://rubygems.org/gems/rails",
+            up_to_date: false,
+            version_used_release_date: Time.new(2025, 1, 1, 0, 0, 0, "+00:00"),
+            version_yanked: false,
+            license: "MIT",
+            libyear: 1.2,
+            unreleased_commits: 17,
           },
-        },
-      }
-      allow(StillActive::Workflow).to(receive_messages(
-        call: rich,
-        ruby_freshness: { version: "3.4.0", release_date: Time.new(2025, 1, 1, 0, 0, 0, "+00:00"), eol_date: Time.new(2028, 1, 1, 0, 0, 0, "+00:00"), eol: false, latest_version: "3.4.1", latest_release_date: Time.new(2026, 1, 1, 0, 0, 0, "+00:00"), libyear: 0.1 },
-      ))
-      allow(StillActive::BotContext).to(receive(:detect).and_return({ bot: "dependabot", bumps: [{ gem: "rack", from: "2.0.0", to: "2.0.6" }] }))
+          "rack" => {
+            source_type: :rubygems,
+            direct: false,
+            dependency_path: ["rails", "actionpack", "rack"],
+            last_commit_date: recent_date,
+            # up_to_date as null (unknown), the other half of its boolean|null type;
+            # rails covers the boolean half.
+            up_to_date: nil,
+            vulnerability_count: 1,
+            alternatives: ["foo"],
+            # A fully OSV-enriched advisory: every vulnerability key the emitters can
+            # attach (deps.dev's cvss3/cvss2/source, OSV's osv_severity/osv_cvss_score/
+            # cvss_version/cvss_vector/fixed_versions, ruby-advisory-db's
+            # no_fix_available). osv_cvss_score is a real number here (the null half is
+            # implicit for un-enriched advisories) so both branches of its type hold.
+            vulnerabilities: [{ id: "CVE-2024-1", url: "https://example/x", title: "t", aliases: ["GHSA-x"], cvss3_score: 7.5, cvss3_vector: "AV:N", cvss2_score: nil, source: "merged", osv_severity: "MODERATE", osv_cvss_score: 8.1, cvss_version: "3.0", cvss_vector: "CVSS:3.0/AV:N/AC:L", fixed_versions: ["2.0.6", "1.6.11"], no_fix_available: false }],
+          },
+          # A poison-pill gem: every constraint field including the security below-
+          # the-fix keys the correlator sets.
+          "protected_attributes" => {
+            source_type: :rubygems,
+            direct: true,
+            poison: true,
+            poison_severity: :critical,
+            poison_security_relevant: true,
+            poison_below_fix: true,
+            constraints: [{ dependency: "activemodel", requirement: "< 5.0", dep_latest: "8.0.1", majors_behind: 4, kind: :ceiling, capped_dep_vulnerable: true, capped_below_fix: true, below_fix_advisory: "CVE-2024-9", below_fix_fixed_in: "5.0.0" }],
+          },
+          # A language-ceiling gem: every language_ceiling field, including
+          # upgrade_blocked (set by CeilingReconciler when a poison cap blocks the
+          # very upgrade that would lift the ceiling), which fixed_by_upgrade flips to
+          # false alongside.
+          "cfpropertylist" => {
+            source_type: :rubygems,
+            direct: true,
+            version_used: "3.0.9",
+            latest_version: "4.0.0",
+            language_ceiling: {
+              runtime: "Ruby",
+              requirement: "< 3.2",
+              eol_forced: true,
+              severity: :critical,
+              ceiling_version: "3.1",
+              ceiling_eol_date: Time.new(2025, 3, 31, 0, 0, 0, "+00:00"),
+              oldest_supported: "3.3",
+              latest_stable: "4.0.5",
+              fixed_by_upgrade: false,
+              upgrade_blocked: true,
+            },
+          },
+        }
+      end
 
-      captured = nil
-      allow($stdout).to(receive(:puts)) { |arg| captured = arg }
-      cli.run(["--gems=rails", "--json"])
-      payload = JSON.parse(captured)
+      def emit_payload(result: exhaustive_result, ruby_info: exhaustive_ruby, pr_context: exhaustive_pr_context)
+        allow(StillActive::Workflow).to(receive_messages(call: result, ruby_freshness: ruby_info))
+        allow(StillActive::BotContext).to(receive(:detect).and_return(pr_context))
+        captured = nil
+        allow($stdout).to(receive(:puts)) { |arg| captured = arg }
+        cli.run(["--gems=rails", "--json"])
+        JSON.parse(captured)
+      end
 
-      errors = JSONSchemer.schema(Pathname.new(schema_path)).validate(payload).to_a
-      expect(errors).to(be_empty, errors.map { |e| "#{e["data_pointer"]}: #{e["type"]} (#{e["data"].inspect})" }.join("\n"))
-      expect(payload["summary"]).to(include("total_gems" => 4, "direct" => 3, "transitive" => 1, "vulnerable_gems" => 1, "ruby_eol" => false))
+      it("emits JSON that validates against the published JSON Schema and carries a summary digest") do
+        payload = emit_payload
+        errors = JSONSchemer.schema(Pathname.new(schema_path)).validate(payload).to_a
+        expect(errors).to(be_empty, errors.map { |e| "#{e["data_pointer"]}: #{e["type"]} (#{e["data"].inspect})" }.join("\n"))
+        expect(payload["summary"]).to(include("total_gems" => 4, "direct" => 3, "transitive" => 1, "vulnerable_gems" => 1, "ruby_eol" => false))
+      end
+
+      # Proves the fixture above is genuinely exhaustive: every property the schema
+      # defines is actually present in the emitted output. Without this, a new
+      # emitted field could be added to both code and schema while the fixture never
+      # exercises it -- and an unschema'd sibling of that field would then slip past
+      # additionalProperties:false unnoticed, exactly the #128 hole. When this fails,
+      # add the named field to exhaustive_result so real output guards it.
+      it("exercises every field the schema defines (so additionalProperties:false actually guards each one)") do
+        payload = emit_payload
+        gems = payload.fetch("gems").values
+        emitted = {
+          "gem" => gems.flat_map(&:keys),
+          "vulnerability" => gems.flat_map { |g| g["vulnerabilities"] || [] }.flat_map(&:keys),
+          "constraint" => gems.flat_map { |g| g["constraints"] || [] }.flat_map(&:keys),
+          "language_ceiling" => gems.filter_map { |g| g["language_ceiling"] }.flat_map(&:keys),
+          "ruby" => payload.fetch("ruby").keys,
+          "summary" => payload.fetch("summary").keys,
+          "pr_context" => payload.fetch("pr_context").keys,
+        }
+        emitted.each do |defn, keys|
+          missing = schema.dig("$defs", defn, "properties").keys - keys.uniq
+          expect(missing).to(be_empty, "the exhaustive fixture never exercises #{defn} field(s): #{missing.join(", ")} -- add them so additionalProperties:false is actually tested against real emitted output")
+        end
+        top_missing = schema.fetch("properties").keys - payload.keys
+        expect(top_missing).to(be_empty, "the exhaustive fixture never exercises top-level field(s): #{top_missing.join(", ")}")
+      end
+
+      # The direct #128 regression: a key the emitters produce but the schema does
+      # not list must fail validation, not pass silently. Injecting a bogus key into
+      # the exhaustive (otherwise-valid) output confirms additionalProperties:false
+      # bites -- if this ever passes, the schema has stopped catching emitted drift.
+      it("rejects a gem carrying a key the schema does not list") do
+        poisoned = exhaustive_result
+        poisoned["rails"] = poisoned["rails"].merge(bogus_unschema_key: "x")
+        payload = emit_payload(result: poisoned)
+        errors = JSONSchemer.schema(Pathname.new(schema_path)).validate(payload).to_a
+        offending = errors.find { |e| e["data_pointer"] == "/gems/rails/bogus_unschema_key" }
+        expect(offending).not_to(be_nil, "additionalProperties:false did not reject an unschema'd gem key; errors: #{errors.map { |e| e["data_pointer"] }.inspect}")
+        expect(offending["schema_pointer"]).to(include("additionalProperties"))
+      end
+
+      # schema.json and schema.md drifted apart before #128. Keep them in step: every
+      # field schema.json defines for these object types must be documented in the
+      # prose table. Scoped to the object types schema.md documents field-by-field.
+      # LIMITATIONS: (1) language_ceiling is excluded -- schema.md documents it as a
+      # single "See SA009" row, not per sub-field, so its keys (ceiling_version,
+      # upgrade_blocked, ...) are a known, accepted doc gap rather than drift. (2) The
+      # reverse direction (every backticked token in schema.md maps to a schema
+      # property) isn't asserted: schema.md backticks example values, flags and
+      # literals too, so exact matching there is too noisy to be reliable.
+      it("documents every schema.json field in schema.md (they drifted before #128)") do
+        md = File.read(schema_md_path)
+        ["gem", "vulnerability", "constraint", "ruby", "summary"].each do |defn|
+          schema.dig("$defs", defn, "properties").each_key do |prop|
+            expect(md).to(match(/\b#{Regexp.escape(prop)}\b/), "schema.json defines #{defn}.#{prop} but schema.md never documents it")
+          end
+        end
+      end
     end
 
     it("omits ruby key when ruby info is nil") do

--- a/spec/still_active/doc_consistency_spec.rb
+++ b/spec/still_active/doc_consistency_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/still_active/sarif/rules"
+require_relative "../../lib/still_active/options"
+
+# Cross-artifact consistency: the docs are hand-written but the source of truth
+# (the SARIF rule catalog, the CLI option parser) is code. These specs derive
+# the expected set from the code and assert the docs cover it, so doc-drift
+# (a shipped rule nobody documented, a new flag missing from the README) fails
+# the suite instead of surviving to a hand audit.
+RSpec.describe("documentation consistency") do # rubocop:disable RSpec/DescribeClass -- spans two source-of-truth artifacts, not one class
+  let(:root) { File.expand_path("../..", __dir__) }
+
+  describe("SARIF rules <-> docs/rules.md") do
+    let(:rule_ids) { StillActive::Sarif::Rules.all.map { |r| r[:id] } }
+    let(:rules_md) { File.read(File.join(root, "docs", "rules.md")) }
+    # Every `## SAxxx ...` heading in docs/rules.md is a documented rule section.
+    let(:documented_ids) { rules_md.scan(/^##\s+(SA\d+)\b/).flatten }
+
+    it("documents every rule id defined in the code catalog") do
+      undocumented = rule_ids - documented_ids
+      expect(undocumented).to(
+        be_empty,
+        "rules defined in lib/still_active/sarif/rules.rb but missing a `## <id>` section in docs/rules.md: #{undocumented.join(", ")}",
+      )
+    end
+
+    it("gives each rule a lowercase anchor docs links can target") do
+      # help_uri builds `docs/rules.md#saxxx`; the section headings carry `{#saxxx}`.
+      rule_ids.each do |id|
+        expect(rules_md).to(
+          include("{##{id.downcase}}"),
+          "docs/rules.md is missing the {##{id.downcase}} anchor for #{id}",
+        )
+      end
+    end
+
+    it("README's SA-range reference spans the full catalog (lowest to highest id)") do
+      readme = File.read(File.join(root, "README.md"))
+      numeric = ->(id) { id.delete_prefix("SA").to_i }
+      lowest = rule_ids.min_by(&numeric)
+      highest = rule_ids.max_by(&numeric)
+
+      # e.g. "Rule reference (SA001-SA009)"; dash may be hyphen/en-dash/em-dash.
+      match = readme.match(/Rule reference \((SA\d+)\s*[-–—]\s*(SA\d+)\)/)
+      expect(match).not_to(
+        be_nil,
+        "README.md is missing the `Rule reference (SAxxx-SAyyy)` line",
+      )
+      expect([match[1], match[2]]).to(
+        eq([lowest, highest]),
+        "README SA-range reference is #{match[1]}-#{match[2]} but the code catalog spans #{lowest}-#{highest} (add the new rule to docs and update the range)",
+      )
+    end
+  end
+
+  describe("CLI --help <-> README help snapshot") do
+    # The real long flags still_active emits, straight from the option parser
+    # (its --help text), not a hand-maintained list.
+    let(:actual_flags) do
+      help = StillActive::Options.new.options_parser.to_s
+      help.scan(/--[a-z][a-z0-9-]*/).uniq
+    end
+
+    # The fenced ```text block under "### CLI options" that pastes the --help output.
+    let(:readme_help_block) do
+      readme = File.read(File.join(root, "README.md"))
+      block = readme[/### CLI options\s*\n+```text\n(.*?)\n```/m, 1]
+      raise "could not find the ```text CLI options block in README.md" if block.nil?
+
+      block
+    end
+
+    # No intentionally-hidden flags exist today: every opts.on in options.rb is
+    # meant to be listed (the emoji flags have no description text but still print
+    # and are documented in the README). If a truly internal flag is ever added,
+    # exclude it here with a note on why it's not user-facing.
+    let(:hidden_flags) { [] }
+
+    it("documents every long flag the CLI emits in the README help block") do
+      expected = actual_flags - hidden_flags
+      missing = expected.reject { |flag| readme_help_block.include?(flag) }
+      expect(missing).to(
+        be_empty,
+        "flags defined in lib/still_active/options.rb but missing from the README `### CLI options` block: #{missing.join(", ")}",
+      )
+    end
+  end
+end

--- a/spec/still_active/poison_security_correlator_fuzz_spec.rb
+++ b/spec/still_active/poison_security_correlator_fuzz_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/still_active/poison_security_correlator"
+
+# "Never raises" fuzz suite for PoisonSecurityCorrelator.correlate. Per the release
+# audit, correlate runs OUTSIDE any rescue in the workflow: a single raise here
+# crashes the whole audit after every fetch has already been paid for. It mutates
+# the result hash in place over the vulnerability/constraint data every provider
+# assembled, so it must tolerate the messy SCALAR shapes real providers emit --
+# the PR #129 class: a non-string advisory alias, a non-string id, a nil/non-string
+# fixed_version, a non-string resolved version.
+RSpec.describe(StillActive::PoisonSecurityCorrelator) do
+  # Reachable malformed shapes: the containers are the arrays/hashes the pipeline
+  # always builds, but the scalars inside are the garbage providers really return
+  # (deps.dev aliases as bare strings vs objects, etc.). None of these must raise.
+  reachable_malformed = {
+    "missing keys entirely" => { "a" => {} },
+    "nil values where scalars expected" => {
+      "a" => { ecosystem: nil, name: nil, version_used: nil, constraints: nil, capped_deps: nil, vulnerabilities: nil, vulnerability_count: nil },
+    },
+    "empty constraints/vulnerabilities arrays" => {
+      "a" => { ecosystem: :pypi, name: "x", constraints: [], vulnerabilities: [], vulnerability_count: 0 },
+    },
+    "non-string dependency + nil requirement in a constraint" => {
+      "a" => { ecosystem: :pypi, name: "x", constraints: [{ dependency: 123, requirement: nil, majors_behind: nil }], vulnerability_count: 1, vulnerabilities: [{ id: nil }] },
+    },
+    "non-string resolved version + non-string requirement (nested)" => {
+      "a" => { ecosystem: :npm, name: "capper", version_used: 123, capped_deps: [{ dependency: "dep", requirement: 999 }] },
+      "b" => { ecosystem: :npm, name: "dep", version_used: [1, 2], vulnerabilities: [{ id: "V", fixed_versions: [nil, 123, "2.0.0"], cvss3_score: 9.1 }] },
+    },
+    "non-string advisory id + aliases (PR #129 alias shape)" => {
+      "a" => { ecosystem: :pypi, name: "capper", constraints: [{ dependency: "dep", requirement: "< 5", majors_behind: 3, kind: :ceiling }] },
+      "b" => { ecosystem: :pypi, name: "dep", version_used: 1, vulnerability_count: 1, vulnerabilities: [{ id: 123, aliases: [456, nil, {}, "CVE-2026-1"], fixed_versions: [789, nil], cvss3_score: 8.1 }] },
+    },
+    "epoch / unparseable fixed_versions" => {
+      "a" => { ecosystem: :pypi, name: "capper", version_used: "1!2.3", constraints: [{ dependency: "dep", requirement: "< 5", majors_behind: 3, kind: :ceiling }] },
+      "b" => { ecosystem: :pypi, name: "dep", version_used: "1!2.3", vulnerability_count: 1, vulnerabilities: [{ id: "CVE-x", fixed_versions: ["1!9.9.9", "garbage"], cvss3_score: 9.8 }] },
+    },
+    "vulnerability_count positive but vulnerabilities absent" => {
+      "a" => { ecosystem: :pypi, name: "x", vulnerability_count: 3, constraints: [{ dependency: "dep", requirement: "< 5" }] },
+    },
+  }.freeze
+
+  describe "reachable malformed result objects never raise (PR #129 scalar shapes)" do
+    reachable_malformed.each do |label, result_object|
+      it "tolerates: #{label}" do
+        expect { described_class.correlate(deep_dup(result_object)) }.not_to(raise_error)
+      end
+    end
+  end
+
+  # Bounded randomized sweep: well-shaped containers (arrays of hashes, as the
+  # pipeline guarantees) filled with faker scalar garbage. Deterministic seed; the
+  # offending object prints on failure.
+  describe "randomized garbage sweep (faker)" do
+    it "never raises across 50 faker-generated result objects" do
+      seed = 20_260_705
+      rng = Random.new(seed)
+      Faker::Config.random = rng
+      50.times do |i|
+        object = build_fuzz_result(rng)
+        expect { described_class.correlate(object) }.not_to(
+          raise_error, "iteration #{i} (seed #{seed}) raised on:\n#{object.inspect}"
+        )
+      end
+    end
+
+    def build_fuzz_result(rng)
+      eco = [:pypi, :rubygems, :npm, :cargo, nil].sample(random: rng)
+      capper = {
+        ecosystem: eco,
+        name: Faker::Lorem.word,
+        version_used: [Faker::App.semantic_version, nil, rng.rand(100)].sample(random: rng),
+        constraints: fuzz_constraints(rng),
+      }
+      capper[:capped_deps] = fuzz_capped_deps(rng) if rng.rand < 0.5
+      dep = {
+        ecosystem: eco,
+        name: Faker::Lorem.word,
+        version_used: [Faker::App.semantic_version, nil].sample(random: rng),
+        vulnerability_count: rng.rand(0..3),
+        vulnerabilities: fuzz_vulns(rng),
+      }
+      { "a" => capper, "b" => dep }
+    end
+
+    def fuzz_constraints(rng)
+      Array.new(rng.rand(0..2)) do
+        { dependency: [Faker::Lorem.word, rng.rand(9)].sample(random: rng), requirement: ["< 5", nil, rng.rand(9)].sample(random: rng), majors_behind: rng.rand(0..4), kind: :ceiling }
+      end
+    end
+
+    def fuzz_capped_deps(rng)
+      Array.new(rng.rand(0..2)) do
+        { dependency: Faker::Lorem.word, requirement: ["^1.0.0", "< 5", nil].sample(random: rng) }
+      end
+    end
+
+    def fuzz_vulns(rng)
+      Array.new(rng.rand(0..3)) do
+        {
+          id: [Faker::Internet.slug, nil, rng.rand(999)].sample(random: rng),
+          aliases: [rng.rand(999), nil, "CVE-#{rng.rand(9999)}"].sample(rng.rand(0..3), random: rng),
+          fixed_versions: [Faker::App.semantic_version, nil, rng.rand(9), "garbage"].sample(rng.rand(0..3), random: rng),
+          cvss3_score: [Faker::Number.between(from: 0.0, to: 10.0), nil].sample(random: rng),
+        }
+      end
+    end
+  end
+
+  # FOUND -- robustness gaps, NOT reachable from the current pipeline. correlate is
+  # the one consumer that does NOT Array()-wrap data[:constraints] / data[:capped_deps]
+  # the way markdown_helper, sarif_helper and terminal_helper all do, and it assumes
+  # each vulnerabilities element is a Hash. The pipeline only ever assigns arrays of
+  # hashes, so these are unreachable today -- but correlate runs unguarded, so the
+  # asymmetry is worth a marker. These are `pending`: they raise now; the day someone
+  # adds the Array()/Hash guard, RSpec flips them green and flags the pending removal.
+  describe "structural invariant violations (pending: documented robustness gap)" do
+    it "does not raise when :constraints is a non-array" do
+      pending("FOUND: correlate iterates data[:constraints] without Array()-wrapping (siblings do). Unreachable from the pipeline; crashes the unguarded pass if it ever occurs.")
+      expect { described_class.correlate({ "a" => { constraints: "nope", vulnerability_count: 1, vulnerabilities: [] } }) }.not_to(raise_error)
+    end
+
+    it "does not raise when :capped_deps is a non-array" do
+      pending("FOUND: promote_nested_below_fix calls data.delete(:capped_deps).filter_map without Array()-wrapping.")
+      expect { described_class.correlate({ "a" => { ecosystem: :npm, name: "x", capped_deps: "nope" } }) }.not_to(raise_error)
+    end
+
+    it "does not raise when a :vulnerabilities element is a non-hash" do
+      pending("FOUND: candidate/every_copy_affected index vuln[:id] assuming each element is a Hash.")
+      object = {
+        "a" => { ecosystem: :pypi, name: "x", constraints: [{ dependency: "dep", requirement: "< 5" }] },
+        "b" => { ecosystem: :pypi, name: "dep", vulnerability_count: 1, vulnerabilities: ["notahash", nil, 5], version_used: "1.0.0" },
+      }
+      expect { described_class.correlate(object) }.not_to(raise_error)
+    end
+  end
+
+  # correlate mutates in place, so the fuzz sweep must not share frozen literals
+  # across iterations; a shallow-enough deep dup for our hash/array/scalar shapes.
+  def deep_dup(object)
+    case object
+    when Hash then object.transform_values { |v| deep_dup(v) }
+    when Array then object.map { |v| deep_dup(v) }
+    else object
+    end
+  end
+end

--- a/spec/still_active/sbom_reader_fuzz_spec.rb
+++ b/spec/still_active/sbom_reader_fuzz_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+# "Never raises" fuzz suite for SbomReader. SbomReader's docstring promises that a
+# missing/malformed SBOM or a bad PURL degrades to empty/unassessable -- it must
+# never backtrace, because one crash in --sbom mode drops EVERY other dependency's
+# verdict. This is the regression net for PR #129: PackageURL.parse raises a BARE
+# ArgumentError (not only the InvalidPackageURL subclass) on inputs like
+# `pkg:npm/@1.0.0` and `pkg:npm/%zz@1.0.0`, common in real Syft/Trivy output.
+#
+# Fail-first check (run once, by hand): narrow the rescue in classify_purl back to
+# `rescue PackageURL::InvalidPackageURL` and the "malformed PURLs" example below
+# goes red on `pkg:npm/@1.0.0` / `pkg:npm/%zz@1.0.0`; restore the broad `ArgumentError`
+# and it is green again.
+RSpec.describe(StillActive::SbomReader) do
+  # A one-component CycloneDX doc whose single library carries `purl`.
+  def one_lib(purl, name: "candidate")
+    { "bomFormat" => "CycloneDX", "components" => [{ "type" => "library", "name" => name, "purl" => purl }] }.to_json
+  end
+
+  # A known-good library plus a suspect one, so we can prove the good dependency
+  # still resolves while the bad one is surfaced (never silently dropped, never a
+  # crash that takes the good one down with it).
+  def good_and(purl)
+    {
+      "bomFormat" => "CycloneDX",
+      "components" => [
+        { "type" => "library", "name" => "lodash", "purl" => "pkg:npm/lodash@4.17.21" },
+        { "type" => "library", "name" => "suspect", "purl" => purl },
+      ],
+    }.to_json
+  end
+
+  # The specific bug shapes from PR #129 plus the surrounding malformed-PURL family.
+  # `pkg:npm/@1.0.0` and `pkg:npm/%zz@1.0.0` raise a BARE ArgumentError; the others
+  # raise PackageURL::InvalidPackageURL (an ArgumentError subclass), and `@@@@@@`
+  # parses but carries no version. All must degrade to an unassessable entry.
+  def malformed_purls
+    [
+      "pkg:npm/@1.0.0",    # empty name after namespace -> bare ArgumentError (PR #129)
+      "pkg:npm/%zz@1.0.0", # bad percent-encoding -> bare ArgumentError (PR #129)
+      "pkg:",
+      "pkg:npm",
+      "pkg:/@",
+      "not-a-purl",
+      "",
+      "pkg:npm/%",
+      "pkg:npm/@@@@@@",
+      "pkg:npm/%2",
+    ]
+  end
+
+  # Exotic but SPEC-VALID purls: they must parse cleanly (no raise) and either land
+  # in dependencies (supported ecosystem + version) or unassessable, never crash.
+  def exotic_valid_purls
+    [
+      "pkg:maven/org.apache.commons/commons-lang3@3.12.0",
+      "pkg:golang/github.com/open-telemetry/opentelemetry-go/exporters/otlp@1.2.3",
+      "pkg:npm/%40scope/deeply/nested@1.0.0",
+      "pkg:pypi/n%C3%A4me@1.0.0", # percent-encoded unicode name
+      "pkg:cargo/serde_derive@1.0.197",
+      "pkg:gem/nokogiri@1.16.0?platform=java",
+      "pkg:golang/gopkg.in/yaml.v3@3.0.1",
+      "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.15.2?type=jar",
+    ]
+  end
+
+  it "surfaces every malformed PURL as unassessable without raising, keeping the good dep (PR #129)" do
+    malformed_purls.each do |purl|
+      result = nil
+      expect { result = described_class.parse_string(good_and(purl)) }.not_to(
+        raise_error, "raised on purl=#{purl.inspect}"
+      )
+      expect(result).to(be_a(described_class::Result), "non-Result for purl=#{purl.inspect}")
+      # The good dependency is untouched by the bad neighbour.
+      expect(result.dependencies.map { |d| d[:name] }).to(eq(["lodash"]), "good dep dropped by purl=#{purl.inspect}")
+      # The bad component is surfaced, never silently dropped: :malformed_purl for a
+      # parse error, :no_purl for the empty string, :no_version for a purl that parses
+      # but carries no version. The contract is that it lands in unassessable.
+      expect(result.unassessable.size).to(eq(1), "bad component not surfaced for purl=#{purl.inspect}")
+      reason = result.unassessable.first[:reason]
+      expect(reason).to(
+        eq(:malformed_purl).or(eq(:no_purl)).or(eq(:no_version)), "unexpected reason #{reason.inspect} for purl=#{purl.inspect}"
+      )
+    end
+  end
+
+  it "parses exotic-but-valid PURLs without raising and never loses the component" do
+    exotic_valid_purls.each do |purl|
+      result = nil
+      expect { result = described_class.parse_string(one_lib(purl)) }.not_to(
+        raise_error, "raised on purl=#{purl.inspect}"
+      )
+      expect(result).to(be_a(described_class::Result), "non-Result for purl=#{purl.inspect}")
+      # A library component is always accounted for: assessed, or surfaced -- never dropped.
+      expect(result.dependencies.size + result.unassessable.size).to(eq(1), "component lost for purl=#{purl.inspect}")
+    end
+  end
+
+  describe "malformed CycloneDX documents degrade to an empty Result" do
+    {
+      "not-json" => "not json at all",
+      "empty object" => "{}",
+      "components is a string" => '{"components":"x"}',
+      "components is a number" => '{"components":42}',
+      "null body" => "null",
+      "bare array" => "[]",
+    }.each do |label, body|
+      it "returns an empty Result for #{label}" do
+        result = nil
+        expect { result = described_class.parse_string(body) }.not_to(raise_error)
+        expect(result).to(eq(described_class::Result.new(dependencies: [], unassessable: [])))
+      end
+    end
+
+    it "handles heterogeneous component entries (empty hash, bare library, non-hash) without raising" do
+      body = '{"components":[{}, {"type":"library"}, "not-a-hash", 7, null]}'
+      result = nil
+      expect { result = described_class.parse_string(body) }.not_to(raise_error)
+      expect(result).to(be_a(described_class::Result))
+      # The {"type":"library"} with no purl is the only assessable-shaped entry; it
+      # surfaces as no_purl. The rest are non-library noise and are dropped by design.
+      expect(result.unassessable.map { |u| u[:reason] }).to(eq([:no_purl]))
+    end
+  end
+
+  it "survives a huge component array with bad PURLs interspersed (no raise, good deps intact)" do
+    good = Array.new(3000) { |i| { "type" => "library", "name" => "pkg#{i}", "purl" => "pkg:npm/pkg#{i}@1.0.#{i}" } }
+    bad = malformed_purls.map.with_index { |p, i| { "type" => "library", "name" => "bad#{i}", "purl" => p } }
+    body = { "bomFormat" => "CycloneDX", "components" => good.concat(bad) }.to_json
+    result = nil
+    expect { result = described_class.parse_string(body) }.not_to(raise_error)
+    expect(result.dependencies.size).to(eq(3000))
+    expect(result.unassessable.size).to(eq(bad.size))
+  end
+
+  # Bounded randomized sweep: faker-generated garbage as both purl and name. The
+  # contract under test is only "never raises, always a Result" -- we do not assert
+  # a classification for arbitrary strings. Deterministic seed so a failure is
+  # reproducible; the offending input is printed in the failure message.
+  it "never raises on 50 faker-generated garbage components" do
+    seed = 20_260_705
+    rng = Random.new(seed)
+    Faker::Config.random = rng
+    50.times do |i|
+      purl = [
+        Faker::Lorem.characters(number: rng.rand(0..60)),
+        Faker::Internet.url,
+        "pkg:#{Faker::Lorem.word}/#{Faker::Internet.slug}@#{Faker::App.semantic_version}",
+        "pkg:npm/#{Faker::Lorem.characters(number: rng.rand(0..20))}@#{Faker::Lorem.word}",
+      ].sample(random: rng)
+      name = Faker::Lorem.characters(number: rng.rand(0..30))
+      body = one_lib(purl, name: name)
+
+      result = nil
+      expect { result = described_class.parse_string(body) }.not_to(
+        raise_error, "iteration #{i} (seed #{seed}) raised on purl=#{purl.inspect} name=#{name.inspect}"
+      )
+      expect(result).to(be_a(described_class::Result), "iteration #{i} returned a non-Result for purl=#{purl.inspect}")
+      # A library component is never silently dropped: it is assessed or surfaced.
+      expect(result.dependencies.size + result.unassessable.size).to(
+        eq(1), "iteration #{i} dropped the component for purl=#{purl.inspect}"
+      )
+    end
+  end
+
+  it "read/read_string never raise and return arrays for malformed input" do
+    expect { expect(described_class.read("spec/fixtures/sbom/does-not-exist.json")).to(eq([])) }.not_to(raise_error)
+    expect { expect(described_class.read_string("garbage")).to(eq([])) }.not_to(raise_error)
+    malformed_purls.each do |purl|
+      expect { described_class.read_string(one_lib(purl)) }.not_to(raise_error, "read_string raised on purl=#{purl.inspect}")
+    end
+  end
+end

--- a/spec/still_active/semver_satisfaction_fuzz_spec.rb
+++ b/spec/still_active/semver_satisfaction_fuzz_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/helpers/semver_satisfaction"
+
+# "Never raises, always tri-state" fuzz suite for SemverSatisfaction.evaluate. The
+# primitive must return true/false/nil for ANY input -- it feeds the below-the-fix
+# wall test, and a raise there would crash the poison correlator (which runs
+# unguarded). semantic_range is a node-semver port fed adversarial strings here.
+RSpec.describe(StillActive::SemverSatisfaction) do
+  def evaluate(requirement, version, ecosystem)
+    described_class.evaluate(requirement: requirement, version: version, ecosystem: ecosystem)
+  end
+
+  def tri_state = [true, false, nil]
+
+  # Adversarial requirement/version strings: empty, blank, nil, unicode, huge,
+  # epoch (PyPI `1!2.3.4`), build metadata, operator soup, partials.
+  def adversarial_inputs
+    [
+      nil,
+      "",
+      "   ",
+      "\t\n",
+      "\u{1F600}",
+      "näme",
+      "1!2.3.4",
+      "1.2.3+build.999",
+      "1.2.3-alpha+001",
+      "^",
+      "~",
+      "~>",
+      ">=",
+      "<=<",
+      "=====",
+      "||",
+      ">=1.0 || garbage",
+      "*",
+      "x",
+      "x.y.z",
+      "1.x",
+      "1.2.x",
+      "1",
+      "1.2",
+      "1.2.3",
+      "v1.2.3",
+      "0.10.38",
+      "-1",
+      "01.02.03",
+      "#{"1." * 200}0",
+      "1.0.0-#{"x" * 4000}",
+      ">=1.0, <1.5",
+      ">= 1.0.0 <2.0.0",
+      "1.2.3 - 2.3.4",
+    ]
+  end
+
+  ecosystems = [:npm, :cargo, :unknown, nil, :rubygems].freeze
+
+  describe "curated adversarial cross-product (requirement x version x ecosystem)" do
+    ecosystems.each do |ecosystem|
+      it "returns only true/false/nil for every adversarial pair under #{ecosystem.inspect}" do
+        adversarial_inputs.each do |requirement|
+          adversarial_inputs.each do |version|
+            result = nil
+            expect { result = evaluate(requirement, version, ecosystem) }.not_to(
+              raise_error, "raised on req=#{requirement.inspect} ver=#{version.inspect} eco=#{ecosystem.inspect}"
+            )
+            expect(tri_state).to(
+              include(result), "req=#{requirement.inspect} ver=#{version.inspect} eco=#{ecosystem.inspect} -> #{result.inspect}"
+            )
+          end
+        end
+      end
+    end
+  end
+
+  describe "unmodelled ecosystems are always undecidable (nil), never a raise" do
+    it "returns nil for ecosystems the primitive does not model, even with valid semver" do
+      [:rubygems, :pypi, :maven, :go, :nuget, :unknown, nil, :made_up].each do |ecosystem|
+        expect(evaluate("^1.0.0", "1.2.0", ecosystem)).to(be_nil)
+      end
+    end
+  end
+
+  # Bounded randomized sweep. Deterministic seed; the offending pair prints on
+  # failure so any regression is reproducible without a property-testing gem.
+  describe "randomized garbage sweep (faker)" do
+    it "never raises and always returns tri-state across 50 faker-generated pairs" do
+      seed = 20_260_705
+      rng = Random.new(seed)
+      Faker::Config.random = rng
+      50.times do |i|
+        requirement = [
+          Faker::App.semantic_version,
+          "^#{Faker::App.semantic_version}",
+          "~> #{Faker::App.semantic_version}",
+          Faker::Lorem.characters(number: rng.rand(0..24)),
+          Faker::Internet.slug,
+        ].sample(random: rng)
+        version = [
+          Faker::App.semantic_version,
+          "#{Faker::App.semantic_version}+#{Faker::Lorem.word}",
+          Faker::Lorem.characters(number: rng.rand(0..16)),
+          Faker::Number.number(digits: rng.rand(1..6)).to_s,
+        ].sample(random: rng)
+        ecosystem = [:npm, :cargo].sample(random: rng)
+
+        result = nil
+        expect { result = evaluate(requirement, version, ecosystem) }.not_to(
+          raise_error, "iteration #{i} (seed #{seed}) raised on req=#{requirement.inspect} ver=#{version.inspect} eco=#{ecosystem.inspect}"
+        )
+        expect(tri_state).to(
+          include(result), "iteration #{i} (seed #{seed}) req=#{requirement.inspect} ver=#{version.inspect} eco=#{ecosystem.inspect} -> #{result.inspect}"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Automates the drift + robustness checks the v3 release audits caught by hand, so they can't silently rot back in.

## What's here (test/CI only)

- **Schema conformance (exhaustive)** in `cli_spec.rb`: an all-signals fixture validated against `docs/still_active.schema.json`, an exhaustiveness proof (every schema `$defs` property must appear in emitted output), an injected-drift test (permanent regression test for #128), and schema.json ↔ schema.md consistency.
- **Doc consistency** (`doc_consistency_spec.rb`): every SA-rule id is in `docs/rules.md`, anchored, and inside the README range; every `--help` long flag is documented.
- **Fuzz "never raises"** (`sbom_reader_fuzz_spec.rb`, `semver_satisfaction_fuzz_spec.rb`, `poison_security_correlator_fuzz_spec.rb`): malformed purls/JSON, garbage version strings, and malformed internal shapes assert no crash. (The 3 correlator cases stay `pending` here; #132 adds the guard that un-pends them.)
- **Changelog CI gate** (`.github/workflows/changelog.yml`): a PR touching `lib/` must touch `CHANGELOG.md`, with a `skip-changelog` / `dependencies` / `documentation` label escape.
- **Coverage floor** (SimpleCov, `COVERAGE=1` in the Ruby 3.4 job): line 92 / branch 82 regression ratchet, measured 96.3 / 87.3.

## simplecov 1.0.0.rc5 (not 0.22)

SimpleCov 1.0 inlined `docile`, `simplecov-html`, and `simplecov_json_formatter`, so the 0.22 stable line would have dragged three transitive dev deps into the lockfile — one of them (`simplecov-html`) an **archived repo that still_active's own dogfood audit rightly flags**. Pinning `~> 1.0.0.rc5` keeps the coverage tooling out of the self-audit entirely, so **no `.still_active.yml` suppression is needed**. It's dev-only (never shipped to consumers) and the pessimistic constraint upgrades itself to 1.0.0 final.

## Verified locally

- `rubocop` clean, `rspec` 1173 examples / 0 failures, `COVERAGE=1` above floor.
- Dogfood: self-audit exits 0; `--baseline` diff vs main shows `0 regressions · 1 added` (simplecov, `ok`), exit 0.

Rebuilt clean off `main` (the earlier version had cross-contaminated commits from #132 and a since-removed baseline-diff change).
