### PR TITLE
fix: guard correlate against malformed internal shapes so it can't crash the audit

### DIFF
--- a/lib/still_active/poison_security_correlator.rb
+++ b/lib/still_active/poison_security_correlator.rb
@@ -42,8 +42,8 @@ module StillActive
         # NESTED (npm/cargo): promote a genuine below-fix candidate into :constraints.
         promote_nested_below_fix(data, copies) if data[:capped_deps]
 
-        constraints = data[:constraints]
-        next if constraints.nil? || constraints.empty?
+        constraints = hashes(data[:constraints])
+        next if constraints.empty?
 
         data[:poison_security_relevant] = true if constraints.any? { |c| c[:capped_dep_vulnerable] }
         data[:poison_below_fix] = true if constraints.any? { |c| c[:capped_below_fix] }
@@ -51,6 +51,15 @@ module StillActive
     end
 
     private
+
+    # This runs OUTSIDE the per-gem rescue (a whole-tree pass after the barrier),
+    # so a malformed shape must degrade that one entry's enrichment, never raise and
+    # crash the audit after every fetch is paid for. The pipeline always assigns
+    # arrays of hashes here, so these guards are unreachable today, but they match the
+    # defensive Array()-wrapping the sibling consumers (markdown/sarif/terminal) apply.
+    def hashes(value)
+      Array(value).grep(Hash)
+    end
 
     # Ecosystem-qualified map of each tree package's advisories AND the version it's
     # pinned at, for the FLAT path (one resolved version per name). A capped dep
@@ -64,7 +73,7 @@ module StillActive
         next unless data[:vulnerability_count].to_i.positive?
 
         name = data[:name] || key
-        map["#{data[:ecosystem]}/#{name}"] = { vulns: data[:vulnerabilities] || [], used_version: data[:version_used] }
+        map["#{data[:ecosystem]}/#{name}"] = { vulns: hashes(data[:vulnerabilities]), used_version: data[:version_used] }
       end
     end
 
@@ -76,13 +85,13 @@ module StillActive
     def copy_index(result_object)
       result_object.each_with_object({}) do |(key, data), map|
         name = data[:name] || key
-        (map["#{data[:ecosystem]}/#{name}"] ||= []) << { version: data[:version_used], vulns: data[:vulnerabilities] || [] }
+        (map["#{data[:ecosystem]}/#{name}"] ||= []) << { version: data[:version_used], vulns: hashes(data[:vulnerabilities]) }
       end
     end
 
     def mark_flat_constraints(data, advisories)
-      constraints = data[:constraints]
-      return if constraints.nil? || constraints.empty?
+      constraints = hashes(data[:constraints])
+      return if constraints.empty?
 
       eco = data[:ecosystem]
       constraints.each do |constraint|
@@ -105,7 +114,7 @@ module StillActive
     def promote_nested_below_fix(data, copies)
       eco = data[:ecosystem]
       # Consume the candidates: they are an internal work-list, never serialized.
-      promoted = data.delete(:capped_deps).filter_map do |candidate|
+      promoted = hashes(data.delete(:capped_deps)).filter_map do |candidate|
         dep_copies = copies["#{eco}/#{candidate[:dependency]}"] || []
         nested_below_fix(eco, candidate[:dependency], candidate[:requirement], dep_copies)
       end

--- a/spec/still_active/poison_security_correlator_fuzz_spec.rb
+++ b/spec/still_active/poison_security_correlator_fuzz_spec.rb
@@ -108,26 +108,22 @@ RSpec.describe(StillActive::PoisonSecurityCorrelator) do
     end
   end
 
-  # FOUND -- robustness gaps, NOT reachable from the current pipeline. correlate is
-  # the one consumer that does NOT Array()-wrap data[:constraints] / data[:capped_deps]
-  # the way markdown_helper, sarif_helper and terminal_helper all do, and it assumes
-  # each vulnerabilities element is a Hash. The pipeline only ever assigns arrays of
-  # hashes, so these are unreachable today -- but correlate runs unguarded, so the
-  # asymmetry is worth a marker. These are `pending`: they raise now; the day someone
-  # adds the Array()/Hash guard, RSpec flips them green and flags the pending removal.
-  describe "structural invariant violations (pending: documented robustness gap)" do
+  # Structural invariants, NOT reachable from the current pipeline (producers only
+  # ever assign arrays of hashes) but guarded anyway: correlate now Array()-wraps
+  # data[:constraints] / data[:capped_deps] and skips non-hash elements, matching the
+  # defensive wrapping markdown_helper, sarif_helper and terminal_helper already apply.
+  # Since correlate runs OUTSIDE the per-gem rescue, a malformed shape must degrade
+  # that entry's enrichment rather than crash the whole audit.
+  describe "structural invariant violations (guarded: robustness)" do
     it "does not raise when :constraints is a non-array" do
-      pending("FOUND: correlate iterates data[:constraints] without Array()-wrapping (siblings do). Unreachable from the pipeline; crashes the unguarded pass if it ever occurs.")
       expect { described_class.correlate({ "a" => { constraints: "nope", vulnerability_count: 1, vulnerabilities: [] } }) }.not_to(raise_error)
     end
 
     it "does not raise when :capped_deps is a non-array" do
-      pending("FOUND: promote_nested_below_fix calls data.delete(:capped_deps).filter_map without Array()-wrapping.")
       expect { described_class.correlate({ "a" => { ecosystem: :npm, name: "x", capped_deps: "nope" } }) }.not_to(raise_error)
     end
 
     it "does not raise when a :vulnerabilities element is a non-hash" do
-      pending("FOUND: candidate/every_copy_affected index vuln[:id] assuming each element is a Hash.")
       object = {
         "a" => { ecosystem: :pypi, name: "x", constraints: [{ dependency: "dep", requirement: "< 5" }] },
         "b" => { ecosystem: :pypi, name: "dep", vulnerability_count: 1, vulnerabilities: ["notahash", nil, 5], version_used: "1.0.0" },


### PR DESCRIPTION
Closes an asymmetry in `PoisonSecurityCorrelator`. `correlate` runs **outside** the per-gem rescue (a whole-tree pass after the fan-out barrier), so any raise there crashes the entire audit *after every network fetch is already paid for*. Yet it was the one consumer that indexed `data[:constraints]`, `data[:capped_deps]`, and each `:vulnerabilities` element without the defensive `Array()`-wrapping its siblings (`markdown_helper`, `sarif_helper`, `terminal_helper`) all apply.

A single private `hashes(value) = Array(value).grep(Hash)` helper at the five index/read sites keeps behaviour **identical for well-shaped input** and turns three hypothetical malformed shapes (non-array `:constraints`/`:capped_deps`, non-hash `:vulnerabilities` element) from "crash the whole audit" into "degrade this one entry's enrichment" — the same trade-off the sibling renderers already accept.

Honest scope: these shapes are **unreachable from the current pipeline** (producers only ever assign arrays of hashes), so this fixes no live bug. It's the robustness half of the fuzz-hardening batch — it flips the three documented-gap fuzz tests in `poison_security_correlator_fuzz_spec.rb` from `pending` to passing.

## Verified

- `rubocop` clean; full suite 1173 examples / 0 failures; the correlator fuzz spec is 12/0 with **no pending**.
- **silent-failure review**: traced all three keys to every producer (native `workflow.rb` + cross-eco `ecosystem_lens.rb`/`sbom_workflow.rb`). `Array(value).grep(Hash)` is a behavioural no-op today (every reachable value is `Array<Hash>` or nil), no `Array()` pair-mangling risk (no producer assigns a bare Hash), and no false-clean path — a partial-failure entry has these keys *absent*, not malformed. Degrades symmetric to the siblings.

Internal-only, no user-facing change → `skip-changelog`. Rebuilt clean off `main` (the earlier version had a leaked SimpleCov commit and a duplicated baseline-diff change from the untangling).
