### PR TITLE
ci(dogfood): audit the local gem, not the published one

### DIFF
--- a/.github/workflows/still_active.yml
+++ b/.github/workflows/still_active.yml
@@ -22,10 +22,23 @@ jobs:
         with:
           ruby-version: '4.0'
           bundler-cache: true
-      - uses: SeanLF/still_active-action@v0
-        with:
-          github-token: ${{ github.token }}
-          sarif: still_active.sarif.json
+
+      # Dogfood the code on THIS ref, not a published gem. The published-gem
+      # path (the SeanLF/still_active-action@v0 install) lags main by a release,
+      # so it never exercised what main is about to ship; `bundle exec` runs the
+      # local still_active. The action is validated separately (its own repo).
+      #
+      # Fetch rubysec/ruby-advisory-db first so still_active's dual-source merge
+      # is active (bundler-audit is a dev dependency; the DB ships separately).
+      # Best-effort: on failure still_active falls back to deps.dev only.
+      - name: Update ruby-advisory-db (enables dual-source vulnerabilities)
+        run: bundle exec bundle-audit update || echo "::warning::bundle-audit update failed; still_active will use deps.dev only"
+
+      - name: Audit still_active's own dependencies -> SARIF
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bundle exec still_active --sarif=still_active.sarif.json
+
       - uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:


### PR DESCRIPTION
The `Dependency audit` job installed still_active via `SeanLF/still_active-action@v0`, which does `gem install still_active` at the latest **stable** version. So CI has been auditing its own dependencies with a release-behind published gem (2.0.0) and **never the code on main it's about to ship** — which is why 3.0's behaviour was never exercised through this job.

Switches the job to `bundle exec still_active --sarif=...` (the local gem on this ref), mirroring the `--baseline` diff job which already uses the local gem. Fetches ruby-advisory-db first for the dual-source vulnerability merge (the one convenience the action provided). The action is validated in its own repo, so no coverage is lost.

Verified locally: `bundle exec still_active --sarif=` exits 0 and writes valid SARIF (9 rules, 19 results). This PR's own audit job runs the new workflow, so it self-validates.