### PR TITLE
chore(release): 3.0.0.rc2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    still_active (3.0.0.rc1)
+    still_active (3.0.0.rc2)
       async (>= 2.2)
       bundler (>= 2.0)
       faraday-retry
@@ -249,7 +249,7 @@ CHECKSUMS
   semantic_range (3.1.1) sha256=508333196ef0c7ba33e79579d4df7eb0a41080595e6a655c2515b03d634ec4a9
   simplecov (1.0.0.rc5) sha256=069108264a60335ebaa014a963b595e15d21541067019659c87bc4e9d6b18743
   simpleidn (0.2.3) sha256=08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29
-  still_active (3.0.0.rc1)
+  still_active (3.0.0.rc2)
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   traces (0.18.2) sha256=80f1649cb4daace1d7174b81f3b3b7427af0b93047759ba349960cb8f315e214

--- a/lib/still_active/version.rb
+++ b/lib/still_active/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module StillActive
-  VERSION = "3.0.0.rc1"
+  VERSION = "3.0.0.rc2"
 end


### PR DESCRIPTION
Second release candidate for 3.0, cut to roll in the stale pre-release fix (#139) before wider soak.

## What changed since rc1

- **#139** A pre-release older than the latest stable no longer reads as a live upgrade target. Previously `up_to_date` compared the version in hand against a stale rc, so a gem that was actually behind got the "futurist" marker and the pre-release column filled with superseded rcs. On a real audit (forem's bundle) this had been mislabelling roughly twenty gems.

## Release mechanics

- `version.rb` -> `3.0.0.rc2`, `Gemfile.lock` refreshed. Same two-file shape as the rc1 bump (#136).
- Still a **prerelease**: a plain `gem install still_active` and the Action's `version: latest` keep resolving to 2.0.0; only `--pre` or an explicit pin picks up rc2.
- Changelog stays under `[Unreleased]` until the final 3.0.0.
- Publish happens on a **published GitHub Release** (`v3.0.0.rc2`, marked prerelease), which triggers trusted publishing via `publish.yml`.
