### PR TITLE
chore(deps): refresh gems and adopt rubocop-shopify 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,18 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in still_active.gemspec
 gemspec
 
-gem "rake", ">= 13.0"
-gem "rspec", ">= 4.0.0.beta1"
-gem "simplecov", "~> 1.0.0.rc5", require: false
-gem "vcr"
-gem "webmock"
+group :development, :test do
+  gem "bundler-audit"
+  gem "debug"
+  gem "faker"
+  gem "json_schemer"
+  gem "rake", ">= 13.0"
+  gem "rspec", ">= 4.0.0.beta1"
+  gem "rubocop"
+  gem "rubocop-performance"
+  gem "rubocop-rspec"
+  gem "rubocop-shopify"
+  gem "simplecov", "~> 1.0.1", require: false
+  gem "vcr"
+  gem "webmock"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,14 +27,13 @@ GEM
       bundler (>= 1.2.0)
       thor (~> 1.0)
     concurrent-ruby (1.3.7)
-    console (1.36.0)
+    console (1.37.0)
       fiber-annotation
       fiber-local (~> 1.1)
       json
     crack (1.0.1)
       bigdecimal
       rexml
-    date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
@@ -60,13 +59,13 @@ GEM
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
-    io-event (1.19.1)
+    io-event (1.19.2)
     irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.20.0)
+    json (2.21.1)
     json_schemer (2.5.0)
       bigdecimal
       hana (~> 1.3)
@@ -83,23 +82,25 @@ GEM
       sawyer (~> 0.9)
     packageurl-ruby (0.2.0)
     parallel (2.1.0)
-    parser (3.3.11.1)
+    parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
     pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
     prism (1.9.0)
-    psych (5.4.0)
-      date
-      stringio
     public_suffix (7.0.5)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.4.2)
-    rdoc (7.2.0)
+    rbs (4.0.3)
+      logger
+      prism (>= 1.6.0)
+      tsort
+    rdoc (8.0.0)
       erb
-      psych (>= 4.0.0)
+      prism (>= 1.6.0)
+      rbs (>= 4.0.0)
       tsort
     regexp_parser (2.12.0)
     reline (0.6.3)
@@ -140,16 +141,16 @@ GEM
       lint_roller (~> 1.1)
       regexp_parser (>= 2.0)
       rubocop (~> 1.86, >= 1.86.2)
-    rubocop-shopify (2.18.0)
-      rubocop (~> 1.62)
+    rubocop-shopify (3.0.1)
+      lint_roller
+      rubocop (~> 1.72, >= 1.72.1)
     ruby-progressbar (1.13.0)
     sawyer (0.9.3)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     semantic_range (3.1.1)
-    simplecov (1.0.0.rc5)
+    simplecov (1.0.1)
     simpleidn (0.2.3)
-    stringio (3.2.0)
     thor (1.5.0)
     traces (0.18.2)
     tsort (0.2.0)
@@ -178,7 +179,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rspec
   rubocop-shopify
-  simplecov (~> 1.0.0.rc5)
+  simplecov (~> 1.0.1)
   still_active!
   vcr
   webmock
@@ -191,9 +192,8 @@ CHECKSUMS
   bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
-  console (1.36.0) sha256=45599ea906cf80a73d8941f03abf873fe66a6a954e0bac5bc1c01e2cdc406f07
+  console (1.37.0) sha256=8093b286c2595a063849c098594fee5155ecc7967d36f3aa8cbe7569c8f3efd7
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
-  date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   diff-lcs (2.0.0) sha256=708a5d52ec2945b50f8f53a181174aa1ef2c496edf81c05957fe956dabb363d5
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
@@ -209,9 +209,9 @@ CHECKSUMS
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
-  io-event (1.19.1) sha256=851aa9a318889cbfdaa9a982b5cd266750f893748752a17f52f880d93ceb6ee6
+  io-event (1.19.2) sha256=c9ac4f0c3153b453727ab15c03cc762b29a207979c703b2bb15c8be6209d4b4c
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
-  json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
+  json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
   json_schemer (2.5.0) sha256=2f01fb4cce721a4e08dd068fc2030cffd0702a7f333f1ea2be6e8991f00ae396
   language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
@@ -221,16 +221,16 @@ CHECKSUMS
   octokit (10.0.0) sha256=82e99a539b7637b7e905e6d277bb0c1a4bed56735935cc33db6da7eae49a24e8
   packageurl-ruby (0.2.0) sha256=9bef22c96622b7d3a0087a7fbca8903f9187b66fbfd6a78299ef115768f5012b
   parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
-  parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
   pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
-  psych (5.4.0) sha256=14f72d69a611af663d7d70e4a7b67d9eb1f3ae9f8d916b478961d5a0075ba5b7
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  rdoc (7.2.0) sha256=8650f76cd4009c3b54955eb5d7e3a075c60a57276766ebf36f9085e8c9f23192
+  rbs (4.0.3) sha256=5a7bf70e2628549d9a1f44eae447b2cfe55968a9c60cfff52693a4bdcc020e14
+  rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
@@ -243,14 +243,13 @@ CHECKSUMS
   rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
   rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
   rubocop-rspec (3.10.2) sha256=0b3e2ecc592cd10ecbf0095bb58d1e357905276e069643523cc19eb7495f65e2
-  rubocop-shopify (2.18.0) sha256=dafa25e5617ce4600ff86b1de3d5b78e43ab3d58cc5729df38e492b8e10294eb
+  rubocop-shopify (3.0.1) sha256=4adffa6313294bd9da2b0896ae44c5eb8e419336b2413de20c38b7691a7e6774
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   sawyer (0.9.3) sha256=0d0f19298408047037638639fe62f4794483fb04320269169bd41af2bdcf5e41
   semantic_range (3.1.1) sha256=508333196ef0c7ba33e79579d4df7eb0a41080595e6a655c2515b03d634ec4a9
-  simplecov (1.0.0.rc5) sha256=069108264a60335ebaa014a963b595e15d21541067019659c87bc4e9d6b18743
+  simplecov (1.0.1) sha256=419d93c40484159d20b40e26e9a83cdd4c3afa2f3fd443bb8946c301cd658d75
   simpleidn (0.2.3) sha256=08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29
   still_active (3.0.0.rc4)
-  stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   traces (0.18.2) sha256=80f1649cb4daace1d7174b81f3b3b7427af0b93047759ba349960cb8f315e214
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f

--- a/lib/still_active/ecosystems_client.rb
+++ b/lib/still_active/ecosystems_client.rb
@@ -26,7 +26,7 @@ module StillActive
     # carries per-version declared dependency constraints (the poison-pill input).
     PACKAGES_BASE_URI = URI("https://packages.ecosyste.ms/")
     # ecosyste.ms asks consumers to identify themselves for its "polite pool".
-    USER_AGENT = "still_active/#{StillActive::VERSION} (+https://github.com/SeanLF/still_active)"
+    USER_AGENT = "still_active/#{StillActive::VERSION} (+https://github.com/SeanLF/still_active)".freeze
 
     # archived + last-commit date from a single repository call. ecosyste.ms's
     # pushed_at mirrors GitHub's, so this returns the same shape as GithubClient.

--- a/lib/still_active/pypi_client.rb
+++ b/lib/still_active/pypi_client.rb
@@ -20,7 +20,7 @@ module StillActive
 
     BASE_URI = URI("https://pypi.org/")
     # Polite identification, matching EcosystemsClient's convention.
-    USER_AGENT = "still_active/#{StillActive::VERSION} (+https://github.com/SeanLF/still_active)"
+    USER_AGENT = "still_active/#{StillActive::VERSION} (+https://github.com/SeanLF/still_active)".freeze
 
     # The PEP 440 `requires_python` specifier a release declares (e.g.
     # ">=3.8,<3.13"), or nil when the version is unreadable or declares none.

--- a/still_active.gemspec
+++ b/still_active.gemspec
@@ -44,15 +44,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Abin/still_active}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency("bundler-audit")
-  spec.add_development_dependency("debug")
-  spec.add_development_dependency("faker")
-  spec.add_development_dependency("json_schemer")
-  spec.add_development_dependency("rubocop")
-  spec.add_development_dependency("rubocop-performance")
-  spec.add_development_dependency("rubocop-rspec")
-  spec.add_development_dependency("rubocop-shopify")
-
   # 2.0/2.1 ship a scheduler that breaks our fan-out (io_read); 2.2 is the
   # verified floor (checked against Ruby 3.3 in Docker). octokit/faraday-retry/
   # gems work down to ancient versions, so they stay unpinned rather than


### PR DESCRIPTION
## What

Routine dependency refresh, plus taking the **rubocop-shopify 3.0** major
instead of pinning away from it.

### Version bumps
`console` 1.37.0, `io-event` 1.19.2, `json` 2.21.1, `parser` 3.3.12.0,
`rdoc` 8.0.0, `simplecov` 1.0.1, `rubocop-shopify` 3.0.1. All dev/transitive,
no runtime dependency of the published gem changed.

`simplecov` moves off the `~> 1.0.0.rc5` pin: 1.0.1 still inlines the archived
`docile`/`simplecov-html` deps that motivated pinning the rc, so the stable
release keeps the `.still_active.yml` suppression chain gone.

### rubocop-shopify 3.0

3.0 drops all `Layout/*` cops and enables a focused lint set. Its two new
offenses are fixed at the source, not suppressed:

- **`Style/MutableConstant`** — froze the interpolated `USER_AGENT` constants.
  `frozen_string_literal` does not freeze an interpolated string (it is a fresh
  mutable `String` at runtime), so the explicit `.freeze` is the correct fix.
- **`Gemspec/DevelopmentDependencies`** — moved the 8 dev deps out of the
  gemspec into a `group :development, :test` block in the Gemfile. This also
  corrects Dependabot: the already-top-level dev gems
  (`rake`/`rspec`/`vcr`/`webmock`/`simplecov`) were being classified as
  `production`; the whole dev toolchain is now grouped consistently.

## Why 3.0 (not a pin)

3.0's "drop Layout, keep a focused lint set, no bundled formatter" is where
mainstream Ruby linting is heading in 2026: the `rubocop-rails-omakase` default
and the ruby-lsp consolidation both point the same way (linter lints, formatter
formats). Adopting it keeps this repo in step.

## Known follow-up

3.0 no longer enforces layout and ships no formatter, so whitespace is now
unenforced here. A separate change should wire up a formatter (`syntax_tree`
is the most defensible pick) to replace the dropped enforcement.

## Verification

- `rake` clean (127 files, 0 rubocop offenses)
- full suite: 1246 passing, 3 pending
- floors suite (`BUNDLE_GEMFILE=Gemfile.floors bundle exec rspec`): green
