### PR TITLE
chore(git): hide the Standard reformat from git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Revisions to skip in `git blame` (bulk mechanical reformats, no authorship signal).
+# Configured locally by bin/setup: git config blame.ignoreRevsFile .git-blame-ignore-revs
+# GitHub's blame view honors this file automatically.
+
+# chore(lint): adopt Standard Ruby, replacing rubocop-shopify (#152)
+1c5edbebdf12631a259b4e2b5f5935836d959d37

--- a/bin/setup
+++ b/bin/setup
@@ -8,3 +8,6 @@ bundle install
 # Wire git hooks shared via .githooks/. Pre-push runs the default rake task
 # (rspec + standard) so cross-file lint issues don't escape to CI.
 git config core.hooksPath .githooks
+
+# Make `git blame` skip bulk mechanical reformats (see .git-blame-ignore-revs).
+git config blame.ignoreRevsFile .git-blame-ignore-revs


### PR DESCRIPTION
Adds `.git-blame-ignore-revs` referencing the #152 bulk `standardrb` reformat (commit `1c5edbe`), so `git blame` attributes lines to their real authors instead of the mechanical restyle.

- **`.git-blame-ignore-revs`**: the one reformat SHA, commented.
- **`bin/setup`**: wires `git config blame.ignoreRevsFile .git-blame-ignore-revs` so every contributor's local blame honors it. GitHub's blame view respects the file automatically, no config needed there.

Verified: on `lib/still_active/pypi_client.rb`, the reformat blames 1 line raw and 0 lines with the ignore file active.

No `lib/` behaviour change (changelog check auto-skips).