### PR TITLE
chore(deps): bump transitive dev gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     diff-lcs (2.0.0)
-    erb (6.0.6)
+    erb (6.0.7)
     faker (3.8.0)
       i18n (>= 1.8.11, < 2)
     faraday (2.14.3)
@@ -56,8 +56,8 @@ GEM
     hashdiff (1.2.1)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
-    io-console (0.8.2)
-    io-event (1.19.4)
+    io-console (0.9.2)
+    io-event (1.19.5)
     irb (1.18.0)
       pp (>= 0.6.0)
       prism (>= 1.3.0)
@@ -90,7 +90,7 @@ GEM
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.4.2)
-    rbs (4.1.0)
+    rbs (4.1.3)
       logger
       prism (>= 1.6.0)
       tsort
@@ -100,7 +100,7 @@ GEM
       rbs (>= 4.0.0)
       tsort
     regexp_parser (2.12.0)
-    reline (0.6.3)
+    reline (0.7.0)
       io-console (~> 0.5)
     rexml (3.4.4)
     rspec (4.0.0.beta1)
@@ -215,7 +215,7 @@ CHECKSUMS
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   diff-lcs (2.0.0) sha256=708a5d52ec2945b50f8f53a181174aa1ef2c496edf81c05957fe956dabb363d5
-  erb (6.0.6) sha256=a9b24986700f5bf127c4f297c5403c3ca41b83b0a316c0cd09a096b56e644ae5
+  erb (6.0.7) sha256=c5ca6dc25b0ef974a44dc8f59fe847577122483b1968a38dec305c60bf91ee92
   faker (3.8.0) sha256=c147b308df73a90f27a4fc84f18d4c22ef0ad9c2a64b2b61c86fd0ca71753efc
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
@@ -227,8 +227,8 @@ CHECKSUMS
   hana (1.3.7) sha256=5425db42d651fea08859811c29d20446f16af196308162894db208cac5ce9b0d
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
   i18n (1.15.2) sha256=00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5
-  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
-  io-event (1.19.4) sha256=c291146e2e70849b9d6b64078f8e98f0154bfd3bc4f9759861ff13e9895e0cce
+  io-console (0.9.2) sha256=efa74f891dd03c0939a931dfc6e74c2813d904763d456ea9762b0525e748db08
+  io-event (1.19.5) sha256=b168a9b7c5a0e894f2047f82f4bf831f59edd067843005e930a62f375738bad2
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   json_schemer (2.5.0) sha256=2f01fb4cce721a4e08dd068fc2030cffd0702a7f333f1ea2be6e8991f00ae396
@@ -247,10 +247,10 @@ CHECKSUMS
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
-  rbs (4.1.0) sha256=8baba59008b0643b4ba2090e9b1d0149655b0bbd42eb2ffe42b1d0eb6923fd72
+  rbs (4.1.3) sha256=0c4474a9751cdc14364bfad0b3e53678323bbdc2c31683b0445932867dbab8c4
   rdoc (8.0.0) sha256=03bf8c08a9639658855a0cfd77c0abca8325c227693f7f33f82957811348c469
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
-  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  reline (0.7.0) sha256=5b012d8e55dbf9d450f12bde2cf7d15ff546ae80b3f8f3b30e570d431815583d
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rspec (4.0.0.beta1) sha256=7edd7fb4e25fe5544146268196bc43b610851ea61581f38fe6ac1f03f4ca6114
   rspec-core (4.0.0.beta1) sha256=11ad8b2f752d08aa5ecc699bd534f2253fe0939144af94365791f99bbefb575e


### PR DESCRIPTION
Routine lockfile refresh from `bundle update`. All five are transitive; no direct dependency moved, so no gemspec floor is affected and `Gemfile.floors` is untouched.

| gem | from | to |
|---|---|---|
| `erb` | 6.0.6 | 6.0.7 |
| `io-console` | 0.8.2 | 0.9.2 |
| `io-event` | 1.19.4 | 1.19.5 |
| `rbs` | 4.1.0 | 4.1.3 |
| `reline` | 0.6.3 | 0.7.0 |

## Deliberately held back

Three gems have newer releases but stay pinned, each by the Standard gem that owns it (read from `Gemfile.lock`, not inferred):

| gem | current | latest | pinned by |
|---|---|---|---|
| `rubocop` | 1.88.2 | 1.89.0 | `standard` 1.56 → `rubocop ~> 1.88.0` |
| `rubocop-performance` | 1.26.1 | 1.27.0 | `standard-performance` 1.9 → `~> 1.26.0` |
| `rubocop-capybara` | 2.23.0 | 3.0.0 | `standard-rspec` 0.5.0 → `~> 2.23` |

Standard owns its cop set, so forcing past those pins would change what we lint against without Standard having vetted the new cops. Given what #152 turned up — a linter release quietly changing which bug-catching cops are enabled — the cop set is exactly the thing not to move on our own initiative. These wait for Standard to move.

## Verification

`rake` green on this branch rebased onto `main`: **1309 examples, 0 failures, 4 pending** (pending = the optional `cvss-suite` integration, not installed locally).

Worth flagging: before the rebase this branch was **red**, but not from the bump. It inherited a pre-existing timezone bug in the SARIF EOL-date renderer that only manifests east of UTC, so UTC-based CI never saw it. Fixed separately in #162; this is rebased on top of that.

No CHANGELOG entry: lockfile-only, no code change.
