### PR TITLE
docs: say which interface is supported, because one of them is not

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ still_active --json > /tmp/main.json && still_active --baseline=/tmp/main.json
 ```
 </details>
 
+Building on top of still_active? The versioned JSON envelope is the supported interface (the Ruby constants are internal): [`docs/schema.md`](docs/schema.md).
+
 Rule reference (SA001-SA010), suppression, and composing with `dependency-review-action`: [`docs/rules.md`](docs/rules.md), [`docs/ci.md`](docs/ci.md). This repo audits itself every push, so you can browse live findings in its [Code Scanning tab](https://github.com/SeanLF/still_active/security/code-scanning?query=tool%3Astill_active+is%3Aopen).
 
 ## Cross-ecosystem audit

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -118,6 +118,19 @@ A digest so a consumer reads the headline posture without iterating every gem. C
 | `latest_release_date` | string \| nil | ISO-8601 timestamp. |
 | `libyear` | float \| nil | Years between current Ruby release and latest. |
 
+## The supported integration surface
+
+**This JSON envelope is the API.** If you are building on top of still_active, parse this (or the SARIF output, or the CycloneDX output). Those are versioned, contract-tested against real output, and covered by the policy below.
+
+**The Ruby constants under `StillActive::` are internal**, and are not a supported interface even though they are technically public. Concretely, they are not usable as one:
+
+- `StillActive.config` is a process-global mutable singleton read from across the library, so two audits with different settings cannot run in one process, and concurrent use is unsafe.
+- `Workflow.call` takes no arguments; it reads its input from that singleton.
+- Every threshold decision (`--fail-if-*` and suppression matching) is private to `CLI`, so there is no supported way to ask "is this result a failure under these thresholds" without reimplementing it.
+- `CLI#run` calls `exit` directly, so it cannot be embedded.
+
+None of this is an oversight to be worked around; it is what makes the CLI simple. Shell out and parse the output. If you need something the output does not carry, that is worth [an issue](https://github.com/SeanLF/still_active/issues) rather than reaching into the internals, because the internals will change without a `schema_version` bump and the output will not.
+
 ## Versioning policy
 
 - **Additive changes** (new fields): no schema bump.


### PR DESCRIPTION
## Why

still_active cannot be embedded as a library, and nothing said so. The constants under `StillActive::` are technically public, so a dependent could reasonably assume they are an interface, then discover the hard way that:

- `StillActive.config` is a process-global mutable singleton, read across 19 files, so two audits with different settings cannot run in one process and concurrent use is unsafe
- `Workflow.call` takes no arguments; it reads its input from that singleton
- every threshold decision (`--fail-if-*`, suppression matching) is private to `CLI` and defined nowhere else
- `CLI#run` calls `exit` directly

Each of those was checked against the source rather than recalled.

That is a perfectly good set of tradeoffs for a CLI. It just needs to be stated, so the JSON, SARIF and CycloneDX outputs are understood as the contract, and the internals are understood as free to change without a `schema_version` bump.

Adds a "supported integration surface" section to `docs/schema.md` and one line in the README pointing at it. Docs only, no behaviour change.
