### PR TITLE
docs: give the --sbom JSON a written contract before 3.0 freezes it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ The new `--fail-if-poison[=TIER]` and `--fail-if-language-ceiling[=TIER]` gates 
 
 ### Fixed
 
+- **The `--sbom` JSON output is documented.** It is a 3.0 headline feature that emits `schema_version: 1` while `docs/schema.md` described only the Gemfile audit's shape, so two structurally different documents both claimed version 1 and one of them had no written contract at all. The cross-ecosystem envelope, its `unassessable` entries, and the fields specific to that path (`ecosystem`, `name`, `purl`, `production`, `direct`, `dependency_path`, `version_unresolved`) are now documented, along with the rule for telling the two apart: check for `gems` versus `dependencies`, not `schema_version`. A doc-consistency spec now fails if the `--sbom` path emits a field that document never mentions, since unlike the native output there is no JSON Schema to catch it.
+
 - **Verified against five real SBOM generators, not one.** The `--sbom` path is now exercised in the test suite against verbatim output from Syft, Trivy, `npm sbom`, `cyclonedx-npm` and `cyclonedx-py`, committed as fixtures rather than hand-written. They disagree about nearly everything a reader could naively depend on: three CycloneDX spec versions (1.5, 1.6, 1.7), four `metadata.component` types including absent entirely, and five mutually incompatible bom-ref conventions (a PURL with a `package-id` qualifier, a bare UUID, `name@version`, a pipe-delimited parent/child path, and a requirements-file line number). Given the same project all five now produce the same verdict, and the suite fails if a future change makes one of them disagree. This closes the gap behind both SBOM bugs found before it: a synthetic fixture only ever encodes the shape whoever wrote it already had in mind.
 
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -118,6 +118,50 @@ A digest so a consumer reads the headline posture without iterating every gem. C
 | `latest_release_date` | string \| nil | ISO-8601 timestamp. |
 | `libyear` | float \| nil | Years between current Ruby release and latest. |
 
+## The `--sbom` output is a different shape
+
+A cross-ecosystem audit emits a **different document** from the Gemfile audit, and the two are told apart by their keys, not by `schema_version`:
+
+| | native (`--gemfile` / `--gems`) | cross-ecosystem (`--sbom`) |
+| --- | --- | --- |
+| `$schema` | present, points at this schema | **absent** |
+| dependency map | `gems`, keyed by bare gem name | `dependencies`, keyed `ecosystem/name@version` |
+| coverage gaps | n/a | `unassessable` array |
+| `ruby` / `pr_context` | present when known | absent |
+
+**Check for `gems` versus `dependencies`, not `schema_version`.** Both documents carry `schema_version: 1`, because the versioning policy below governs both, but only the native one claims this schema. The SBOM output deliberately omits `$schema`: pointing at a contract it does not match would be a false claim.
+
+The SBOM output is **not** covered by the JSON Schema file. It is documented here and versioned by the same policy, and that difference is deliberate rather than an omission: composite keys and an `unassessable` list do not fit the native `gem` definition.
+
+### Envelope
+
+| field | type | notes |
+| --- | --- | --- |
+| `schema_version` | integer | `1`. Same policy as the native output. |
+| `tool` | object | `{ name, version }`. |
+| `generated_at` | string | ISO-8601 timestamp. |
+| `summary` | object | `total_assessed`, `unassessable_count`, `status` (worst per-dependency verdict), `status_counts` (a tally per status). |
+| `dependencies` | object | Keyed `ecosystem/name@version`, so a package appearing at two versions in a merged SBOM does not collide. |
+| `unassessable` | array | Components that could not be assessed. Never silently dropped. |
+
+### Per dependency
+
+Most fields carry the same meaning as the native `gem` object above, so they are not repeated here: `activity_level`, `archived`, `deprecated`, `deprecation_reason`, `last_commit_date`, `latest_version`, `latest_version_release_date`, `libyear`, `license`, `repository_url`, `scorecard_maintained`, `scorecard_score`, `status`, `up_to_date`, `version_used`, `version_used_release_date`, `vulnerabilities`, `vulnerability_count`.
+
+Fields specific to this path:
+
+| field | type | notes |
+| --- | --- | --- |
+| `ecosystem` | string | `npm`, `pypi`, `cargo`, `go`, `maven`, `nuget`, `rubygems`. The native audit is Ruby by definition, so it has nothing to disambiguate. |
+| `name` | string | The bare package name. The native result is keyed by it; here the key is composite, so it is carried as a field. |
+| `purl` | string | The input SBOM's own package URL, kept verbatim (minus Syft's `package-id` bookkeeping) so an enriched SBOM re-emits what the consumer already matched on. |
+| `production` | bool | Present only when the SBOM marks dev-vs-prod scope. Absent means unknown, never assumed production. |
+| `direct` | bool | Present only when the SBOM's dependency graph places the package. **Absent means the document could not say**, which is not the same as `false`. |
+| `dependency_path` | array | Present only for a transitive package, head-first, naming the declared dependency that pulls it in as `ecosystem/name`. |
+| `version_unresolved` | bool | The pinned version could not be resolved while the package could. The cross-ecosystem analogue of `version_yanked`. |
+
+Each `unassessable` entry carries `ecosystem`, `name` and a `reason` (an unsupported ecosystem, a missing version or PURL, a private registry, a malformed PURL, or a failed lookup), plus `version` and `production` when known.
+
 ## The supported integration surface
 
 **This JSON envelope is the API.** If you are building on top of still_active, parse this (or the SARIF output, or the CycloneDX output). Those are versioned, contract-tested against real output, and covered by the policy below.

--- a/spec/still_active/doc_consistency_spec.rb
+++ b/spec/still_active/doc_consistency_spec.rb
@@ -87,4 +87,47 @@ RSpec.describe("documentation consistency") do # rubocop:disable RSpec/DescribeC
       )
     end
   end
+
+  # The --sbom JSON carries `schema_version: 1` but is NOT covered by the JSON
+  # Schema file, so nothing but this stops its documented shape drifting from the
+  # emitted one. It went undocumented entirely until a pre-3.0 readiness pass
+  # noticed two structurally different documents both claiming version 1.
+  describe("--sbom JSON <-> docs/schema.md") do
+    let(:schema_md) { File.read(File.join(root, "docs", "schema.md")) }
+
+    # The per-dependency keys the SBOM path can emit, derived the same way the
+    # parity spec derives them: from the lens, what SbomWorkflow copies across,
+    # what the correlator writes, and what emit_sbom_json derives at render time.
+    let(:emitted_fields) do
+      lens = File.read(File.join(root, "lib", "still_active", "ecosystem_lens.rb"))
+      workflow = File.read(File.join(root, "lib", "still_active", "sbom_workflow.rb"))
+      correlator = File.read(File.join(root, "lib", "still_active", "poison_security_correlator.rb"))
+      literal = lens[/gem_data = \{(.*?)^\s{6}\}/m, 1].to_s
+      fields = literal.scan(/^\s{8}([a-z_][a-z0-9_]*):/).flatten +
+        lens.scan(/gem_data\[:([a-z_][a-z0-9_]*)\]/).flatten +
+        workflow.scan(/dep\.slice\(([^)]*)\)/).join(",").scan(/:([a-z_]+)/).flatten +
+        correlator.scan(/\bdata\[:([a-z_][a-z0-9_]*)\]\s*=/).flatten
+      # capped_deps is an internal work-list the correlator deletes before output.
+      (fields.uniq - ["capped_deps"]).sort
+    end
+
+    it("derives a plausible field set, so a broken extractor cannot pass vacuously") do
+      expect(emitted_fields.size).to(be >= 18, "field extraction found #{emitted_fields.size}; the sources it reads were probably restructured")
+    end
+
+    it("documents every per-dependency field the --sbom path can emit") do
+      undocumented = emitted_fields.reject { |field| schema_md.include?("`#{field}`") }
+
+      expect(undocumented).to(
+        be_empty,
+        "the --sbom JSON emits these but docs/schema.md never mentions them: #{undocumented.join(", ")}. " \
+          "That output carries schema_version but no JSON Schema, so this doc is its only contract."
+      )
+    end
+
+    it("tells a consumer how to distinguish the two documents") do
+      # Both carry `schema_version: 1`, so keying on it is the mistake to prevent.
+      expect(schema_md).to(match(/`gems`.{0,40}`dependencies`|`dependencies`.{0,40}`gems`/m))
+    end
+  end
 end


### PR DESCRIPTION
## What prompted this

A pre-3.0 audit of the published schema. The native one held up on every check:

| check | result |
| --- | --- |
| valid against the draft 2020-12 meta-schema | pass |
| `$id` URL resolves | HTTP 200 |
| every object closes `additionalProperties` | pass, no gaps |
| `status` enum vs `StatusHelper::SEVERITY` | exact match |
| `activity_level` enum vs what the code returns | exact match |
| rejects malformed output | **8 of 8** mutations caught |

Those eight: an unknown field on a gem, an unknown top-level field, `status` outside its enum, `activity_level` outside its enum, a missing required `summary`, `schema_version` as a string, `libyear` as a string, and `deprecated` as a string.

## The gap was beside it

The `--sbom` JSON emits `schema_version: 1`, and `docs/schema.md` described **only** the Gemfile audit. So two structurally different documents both claimed version 1, and one of them had no written contract at all.

That output is a 3.0 headline feature, and it gained `purl`, `direct`, `dependency_path`, `deprecated` and `license` today. Its shape is de facto frozen the moment 3.0 ships.

## What this adds

The cross-ecosystem envelope, its `unassessable` entries, and the fields specific to that path (`ecosystem`, `name`, `purl`, `production`, `direct`, `dependency_path`, `version_unresolved`), plus the rule a consumer actually needs:

> Check for `gems` versus `dependencies`, **not** `schema_version`, which is identical on both.

The deliberate absence of `$schema` on that path is now explained rather than merely true: pointing at a contract it does not match would be a false claim.

## A guard, because prose drifts

The native output has a JSON Schema to catch drift. This one has nothing. So a doc-consistency spec derives the emitted field set from the same four sources the parity spec reads, and fails if any field is undocumented, with a floor on the extraction so a broken reader cannot pass vacuously.

Negative-controlled: un-documenting `purl` fails it by name.

`rake` green.
