### PR TITLE
chore(release): 3.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    still_active (3.0.0.rc6)
+    still_active (3.0.0)
       async (>= 2.2)
       bundler (>= 2.0)
       faraday-retry
@@ -273,7 +273,7 @@ CHECKSUMS
   standard-custom (1.0.2) sha256=424adc84179a074f1a2a309bb9cf7cd6bfdb2b6541f20c6bf9436c0ba22a652b
   standard-performance (1.9.0) sha256=49483d31be448292951d80e5e67cdcb576c2502103c7b40aec6f1b6e9c88e3f2
   standard-rspec (0.5.0) sha256=64d396524a65af47f5331b423d8cdd313e0267401647bb7892489ca89dad2973
-  still_active (3.0.0.rc6)
+  still_active (3.0.0)
   thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42

--- a/lib/still_active/version.rb
+++ b/lib/still_active/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module StillActive
-  VERSION = "3.0.0.rc6"
+  VERSION = "3.0.0"
 end


### PR DESCRIPTION
Bumps `version.rb` off the release-candidate line. `Gemfile.lock` moves with it, since still_active pins its own version there through the gemspec.

## Verified the artifact, not just the constant

| check | result |
| --- | --- |
| built gem version | `3.0.0`, `prerelease? = false` |
| dogfood from the built gem | 76 dependencies, 0 vulnerabilities, exit 0 |
| SARIF `tool.driver` | `version: "3.0.0"`, `semanticVersion: "3.0.0"` |
| JSON envelope | `tool.version: "3.0.0"`, `schema_version: 1` |
| `rake` | green |
| floors suite | green |

The SARIF one is worth calling out: `semanticVersion` had to carry `3.0.0-rc6` while the version was a prerelease (SemVer 2.0.0 does not accept RubyGems' `3.0.0.rc6`). It is now plainly `3.0.0`, so that conversion is no longer doing anything and cannot mask a mistake.

**Correction to the commit message:** it says `Gemfile.floors.lock` moved too. That file is gitignored and regenerated in CI, so it is not part of this diff. I did regenerate it locally and ran the floors suite against it (green), which is what the claim was meant to convey.

No code change: `version.rb` and `Gemfile.lock` only.

## What happens after this merges

The release itself is **not** in this PR. Cutting a non-prerelease GitHub Release on `main` triggers `publish.yml` and pushes to RubyGems via trusted publishing, which moves `latest` off 2.0.0 for every plain `gem install` **and** every `still_active-action` user on the default `version: latest`.

That is the step with the blast radius, and it is a one-way door in one respect: `gem yank` restores 2.0.0, but SA008/SA009/SA010 alerts already ingested into anyone's GitHub Security tab do not roll back.

Then: merge `still_active-action#8` (sbom+cyclonedx, `fail-if-deprecated`) and re-tag the Action, both of which need the published gem to exist first.
