### PR TITLE
chore(deps): loosen the simplecov pin so it can follow the 1.x line

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development, :test do
   gem "json_schemer"
   gem "rake", ">= 13.0"
   gem "rspec", ">= 4.0.0.beta1"
-  gem "simplecov", "~> 1.1.1", require: false
+  gem "simplecov", "~> 1.0", require: false
   gem "standard"
   gem "standard-rspec"
   gem "vcr"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
     semantic_range (3.1.1)
-    simplecov (1.1.1)
+    simplecov (1.2.0)
     simpleidn (0.3.0)
     standard (1.56.0)
       language_server-protocol (~> 3.17.0.2)
@@ -196,7 +196,7 @@ DEPENDENCIES
   json_schemer
   rake (>= 13.0)
   rspec (>= 4.0.0.beta1)
-  simplecov (~> 1.1.1)
+  simplecov (~> 1.0)
   standard
   standard-rspec
   still_active!
@@ -267,7 +267,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   sawyer (0.9.3) sha256=0d0f19298408047037638639fe62f4794483fb04320269169bd41af2bdcf5e41
   semantic_range (3.1.1) sha256=508333196ef0c7ba33e79579d4df7eb0a41080595e6a655c2515b03d634ec4a9
-  simplecov (1.1.1) sha256=25825ef13f0b2e74694d769817dad6ab8e90131dabdaa666e522fea105521e78
+  simplecov (1.2.0) sha256=ea6acd05eece5a41990e2a5171c57d15700d329326c7666c85ee8c6a0dd0977e
   simpleidn (0.3.0) sha256=12ca730bed2f3db04d11e9bfd1bca3e11fb37f55b21eb2e9793fb5814bf54d03
   standard (1.56.0) sha256=ae2af4d9669589162ac69ed5ef59dcf9f346d4afc81f7e62b84339310dfcb787
   standard-custom (1.0.2) sha256=424adc84179a074f1a2a309bb9cf7cd6bfdb2b6541f20c6bf9436c0ba22a652b


### PR DESCRIPTION
Found while checking what's held back after #181/#182/#183.

The simplecov pin from #131 was `~> 1.1.1`, which only admits 1.1.x. The intent in that commit was "1.0 or later" (1.0 inlined the archived transitives), so `~> 1.0` states it correctly and lets 1.2.0 in. 1.2.0 has zero runtime deps, same as 1.1.1.

`COVERAGE=1 rspec` on 1.2.0: line 96.35%, branch 87.29%, identical to before. `rake` green.

Everything else `bundle outdated` lists (rubocop 1.90, rubocop-performance 1.27, rubocop-capybara 3.0) is held by the latest standard / standard-performance / standard-rspec releases, so nothing to do on our side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLbAzCpKkk4EmSLcdAecVw
